### PR TITLE
chore: argentina batch request & additional tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 dependencies = [
     "prefect-client>=3.0.0",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
-    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@a3cbcf95338b4c38b329d75e460844804ab2f953",
+    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@e0b02e58708bf708bc33d6734f673c2efcaea9b8",
     "PyGithub",
     "pandera",
     "pandas",

--- a/src/tsn_adapters/common/interfaces/target.py
+++ b/src/tsn_adapters/common/interfaces/target.py
@@ -6,6 +6,9 @@ from abc import ABC, abstractmethod
 from typing import Generic, Optional, TypeVar
 
 import pandas as pd
+from pandera.typing import DataFrame
+
+from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
 
 S = TypeVar("S")  # For stream ID types (e.g. StreamId)
 
@@ -24,6 +27,13 @@ class ITargetClient(ABC, Generic[S]):
 
         Returns:
             pd.DataFrame: The existing data in the target system
+        """
+        pass
+
+    @abstractmethod
+    def batch_insert_data(self, data: DataFrame[TnDataRowModel]) -> None:
+        """
+        Batch insert data into the target system.
         """
         pass
 

--- a/src/tsn_adapters/tasks/argentina/task_wrappers.py
+++ b/src/tsn_adapters/tasks/argentina/task_wrappers.py
@@ -3,7 +3,6 @@ Task wrappers for Argentina data pipeline.
 """
 
 from datetime import datetime, timedelta
-from typing import Optional
 
 import pandas as pd
 from pandera.typing import DataFrame
@@ -15,7 +14,7 @@ from tsn_adapters.common.interfaces.provider import IProviderGetter
 from tsn_adapters.common.interfaces.reconciliation import IReconciliationStrategy
 from tsn_adapters.common.interfaces.target import ITargetClient
 from tsn_adapters.common.interfaces.transformer import IDataTransformer
-from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel, TnRecordModel
+from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
 from tsn_adapters.tasks.argentina.models.category_map import SepaProductCategoryMapModel
 from tsn_adapters.tasks.argentina.provider.factory import create_sepa_processed_provider
 from tsn_adapters.tasks.argentina.reconciliation.strategies import create_reconciliation_strategy
@@ -136,22 +135,18 @@ def task_get_latest_records(client: ITargetClient, stream_id: StreamId, data_pro
 
 
 @task
-def task_insert_data(
-    client: ITargetClient, stream_id: StreamId, data: DataFrame[TnRecordModel], data_provider: Optional[str] = None
-) -> None:
+def task_insert_data(client: ITargetClient, data: DataFrame[TnDataRowModel]) -> None:
     """
     Insert data into the target system.
 
     Args:
         client: The target client to use
-        stream_id: The stream ID to insert data for
         data: The data to insert
-        data_provider: The data provider identifier
     """
     logger = get_run_logger()
-    logger.info(f"Inserting {len(data)} rows for stream: {stream_id}")
+    logger.info(f"Inserting {len(data)} rows")
     try:
-        client.insert_data(stream_id=stream_id, data=data, data_provider=data_provider)
+        client.batch_insert_data(data=data)
         logger.info("Data inserted successfully")
     except Exception as e:
         logger.error(f"Failed to insert data: {e}")

--- a/tests/argentina/flows/test_preprocess_flow.py
+++ b/tests/argentina/flows/test_preprocess_flow.py
@@ -1,0 +1,625 @@
+"""Tests for the Argentina SEPA preprocessing flow."""
+
+from datetime import datetime
+import re
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pandas as pd
+from pandera.errors import SchemaError
+from prefect.logging.loggers import disable_run_logger
+from prefect_aws import S3Bucket
+import pytest
+from pytest_mock import MockerFixture
+
+from tsn_adapters.tasks.argentina.flows.preprocess_flow import PreprocessFlow, preprocess_flow
+from tsn_adapters.tasks.argentina.models.aggregated_prices import SepaAggregatedPricesModel
+from tsn_adapters.tasks.argentina.models.category_map import SepaProductCategoryMapModel
+from tsn_adapters.tasks.argentina.models.sepa.sepa_models import SepaProductosDataModel
+from tsn_adapters.tasks.argentina.provider.s3 import ProcessedDataProvider, RawDataProvider
+from tsn_adapters.tasks.argentina.types import (
+    AggregatedPricesDF,
+    DateStr,
+    UncategorizedDF,
+)
+
+# Test constants
+TEST_DATE = DateStr("2024-01-01")
+TEST_CATEGORY_MAP_URL = "http://example.com/category_map.csv"
+INVALID_DATE = "2024/01/01"  # Wrong format
+
+# Test data
+SAMPLE_RAW_DATA = {
+    "id_producto": ["P1", "P2", "P3"],
+    "productos_descripcion": ["Product A", "Product B", "Product C"],
+    "productos_precio_lista": [100.0, 200.0, 300.0],
+    "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+}
+
+SAMPLE_CATEGORY_MAP = {
+    "id_producto": ["P1", "P2", "P3"],
+    "productos_descripcion": ["Product A", "Product B", "Product C"],
+    "category_id": ["C1", "C2", "C3"],
+    "category_name": ["Category 1", "Category 2", "Category 3"],
+}
+
+SAMPLE_PROCESSED_DATA = {
+    "category_id": ["C1", "C2", "C3"],
+    "avg_price": [100.0, 200.0, 300.0],
+    "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_run_logger():
+    with disable_run_logger():
+        yield
+
+
+class TestPreprocessFlowInit:
+    """Tests for the PreprocessFlow class initialization."""
+
+    def test_init_success(self):
+        """Test successful initialization of PreprocessFlow."""
+        mock_s3_block = MagicMock(spec=S3Bucket)
+
+        flow = PreprocessFlow(
+            product_category_map_url=TEST_CATEGORY_MAP_URL,
+            s3_block=mock_s3_block,
+        )
+
+        assert isinstance(flow.raw_provider, RawDataProvider)
+        assert isinstance(flow.processed_provider, ProcessedDataProvider)
+        assert flow.category_map_url == TEST_CATEGORY_MAP_URL
+        # Check that providers were initialized with the correct S3 block
+        assert flow.raw_provider.s3_block == mock_s3_block
+        assert flow.processed_provider.s3_block == mock_s3_block
+
+
+class TestPreprocessFlowRunFlow:
+    """Tests for the PreprocessFlow run_flow method."""
+
+    @pytest.fixture
+    def mock_preprocess_flow(self) -> PreprocessFlow:
+        """Fixture to create a PreprocessFlow instance with mocked providers."""
+        mock_s3_block = MagicMock(spec=S3Bucket)
+        flow = PreprocessFlow(
+            product_category_map_url=TEST_CATEGORY_MAP_URL,
+            s3_block=mock_s3_block,
+        )
+        # Mock the providers directly with proper typing
+        flow.raw_provider = cast(Any, MagicMock(spec=RawDataProvider))
+        flow.processed_provider = cast(Any, MagicMock(spec=ProcessedDataProvider))
+        return flow
+
+    def test_run_flow_happy_path(self, mock_preprocess_flow: PreprocessFlow):
+        """Test the run_flow method's happy path."""
+        # Mock list_available_keys to return a list of dates
+        raw_provider = cast(Any, mock_preprocess_flow.raw_provider)
+        processed_provider = cast(Any, mock_preprocess_flow.processed_provider)
+        raw_provider.list_available_keys.return_value = [
+            DateStr("2024-01-01"),
+            DateStr("2024-01-02"),
+            DateStr("2024-01-03"),
+        ]
+        # Mock exists to simulate some dates already existing
+        processed_provider.exists.side_effect = [
+            True,  # 2024-01-01 exists
+            False,  # 2024-01-02 does not exist
+            True,  # 2024-01-03 exists
+        ]
+        # Mock process_date
+        process_date_mock = cast(Any, MagicMock())
+        mock_preprocess_flow.process_date = process_date_mock
+
+        mock_preprocess_flow.run_flow()
+
+        # Verify that process_date was called only for the date that doesn't exist
+        process_date_mock.assert_called_once_with(DateStr("2024-01-02"))
+
+    def test_run_flow_no_dates_available(self, mock_preprocess_flow: PreprocessFlow):
+        """Test run_flow when no dates are available."""
+        raw_provider = cast(Any, mock_preprocess_flow.raw_provider)
+        raw_provider.list_available_keys.return_value = []
+        process_date_mock = cast(Any, MagicMock())
+        mock_preprocess_flow.process_date = process_date_mock
+
+        mock_preprocess_flow.run_flow()
+
+        # Verify process_date was not called
+        process_date_mock.assert_not_called()
+
+    def test_run_flow_all_dates_processed(self, mock_preprocess_flow: PreprocessFlow):
+        """Test run_flow when all dates are already processed."""
+        raw_provider = cast(Any, mock_preprocess_flow.raw_provider)
+        processed_provider = cast(Any, mock_preprocess_flow.processed_provider)
+        raw_provider.list_available_keys.return_value = [
+            DateStr("2024-01-01"),
+            DateStr("2024-01-02"),
+        ]
+        # Mock exists to return True for all dates
+        processed_provider.exists.return_value = True
+        process_date_mock = cast(Any, MagicMock())
+        mock_preprocess_flow.process_date = process_date_mock
+
+        mock_preprocess_flow.run_flow()
+
+        # Verify process_date was not called
+        process_date_mock.assert_not_called()
+
+
+class TestPreprocessFlowProcessDate:
+    """Tests for the PreprocessFlow process_date method."""
+
+    @pytest.fixture
+    def mock_preprocess_flow(self) -> PreprocessFlow:
+        """Fixture to create a PreprocessFlow instance with mocked providers."""
+        mock_s3_block = MagicMock(spec=S3Bucket)
+        flow = PreprocessFlow(
+            product_category_map_url=TEST_CATEGORY_MAP_URL,
+            s3_block=mock_s3_block,
+        )
+        # Mock the providers directly with proper typing
+        flow.raw_provider = cast(Any, MagicMock(spec=RawDataProvider))
+        flow.processed_provider = cast(Any, MagicMock(spec=ProcessedDataProvider))
+        # Mock _create_summary as a MagicMock
+        flow._create_summary = cast(Any, MagicMock())
+        return flow
+
+    def test_process_date_happy_path(self, mock_preprocess_flow: PreprocessFlow, mocker: MockerFixture):
+        """Test process_date with valid data."""
+        # Mock dependencies
+        mock_raw_data = cast(Any, MagicMock(spec=pd.DataFrame))
+        mock_raw_data.empty = False
+        raw_provider = cast(Any, mock_preprocess_flow.raw_provider)
+        raw_provider.get_raw_data_for.return_value = mock_raw_data
+
+        mock_category_map = cast(Any, MagicMock(spec=pd.DataFrame))
+        mock_task_load_category_map = cast(
+            Any,
+            mocker.patch(
+                "tsn_adapters.tasks.argentina.flows.preprocess_flow.task_load_category_map",
+                return_value=mock_category_map,
+            ),
+        )
+
+        mock_processed_data = cast(Any, MagicMock(spec=pd.DataFrame))
+        mock_uncategorized = cast(Any, MagicMock(spec=pd.DataFrame))
+        mock_process_raw_data = cast(
+            Any,
+            mocker.patch(
+                "tsn_adapters.tasks.argentina.flows.preprocess_flow.process_raw_data",
+                return_value=(mock_processed_data, mock_uncategorized),
+            ),
+        )
+
+        # Run the method
+        mock_preprocess_flow.process_date(TEST_DATE)
+
+        # Verify interactions
+        raw_provider.get_raw_data_for.assert_called_once_with(TEST_DATE)
+        mock_task_load_category_map.assert_called_once_with(url=mock_preprocess_flow.category_map_url)
+        mock_process_raw_data.assert_called_once_with(raw_data=mock_raw_data, category_map_df=mock_category_map)
+        processed_provider = cast(Any, mock_preprocess_flow.processed_provider)
+        processed_provider.save_processed_data.assert_called_once_with(
+            date_str=TEST_DATE,
+            data=mock_processed_data,
+            uncategorized=mock_uncategorized,
+            logs=b"Placeholder for logs",
+        )
+        create_summary = cast(Any, mock_preprocess_flow._create_summary)
+        create_summary.assert_called_once_with(TEST_DATE, mock_processed_data, mock_uncategorized)
+
+    def test_process_date_no_data(self, mock_preprocess_flow: PreprocessFlow):
+        """Test process_date when no data is available for the date."""
+        # Mock raw_provider to return empty DataFrame
+        mock_empty_df = cast(Any, MagicMock(spec=pd.DataFrame))
+        mock_empty_df.empty = True
+        raw_provider = cast(Any, mock_preprocess_flow.raw_provider)
+        raw_provider.get_raw_data_for.return_value = mock_empty_df
+
+        mock_preprocess_flow.process_date(TEST_DATE)
+
+        # Verify that processing stops after finding no data
+        raw_provider.get_raw_data_for.assert_called_once_with(TEST_DATE)
+        processed_provider = cast(Any, mock_preprocess_flow.processed_provider)
+        processed_provider.save_processed_data.assert_not_called()
+        create_summary = cast(Any, mock_preprocess_flow._create_summary)
+        create_summary.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "invalid_date",
+        [
+            "2024/01/01",  # Wrong separator
+            "24-01-01",  # Wrong year format
+            "2024-1-1",  # Wrong month/day format
+            "2024-13-01",  # Invalid month
+            "2024-01-32",  # Invalid day
+        ],
+    )
+    def test_process_date_invalid_date(self, mock_preprocess_flow: PreprocessFlow, invalid_date: str):
+        """Test process_date with invalid date format."""
+
+        # Override validate_date to do stricter validation
+        def strict_validate_date(date: DateStr) -> None:
+            # First check format with regex
+            if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
+                raise ValueError(f"Invalid date format: {date}")
+
+            # Then check if it's a valid date
+            try:
+                datetime.strptime(date, "%Y-%m-%d")
+            except ValueError:
+                raise ValueError(f"Invalid date format: {date}")
+
+        mock_preprocess_flow.validate_date = strict_validate_date
+
+        with pytest.raises(ValueError, match=f"Invalid date format: {invalid_date}"):
+            mock_preprocess_flow.process_date(cast(DateStr, invalid_date))
+
+        # Verify no processing was attempted
+        mock_preprocess_flow.raw_provider.get_raw_data_for.assert_not_called()
+
+    def test_process_date_category_map_error(self, mock_preprocess_flow: PreprocessFlow, mocker: MockerFixture):
+        """Test process_date when category map loading fails."""
+        # Mock raw data
+        mock_raw_data = cast(Any, MagicMock(spec=pd.DataFrame))
+        mock_raw_data.empty = False
+        raw_provider = cast(Any, mock_preprocess_flow.raw_provider)
+        raw_provider.get_raw_data_for.return_value = mock_raw_data
+
+        # Mock category map loading to fail
+        mock_task_load_category_map = cast(
+            Any,
+            mocker.patch(
+                "tsn_adapters.tasks.argentina.flows.preprocess_flow.task_load_category_map",
+                side_effect=Exception("Failed to load category map"),
+            ),
+        )
+
+        with pytest.raises(Exception, match="Failed to load category map"):
+            mock_preprocess_flow.process_date(TEST_DATE)
+
+        # Verify interactions
+        raw_provider.get_raw_data_for.assert_called_once_with(TEST_DATE)
+        mock_task_load_category_map.assert_called_once_with(url=mock_preprocess_flow.category_map_url)
+        processed_provider = cast(Any, mock_preprocess_flow.processed_provider)
+        processed_provider.save_processed_data.assert_not_called()
+        create_summary = cast(Any, mock_preprocess_flow._create_summary)
+        create_summary.assert_not_called()
+
+    def test_process_date_processing_error(self, mock_preprocess_flow: PreprocessFlow, mocker: MockerFixture):
+        """Test process_date when data processing fails."""
+        # Mock raw data and category map
+        mock_raw_data = cast(Any, MagicMock(spec=pd.DataFrame))
+        mock_raw_data.empty = False
+        raw_provider = cast(Any, mock_preprocess_flow.raw_provider)
+        raw_provider.get_raw_data_for.return_value = mock_raw_data
+
+        mock_category_map = cast(Any, MagicMock(spec=pd.DataFrame))
+        mocker.patch(
+            "tsn_adapters.tasks.argentina.flows.preprocess_flow.task_load_category_map", return_value=mock_category_map
+        )
+
+        # Mock process_raw_data to fail
+        cast(
+            Any,
+            mocker.patch(
+                "tsn_adapters.tasks.argentina.flows.preprocess_flow.process_raw_data",
+                side_effect=Exception("Processing failed"),
+            ),
+        )
+
+        with pytest.raises(Exception, match="Processing failed"):
+            mock_preprocess_flow.process_date(TEST_DATE)
+
+        # Verify that save_processed_data was not called
+        processed_provider = cast(Any, mock_preprocess_flow.processed_provider)
+        processed_provider.save_processed_data.assert_not_called()
+        create_summary = cast(Any, mock_preprocess_flow._create_summary)
+        create_summary.assert_not_called()
+
+
+class TestPreprocessFlowCreateSummary:
+    """Tests for the PreprocessFlow _create_summary method."""
+
+    @pytest.fixture
+    def mock_preprocess_flow(self) -> PreprocessFlow:
+        """Fixture to create a PreprocessFlow instance with mocked providers."""
+        mock_s3_block = MagicMock(spec=S3Bucket)
+        flow = PreprocessFlow(
+            product_category_map_url=TEST_CATEGORY_MAP_URL,
+            s3_block=mock_s3_block,
+        )
+        return flow
+
+    def test_create_summary_with_uncategorized(self, mock_preprocess_flow: PreprocessFlow, mocker: MockerFixture):
+        """Test _create_summary with both processed and uncategorized data."""
+        # Mock create_markdown_artifact
+        mock_create_artifact = mocker.patch(
+            "tsn_adapters.tasks.argentina.flows.preprocess_flow.create_markdown_artifact"
+        )
+
+        # Create test data
+        processed_data = cast(
+            AggregatedPricesDF,
+            pd.DataFrame(
+                {
+                    "category_id": ["C1", "C2", "C3"],
+                    "avg_price": [10.0, 20.0, 30.0],
+                    "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+                }
+            ),
+        )
+        uncategorized = cast(
+            UncategorizedDF,
+            pd.DataFrame({"id_producto": ["P4", "P5"], "productos_descripcion": ["Product D", "Product E"]}),
+        )
+
+        # Call the method
+        mock_preprocess_flow._create_summary(TEST_DATE, processed_data, uncategorized)
+
+        # Verify the artifact creation
+        mock_create_artifact.assert_called_once()
+        call_args = mock_create_artifact.call_args[1]
+        assert call_args["key"] == f"preprocessing-summary-{TEST_DATE}"
+        assert "description" in call_args
+
+        # Verify markdown content
+        markdown = call_args["markdown"]
+        assert f"# SEPA Preprocessing Summary for {TEST_DATE}" in markdown
+        assert "Total records processed: 5" in markdown  # 3 processed + 2 uncategorized
+        assert "Successfully categorized: 3" in markdown
+        assert "Uncategorized products: 2" in markdown
+        assert "Product D" in markdown  # Sample uncategorized product
+        assert "Product E" in markdown  # Sample uncategorized product
+
+    def test_create_summary_no_uncategorized(self, mock_preprocess_flow: PreprocessFlow, mocker: MockerFixture):
+        """Test _create_summary with only processed data (no uncategorized)."""
+        # Mock create_markdown_artifact
+        mock_create_artifact = mocker.patch(
+            "tsn_adapters.tasks.argentina.flows.preprocess_flow.create_markdown_artifact"
+        )
+
+        # Create test data
+        processed_data = cast(
+            AggregatedPricesDF,
+            pd.DataFrame(
+                {
+                    "category_id": ["C1", "C2", "C3"],
+                    "avg_price": [10.0, 20.0, 30.0],
+                    "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+                }
+            ),
+        )
+        uncategorized = cast(UncategorizedDF, pd.DataFrame())
+
+        # Call the method
+        mock_preprocess_flow._create_summary(TEST_DATE, processed_data, uncategorized)
+
+        # Verify the artifact creation
+        mock_create_artifact.assert_called_once()
+        call_args = mock_create_artifact.call_args[1]
+
+        # Verify markdown content
+        markdown = call_args["markdown"]
+        assert f"# SEPA Preprocessing Summary for {TEST_DATE}" in markdown
+        assert "Total records processed: 3" in markdown
+        assert "Successfully categorized: 3" in markdown
+        assert "Uncategorized products: 0" in markdown
+        assert "Sample Uncategorized Products" not in markdown  # No uncategorized section
+
+    def test_create_summary_empty_data(self, mock_preprocess_flow: PreprocessFlow, mocker: MockerFixture):
+        """Test _create_summary with empty DataFrames."""
+        # Mock create_markdown_artifact
+        mock_create_artifact = mocker.patch(
+            "tsn_adapters.tasks.argentina.flows.preprocess_flow.create_markdown_artifact"
+        )
+
+        # Create empty test data
+        processed_data = cast(AggregatedPricesDF, pd.DataFrame())
+        uncategorized = cast(UncategorizedDF, pd.DataFrame())
+
+        # Call the method
+        mock_preprocess_flow._create_summary(TEST_DATE, processed_data, uncategorized)
+
+        # Verify the artifact creation
+        mock_create_artifact.assert_called_once()
+        call_args = mock_create_artifact.call_args[1]
+
+        # Verify markdown content
+        markdown = call_args["markdown"]
+        assert f"# SEPA Preprocessing Summary for {TEST_DATE}" in markdown
+        assert "Total records processed: 0" in markdown
+        assert "Successfully categorized: 0" in markdown
+        assert "Uncategorized products: 0" in markdown
+        assert "Sample Uncategorized Products" not in markdown
+
+
+class TestPreprocessFlowTopLevel:
+    """Tests for the top-level preprocess_flow function."""
+
+    def test_preprocess_flow_happy_path(self, mocker: MockerFixture):
+        """Test the top-level preprocess_flow function's happy path."""
+        # Mock S3Bucket.load
+        mock_s3_block = MagicMock(spec=S3Bucket)
+        mock_s3_load = mocker.patch(
+            "tsn_adapters.tasks.argentina.flows.preprocess_flow.S3Bucket.load", return_value=mock_s3_block
+        )
+
+        # Mock PreprocessFlow
+        mock_flow = MagicMock(spec=PreprocessFlow)
+        mock_flow_class = mocker.patch(
+            "tsn_adapters.tasks.argentina.flows.preprocess_flow.PreprocessFlow", return_value=mock_flow
+        )
+
+        # Test parameters
+        test_s3_block_name = "test-s3-block"
+
+        # Run the flow
+        preprocess_flow(
+            product_category_map_url=TEST_CATEGORY_MAP_URL,
+            s3_block_name=test_s3_block_name,
+        )
+
+        # Verify S3 block loading
+        mock_s3_load.assert_called_once_with(test_s3_block_name)
+
+        # Verify PreprocessFlow instantiation and execution
+        mock_flow_class.assert_called_once_with(
+            product_category_map_url=TEST_CATEGORY_MAP_URL,
+            s3_block=mock_s3_block,
+        )
+        mock_flow.run_flow.assert_called_once()
+
+    def test_preprocess_flow_s3_block_error(self, mocker: MockerFixture):
+        """Test preprocess_flow when S3 block loading fails."""
+        # Mock S3Bucket.load to raise an exception
+        mock_s3_load = mocker.patch(
+            "tsn_adapters.tasks.argentina.flows.preprocess_flow.S3Bucket.load",
+            side_effect=Exception("Failed to load S3 block"),
+        )
+
+        # Test parameters
+        test_s3_block_name = "test-s3-block"
+
+        # Run the flow and expect exception
+        with pytest.raises(Exception, match="Failed to load S3 block"):
+            preprocess_flow(
+                product_category_map_url=TEST_CATEGORY_MAP_URL,
+                s3_block_name=test_s3_block_name,
+            )
+
+        # Verify S3 block loading attempt
+        mock_s3_load.assert_called_once_with(test_s3_block_name)
+
+    def test_preprocess_flow_run_error(self, mocker: MockerFixture):
+        """Test preprocess_flow when flow execution fails."""
+        # Mock S3Bucket.load
+        mock_s3_block = MagicMock(spec=S3Bucket)
+        mocker.patch("tsn_adapters.tasks.argentina.flows.preprocess_flow.S3Bucket.load", return_value=mock_s3_block)
+
+        # Mock PreprocessFlow with failing run_flow
+        mock_flow = MagicMock(spec=PreprocessFlow)
+        mock_flow.run_flow.side_effect = Exception("Flow execution failed")
+        mocker.patch("tsn_adapters.tasks.argentina.flows.preprocess_flow.PreprocessFlow", return_value=mock_flow)
+
+        # Test parameters
+        test_s3_block_name = "test-s3-block"
+
+        # Run the flow and expect exception
+        with pytest.raises(Exception, match="Flow execution failed"):
+            preprocess_flow(
+                product_category_map_url=TEST_CATEGORY_MAP_URL,
+                s3_block_name=test_s3_block_name,
+            )
+
+        # Verify flow execution attempt
+        mock_flow.run_flow.assert_called_once()
+
+
+class TestPreprocessFlowDataTypes:
+    """Tests for data type validation in the PreprocessFlow."""
+
+    def test_raw_data_schema(self):
+        """Test that raw data matches the expected schema."""
+        df = pd.DataFrame(SAMPLE_RAW_DATA)
+
+        # This should not raise an exception
+        validated_df = SepaProductosDataModel.validate(df)
+        assert isinstance(validated_df, pd.DataFrame)
+        assert all(
+            validated_df.dtypes
+            == pd.Series(
+                {
+                    "id_producto": "object",
+                    "productos_descripcion": "object",
+                    "productos_precio_lista": "float64",
+                    "date": "object",
+                }
+            )
+        )
+
+    def test_category_map_schema(self):
+        """Test that category map data matches the expected schema."""
+        df = pd.DataFrame(SAMPLE_CATEGORY_MAP)
+
+        # This should not raise an exception
+        validated_df = SepaProductCategoryMapModel.validate(df)
+        assert isinstance(validated_df, pd.DataFrame)
+        assert all(
+            validated_df.dtypes
+            == pd.Series(
+                {
+                    "id_producto": "object",
+                    "productos_descripcion": "object",
+                    "category_id": "object",
+                    "category_name": "object",
+                }
+            )
+        )
+
+    def test_processed_data_schema(self):
+        """Test that processed data matches the expected schema."""
+        df = pd.DataFrame(SAMPLE_PROCESSED_DATA)
+
+        # This should not raise an exception
+        validated_df = SepaAggregatedPricesModel.validate(df)
+        assert isinstance(validated_df, pd.DataFrame)
+        assert all(
+            validated_df.dtypes
+            == pd.Series(
+                {
+                    "category_id": "object",
+                    "avg_price": "float64",
+                    "date": "object",
+                }
+            )
+        )
+
+    def test_invalid_raw_data_schema(self):
+        """Test that invalid raw data fails schema validation."""
+        invalid_data = {
+            "id_producto": [1, 2, 3],  # Should be strings
+            "productos_descripcion": ["Product A", "Product B", "Product C"],
+            "productos_precio_lista": ["100.0", "200.0", "300.0"],  # Should be floats
+            "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+        }
+        df = pd.DataFrame(invalid_data)
+
+        # Disable coercion to ensure type validation fails
+        schema = SepaProductosDataModel.to_schema()
+        schema.coerce = False
+        with pytest.raises(SchemaError):
+            schema.validate(df)
+
+    def test_invalid_category_map_schema(self):
+        """Test that invalid category map data fails schema validation."""
+        invalid_data = {
+            "id_producto": ["P1", "P2", "P3"],
+            "productos_descripcion": ["Product A", "Product B", "Product C"],
+            "category_id": [1, 2, 3],  # Should be strings
+            "category_name": [True, False, True],  # Should be strings
+        }
+        df = pd.DataFrame(invalid_data)
+
+        # Disable coercion to ensure type validation fails
+        schema = SepaProductCategoryMapModel.to_schema()
+        schema.coerce = False
+        with pytest.raises(SchemaError):
+            schema.validate(df)
+
+    def test_invalid_processed_data_schema(self):
+        """Test that invalid processed data fails schema validation."""
+        invalid_data = {
+            "category_id": ["C1", "C2", "C3"],
+            "avg_price": ["100.0", "200.0", "300.0"],  # Should be floats
+            "date": [20240101, 20240101, 20240101],  # Should be strings
+        }
+        df = pd.DataFrame(invalid_data)
+
+        # Disable coercion to ensure type validation fails
+        schema = SepaAggregatedPricesModel.to_schema()
+        schema.coerce = False
+        with pytest.raises(SchemaError):
+            schema.validate(df)

--- a/tests/fmp/test_historical_flow.py
+++ b/tests/fmp/test_historical_flow.py
@@ -12,7 +12,6 @@ from typing import Optional
 
 import pandas as pd
 from pandera.typing import DataFrame
-from prefect.testing.utilities import prefect_test_harness
 from pydantic import SecretStr
 import pytest
 from trufnetwork_sdk_py.client import TNClient
@@ -38,43 +37,52 @@ pytestmark = pytest.mark.asyncio
 
 EXPECTED_TN_DATA_COLUMNS = {"stream_id", "date", "value"}
 
+
 def assert_tn_data_schema(df: pd.DataFrame):
     """Helper to assert that a DataFrame has the TN data schema."""
     assert set(df.columns) == EXPECTED_TN_DATA_COLUMNS, f"Got columns: {df.columns}"
+
 
 def assert_all_records_for_stream(df: pd.DataFrame, stream_id: str):
     """Helper to assert that all records in a DataFrame belong to a given stream."""
     assert all(df["stream_id"] == stream_id), f"Not all records are for {stream_id}"
 
+
 def assert_batch_sizes(batch_sizes: list[int], expected_sizes: list[int]):
     """Helper to assert that batch sizes match expected sizes."""
     assert batch_sizes == expected_sizes, f"Expected batch sizes {expected_sizes}, got {batch_sizes}"
 
+
 class SequenceTracker:
     """Helper class to track execution sequence of operations."""
+
     def __init__(self):
         self.sequence = []
         self._counter = 0
-    
+
     def next(self, operation: str) -> int:
         """Record next operation in sequence."""
         self._counter += 1
         self.sequence.append((self._counter, operation))
         return self._counter
-    
+
     def get_operations_by_type(self, prefix: str) -> list[tuple[int, str]]:
         """Get all operations that start with the given prefix."""
         return [(seq, op) for seq, op in self.sequence if op.startswith(prefix)]
-    
+
     def assert_sequential_operations(self, prefix: str):
         """Assert that operations of a given type occurred in sequence."""
         operations = self.get_operations_by_type(prefix)
         for i in range(len(operations) - 1):
             curr_seq = operations[i][0]
             next_seq = operations[i + 1][0]
-            assert curr_seq < next_seq, f"{prefix} operations should be sequential, but {curr_seq} came before {next_seq}"
+            assert (
+                curr_seq < next_seq
+            ), f"{prefix} operations should be sequential, but {curr_seq} came before {next_seq}"
+
 
 # --- Common Mock Blocks ---
+
 
 class FakeFMPBlock(FMPBlock):
     """Mock FMPBlock that returns predefined data."""
@@ -103,6 +111,7 @@ class FakeFMPBlock(FMPBlock):
             )
         )
 
+
 class FakePrimitiveSourcesDescriptorBlock(PrimitiveSourcesDescriptorBlock):
     """Mock descriptor block that returns predefined mappings."""
 
@@ -114,6 +123,7 @@ class FakePrimitiveSourcesDescriptorBlock(PrimitiveSourcesDescriptorBlock):
             "source_type": ["stock", "stock"],
         }
         return DataFrame[PrimitiveSourceDataModel](pd.DataFrame(data))
+
 
 class FakeTNAccessBlock(TNAccessBlock):
     """Fake TN access block that tracks inserted records."""
@@ -138,7 +148,7 @@ class FakeTNAccessBlock(TNAccessBlock):
     def batch_sizes(self) -> list[int]:
         return self._batch_sizes
 
-    def batch_insert_unix_tn_records(
+    def batch_insert_tn_records(
         self, records: DataFrame[TnDataRowModel], data_provider: str | None = None
     ) -> Optional[str]:
         """Track inserted records and return a fake BatchInsertResults."""
@@ -163,46 +173,59 @@ class FakeTNAccessBlock(TNAccessBlock):
         """Mock to prevent real client creation."""
         return None  # type: ignore
 
+
 # --- Fixtures ---
+
 
 @pytest.fixture(scope="session", autouse=True)
 def include_prefect_in_all_tests(prefect_test_fixture):
     """Include Prefect test harness in all tests."""
     yield prefect_test_fixture
 
+
 @pytest.fixture
 def fake_fmp_block() -> FMPBlock:
     """Fixture for basic FMP block."""
     return FakeFMPBlock(api_key=SecretStr("fake"))
+
 
 @pytest.fixture
 def fake_psd_block() -> PrimitiveSourcesDescriptorBlock:
     """Fixture for basic PSD block."""
     return FakePrimitiveSourcesDescriptorBlock()
 
+
 @pytest.fixture
 def fake_tn_block() -> FakeTNAccessBlock:
     """Fixture for basic TN block."""
     return FakeTNAccessBlock()
 
+
 @pytest.fixture
 def error_fmp_block():
     """Fixture for error-raising FMP block."""
+
     class ErrorFMPBlock(FMPBlock):
         def get_historical_eod_data(
             self, symbol: str, start_date: str | None = None, end_date: str | None = None
         ) -> DataFrame[EODData]:
             """Simulate API error."""
             raise RuntimeError("API Error")
+
     return ErrorFMPBlock(api_key=SecretStr("fake"))
+
 
 @pytest.fixture
 def set_test_batch_size(monkeypatch):
     """Fixture to set test batch size."""
+
     def _set_batch_size(size: int):
         import tsn_adapters.flows.fmp.historical_flow as flow_module
+
         monkeypatch.setattr(flow_module, "BATCH_SIZE", size)
+
     return _set_batch_size
+
 
 @pytest.fixture
 def sample_eod_data() -> DataFrame[EODData]:
@@ -215,7 +238,9 @@ def sample_eod_data() -> DataFrame[EODData]:
     }
     return DataFrame[EODData](pd.DataFrame(data))
 
+
 # --- Test Classes ---
+
 
 class TestHistoricalFlow:
     """Tests for the historical flow functionality."""
@@ -224,11 +249,7 @@ class TestHistoricalFlow:
     @pytest.mark.timeout(5, func_only=True)
     async def test_historical_flow_success(self, fake_fmp_block, fake_psd_block, fake_tn_block):
         """Test the complete historical flow with mock blocks."""
-        await historical_flow(
-            fmp_block=fake_fmp_block,
-            psd_block=fake_psd_block,
-            tn_block=fake_tn_block
-        )
+        await historical_flow(fmp_block=fake_fmp_block, psd_block=fake_psd_block, tn_block=fake_tn_block)
 
         # Verify that data was processed and inserted
         assert len(fake_tn_block.inserted_records) > 0
@@ -260,6 +281,7 @@ class TestHistoricalFlow:
         # Verify that no records were inserted for the failed ticker
         assert len(fake_tn_block.inserted_records) == 0
 
+
 class TestDataProcessing:
     """Tests for data processing functionality."""
 
@@ -269,7 +291,7 @@ class TestDataProcessing:
         [
             ("stream_aapl", False),
             ("unknown", True),
-        ]
+        ],
     )
     def test_get_earliest_data_date(self, fake_tn_block, stream_id, should_raise):
         """Test getting earliest data date for different tickers."""
@@ -284,9 +306,9 @@ class TestDataProcessing:
     @pytest.mark.parametrize(
         "symbol, expected_length",
         [
-            ("AAPL", 2),     # returns two rows
+            ("AAPL", 2),  # returns two rows
             ("UNKNOWN", 0),  # returns an empty DataFrame
-        ]
+        ],
     )
     def test_fetch_historical_data(self, fake_fmp_block, symbol, expected_length):
         """Test historical data fetching for different scenarios."""
