### PR TITLE
feat(argentina): price aggregation functionality

### DIFF
--- a/src/tsn_adapters/tasks/argentina/aggregate/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/aggregate/__init__.py
@@ -1,0 +1,10 @@
+"""
+Price aggregation functionality for the Argentina SEPA data.
+
+This package provides functions for aggregating and transforming price data
+from the SEPA dataset.
+"""
+
+from tsn_adapters.tasks.argentina.aggregate.category_price_aggregator import aggregate_prices_by_category
+
+__all__ = ["aggregate_prices_by_category"]

--- a/src/tsn_adapters/tasks/argentina/aggregate/category_price_aggregator.py
+++ b/src/tsn_adapters/tasks/argentina/aggregate/category_price_aggregator.py
@@ -1,0 +1,61 @@
+"""
+Category price aggregation logic for SEPA data.
+
+This module contains functions for aggregating product prices by category from the
+SEPA dataset.
+"""
+
+from pandera.typing import DataFrame as paDataFrame
+from tsn_adapters.tasks.argentina.models import (
+    SepaProductCategoryMapModel,
+    SepaAggregatedPricesModel,
+    SepaAvgPriceProductModel,
+)
+
+
+def aggregate_prices_by_category(
+    product_category_map_df: paDataFrame[SepaProductCategoryMapModel],
+    avg_price_product_df: paDataFrame[SepaAvgPriceProductModel],
+) -> paDataFrame[SepaAggregatedPricesModel]:
+    """
+    Aggregate product prices by category over time.
+
+    This function combines product category mapping data with average price data
+    to compute category-level price averages for each date.
+
+    Parameters
+    ----------
+    product_category_map_df : paDataFrame[SepaProductCategoryMapModel]
+        DataFrame containing the mapping between products and their categories
+    avg_price_product_df : paDataFrame[SepaAvgPriceProductModel]
+        DataFrame containing average prices per product over time
+
+    Returns
+    -------
+    paDataFrame[SepaAggregatedPricesModel]
+        DataFrame containing average prices per category over time
+
+    Notes
+    -----
+    The aggregation process:
+    1. Merges product prices with their category assignments
+    2. Groups the data by category and date
+    3. Computes the mean price for each category-date combination
+    """
+    # Merge the product categories with prices
+    merged_df = avg_price_product_df.merge(
+        product_category_map_df,
+        how="inner",
+        left_on="id_producto",
+        right_on="id_producto",
+    )
+
+    # Group by category_id and date, and aggregate the avg price
+    aggregated_df = merged_df.groupby(["category_id", "date"]).agg(
+        avg_price=("productos_precio_lista_avg", "mean"),
+    )
+
+    # Reset index to convert groupby result to regular columns
+    aggregated_df = aggregated_df.reset_index()
+
+    return paDataFrame[SepaAggregatedPricesModel](aggregated_df) 

--- a/src/tsn_adapters/tasks/argentina/models/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/models/__init__.py
@@ -1,6 +1,16 @@
-from .sepa_models import (
-    SepaProductosDataModel,
-    FullSepaProductosDataModel,
-    ProductDescriptionModel,
-    SepaAvgPriceProductModel,
-) 
+"""
+Models for the Argentina SEPA data processing pipeline.
+
+This package contains Pandera models for validating and typing data structures
+used in processing SEPA data.
+"""
+
+from tsn_adapters.tasks.argentina.models.category_map import SepaProductCategoryMapModel
+from tsn_adapters.tasks.argentina.models.aggregated_prices import SepaAggregatedPricesModel
+from tsn_adapters.tasks.argentina.models.sepa_models import SepaAvgPriceProductModel
+
+__all__ = [
+    "SepaProductCategoryMapModel",
+    "SepaAggregatedPricesModel",
+    "SepaAvgPriceProductModel",
+]

