### PR TITLE
chore: bump truf.network python sdk version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 dependencies = [
     "prefect-client==3.1.11",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
-    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@fa51592c87469078686df4d6df413ea24f4d475f",
+    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@109cadf7c732c845ef074274d4af207256404602",
     "PyGithub",
     "pandera",
     "pandas",


### PR DESCRIPTION
This pull request includes an update to the `pyproject.toml` file to change the version of the `trufnetwork-sdk-py` dependency.

Dependency update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L13-R13): Updated the `trufnetwork-sdk-py` dependency to use the commit `109cadf7c732c845ef074274d4af207256404602` instead of the previous commit `fa51592c87469078686df4d6df413ea24f4d475f`.