@@ -315,6 +337,7 @@ class TestDataProcessing:
         assert len(result) == len(sample_eod_data)
         assert_all_records_for_stream(result_df, stream_id)
         assert all(result_df["value"].astype(float) > 0)  # Values should be positive prices
+
 
 class TestHistoricalFlowAdvanced:
     """Advanced tests for historical flow focusing on async behavior and batching."""
@@ -437,12 +460,12 @@ class TestHistoricalFlowAdvanced:
                 super().__init__()
                 self.sequence = sequence_tracker
 
-            def batch_insert_unix_tn_records(
+            def batch_insert_tn_records(
                 self, records: DataFrame[TnDataRowModel], data_provider: str | None = None
             ) -> Optional[str]:
                 """Track batch insertions with sequence information."""
-                seq_num = self.sequence.next(f"insert_batch_{len(records)}")
-                return super().batch_insert_unix_tn_records(records, data_provider)
+                self.sequence.next(f"insert_batch_{len(records)}")
+                return super().batch_insert_tn_records(records, data_provider)
 
         # Create blocks with timing tracking
         fmp_block = TimingFMPBlock(sequence_tracker=sequence, api_key=SecretStr("fake"))
@@ -473,34 +496,33 @@ class TestHistoricalFlowAdvanced:
         # Verify operations are sequential
         fetch_operations = sequence.get_operations_by_type("fetch_")
         insert_operations = sequence.get_operations_by_type("insert_batch_")
-        
+
         # Verify we have the right number of operations
         assert len(fetch_operations) == 4, "Should have 4 fetch operations"
         assert len(insert_operations) == 2, "Should have 2 insert operations"
-        
+
         # Verify fetches are sequential
         sequence.assert_sequential_operations("fetch_")
-        
+
         # Verify batch insertions happen at the right time
         first_insert_seq = insert_operations[0][0]
         second_insert_seq = insert_operations[1][0]
-        
+
         # Count fetches before each insert
         fetches_before_first = len([seq for seq, _ in fetch_operations if seq < first_insert_seq])
         fetches_before_second = len([seq for seq, _ in fetch_operations if seq < second_insert_seq])
-        
+
         # First batch should be inserted after TEST_BATCH_SIZE fetches
         assert fetches_before_first == TEST_BATCH_SIZE, (
             f"First batch should be inserted after {TEST_BATCH_SIZE} fetches, "
             f"but was inserted after {fetches_before_first}"
         )
-        
+
         # Second batch should be inserted after all fetches
         assert fetches_before_second == 4, (
-            "Second batch should be inserted after all fetches, "
-            f"but was inserted after {fetches_before_second}"
+            "Second batch should be inserted after all fetches, " f"but was inserted after {fetches_before_second}"
         )
-        
+
         # Verify batch sizes
         assert_batch_sizes(tn_block.batch_sizes, [2, 2])
 
@@ -538,9 +560,7 @@ class TestHistoricalFlowAdvanced:
                         "volume": [1100000] * len(dates),
                     }
                     return DataFrame[EODData](pd.DataFrame(data))
