### PR TITLE
chore: defaulted waiting for data insertion into false

### DIFF
--- a/src/tsn_adapters/common/trufnetwork/tn.py
+++ b/src/tsn_adapters/common/trufnetwork/tn.py
@@ -12,7 +12,7 @@ def task_insert_tsn_records(
     stream_id: str,
     records: pd.DataFrame,
     client: tn_client.TNClient,
-    wait: bool = True,
+    wait: bool = False,
     data_provider: Optional[str] = None,
 ):
     return insert_tsn_records(stream_id, records, client, wait, data_provider)


### PR DESCRIPTION
This locks up our prefect concurrencies. It is used by sap500 which locking everything else.

This pull request includes a small change to the `task_insert_tsn_records` function in the `src/tsn_adapters/common/trufnetwork/tn.py` file. The change modifies the default value of the `wait` parameter from `True` to `False`.

* [`src/tsn_adapters/common/trufnetwork/tn.py`](diffhunk://#diff-242c6777a1982296ba60f46863874e48eece8a1137810fa528aa47107efc42e3L15-R15): Changed the default value of the `wait` parameter in the `task_insert_tsn_records` function to `False`.

related: https://github.com/trufnetwork/truf-data-provider/issues/418
resolves: https://github.com/trufnetwork/adapters/issues/58