--- a/src/tsn_adapters/tasks/argentina/models/aggregated_prices.py
+++ b/src/tsn_adapters/tasks/argentina/models/aggregated_prices.py
@@ -1,0 +1,34 @@
+"""
+Models for aggregated price data in the SEPA dataset.
+
+This module contains the Pandera model for validating and typing the aggregated
+price data from the SEPA dataset.
+"""
+
+from pandera.typing import Series
+from pandera import DataFrameModel
+
+
+class SepaAggregatedPricesModel(DataFrameModel):
+    """
+    Pandera model for aggregated price data by category.
+
+    This model validates the structure of DataFrames containing aggregated price
+    information for each category over time.
+
+    Attributes
+    ----------
+    category_id : Series[str]
+        Identifier for the category
+    avg_price : Series[float]
+        Average price for the category
+    date : Series[str]
+        Date of the price record in string format
+    """
+    category_id: Series[str]
+    avg_price: Series[float]
+    date: Series[str]
+
+    class Config:
+        strict = True
+        coerce = True 

--- a/src/tsn_adapters/tasks/argentina/models/category_map.py
+++ b/src/tsn_adapters/tasks/argentina/models/category_map.py
@@ -1,0 +1,61 @@
+"""
+Models for product-to-category mapping in the SEPA dataset.
+
+This module contains the Pandera model for validating and typing the mapping between
+products and their categories in the SEPA dataset.
+"""
+
+import pandas as pd
+from pandera.typing import DataFrame, Series
+from pandera import DataFrameModel
+from pandas._typing import CompressionOptions
+
+
+class SepaProductCategoryMapModel(DataFrameModel):
+    """
+    Pandera model for the product-to-category mapping data.
+
+    This model validates the structure of DataFrames containing mappings between
+    SEPA products and their corresponding categories.
+
+    Attributes
+    ----------
+    id_producto : Series[str]
+        Unique identifier for each product
+    productos_descripcion : Series[str]
+        Description of the product
+    category_id : Series[str]
+        Identifier for the category this product belongs to
+    category_name : Series[str]
+        Human-readable name of the category
+    """
+    id_producto: Series[str]
+    productos_descripcion: Series[str]
+    category_id: Series[str]
+    category_name: Series[str]
+
+    @staticmethod
+    def from_url(url: str, sep: str = '|', compression: CompressionOptions = None) -> DataFrame["SepaProductCategoryMapModel"]:
+        """
+        Create a validated DataFrame from a URL source.
+
+        Parameters
+        ----------
+        url : str
+            URL pointing to the CSV data source
+        sep : str, optional
+            Delimiter to use for the CSV file, by default '|', because some product ids contains commas
+        compression : CompressionOptions, optional
+            Compression type of the file, by default None
+
+        Returns
+        -------
+        DataFrame[SepaProductCategoryMapModel]
+            A validated DataFrame containing the product-category mapping
+        """
+        df = pd.read_csv(url, compression=compression, sep=sep)
+        return DataFrame[SepaProductCategoryMapModel](df)
+
+    class Config:
+        strict = True
+        coerce = True 

--- a/src/tsn_adapters/tasks/argentina/models/sepa_models.py
+++ b/src/tsn_adapters/tasks/argentina/models/sepa_models.py
@@ -79,18 +79,19 @@ class SepaAvgPriceProductModel(ProductDescriptionModel):
     Pandera model for product descriptions with average prices.
     """
     productos_precio_lista_avg: Series[float]
-
+    date: Series[str]
     @staticmethod
     def from_sepa_product_data(
         data: DataFrame[SepaProductosDataModel],
     ) -> DataFrame["SepaAvgPriceProductModel"]:
         with_average_price = (
-            data.groupby("id_producto")
+            data.groupby([ "id_producto", "date" ])
             .agg(
                 {
                     "id_producto": "first",
                     "productos_precio_lista": "mean",
                     "productos_descripcion": "first",
+                    "date": "first",
                 }
             )
             .reset_index(drop=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Added new price aggregation functionality for Argentina SEPA data
- Implemented category-based price aggregation logic
- Created new Pandera models for data validation:
  - `SepaProductCategoryMapModel` for product-category mapping
  - `SepaAggregatedPricesModel` for aggregated price data
- Updated existing `SepaAvgPriceProductModel` to include date in grouping
- Reorganized model imports and documentation

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix [#21](https://github.com/trufnetwork/adapters/issues/21)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It was used to create the [presented data](https://docs.google.com/spreadsheets/d/1fvYSw_PMtv-CJXS-3riwEzMKIodtwvlojA8VNeGQQCQ/edit?gid=77269284#gid=77269284)