-                return DataFrame[EODData](
-                    pd.DataFrame({"date": [], "symbol": [], "price": [], "volume": []})
-                )
+                return DataFrame[EODData](pd.DataFrame({"date": [], "symbol": [], "price": [], "volume": []}))
 
         # Create a descriptor block with two tickers
         class LargeFetchDescriptorBlock(PrimitiveSourcesDescriptorBlock):
@@ -577,16 +597,17 @@ class TestHistoricalFlowAdvanced:
 
         # Verify batch handling
         assert_batch_sizes(tn_block.batch_sizes, [8, 2])
-        
+
         # First batch should contain all TICK0 records (processed when exceeding BATCH_SIZE)
         assert_all_records_for_stream(tn_block.inserted_records[0], "stream_tick0")
-        
+
         # Second batch should contain TICK1 records (processed at end of pipeline)
         assert_all_records_for_stream(tn_block.inserted_records[1], "stream_tick1")
 
         # Verify total records
         total_records = sum(tn_block.batch_sizes)
         assert total_records == 10, "Expected 10 total records (8 from TICK0 + 2 from TICK1)"
+
 
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/fmp/test_real_time_flow.py
+++ b/tests/fmp/test_real_time_flow.py
@@ -104,7 +104,7 @@ class FakeTNAccessBlock(TNAccessBlock):
         super().__init__(tn_provider="fake", tn_private_key=SecretStr("fake"))
         self.inserted_records = []
 
-    def batch_insert_unix_tn_records(
+    def batch_insert_tn_records(
         self, records: DataFrame[TnDataRowModel], data_provider: str | None = None
     ) -> Optional[str]:
         """Track inserted records and return a fake BatchInsertResults."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
Refactors the TrufNetwork data insertion methods in `TNAccessBlock` and related tasks to improve efficiency and clarity.  The main changes include:

-   Introduced a unified `batch_insert_tn_records` method to handle both regular and unix timestamped data, replacing `batch_insert_unix_tn_records`. The `is_unix` flag controls the timestamp format.
-   Renamed `split_and_insert_records_unix` to `split_and_insert_records` and added the `is_unix` parameter.
-   Updated task wrappers and flows to use the new unified methods.
-   Added `batch_insert_data` to the `ITargetClient` interface and implemented it in `TrufNetworkClient`.  The old `insert_data` method is now deprecated.
-   Simplified the Argentina ingest flow (`ingest_flow.py`) by using the new batch insert method, removing redundant per-stream insertion logic.
-   Added comprehensive unit tests for the Argentina preprocess flow (`test_preprocess_flow.py`).

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #91 

## How Has This Been Tested?
- Added new unit tests for `test_preprocess_flow.py` covering various scenarios, including data validation, error handling, and flow execution.
- Existing unit tests for FMP flows (`test_historical_flow.py`, `test_real_time_flow.py`) were updated to reflect the changes in `TNAccessBlock`.  These tests cover batch insertion and sequence tracking.