### PR TITLE
feat(adapter): deploy unix contract

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
   prefect:
     restart: always
-    image: prefecthq/prefect:3.1.12-python3.10-conda 
+    image: prefecthq/prefect:3.2.1-python3.10-conda
     environment:
       PREFECT_HOME: /data
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:password@prefect-postgres/prefect
@@ -29,7 +29,7 @@ services:
 
   prefect-worker:
     restart: always
-    image: prefecthq/prefect:3.1.12-python3.10-conda
+    image: prefecthq/prefect:3.2.1-python3.10-conda
     command: prefect worker start -p default-workers
     environment:
       PREFECT_API_URL: http://prefect:4200/api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A collection of prefect tasks and examples ingesting data into TSN"
 readme = "README.md"
 dependencies = [
-    "prefect-client>=3.0.0",
+    "prefect-client==3.2.1",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@e0b02e58708bf708bc33d6734f673c2efcaea9b8",
     "PyGithub",

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -73,7 +73,7 @@ class TNAccessBlock(Block):
     def helper_contract_stream_id(self):
         if not self.helper_contract_name:
             raise self.Error("Helper contract name is not set")
-        return generate_stream_id(self.helper_contract_name)
+        return self.helper_contract_name
 
     @property
     def helper_contract_provider(self):

--- a/src/tsn_adapters/common/trufnetwork/tn.py
+++ b/src/tsn_adapters/common/trufnetwork/tn.py
@@ -79,15 +79,18 @@ def get_all_tsn_records(
 
 
 @task(tags=["tn", "tn-write"])
-def task_deploy_primitive(stream_id: str, client: tn_client.TNClient, wait: bool = True) -> str:
-    return deploy_primitive(stream_id, client, wait)
+def task_deploy_primitive(stream_id: str, client: tn_client.TNClient, wait: bool = True, is_unix: bool = False) -> str:
+    return deploy_primitive(stream_id, client, wait, is_unix)
 
-def deploy_primitive(stream_id: str, client: tn_client.TNClient, wait: bool = True) -> str:
+def deploy_primitive(stream_id: str, client: tn_client.TNClient, wait: bool = True, is_unix: bool = False) -> str:
     logging = get_run_logger()
     with concurrency("tn-write", occupy=1):
         logging.info(f"Deploying stream {stream_id}")
         # The wait parameter controls whether we block until the transaction is mined.
-        tx_hash = client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive, wait=wait)
+        if is_unix:
+            tx_hash = client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitiveUnix, wait=wait)
+        else:
+            tx_hash = client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive, wait=wait)
         logging.debug(f"Deployed stream {stream_id}")
         return tx_hash
 

--- a/src/tsn_adapters/flows/stream_deploy_flow.py
+++ b/src/tsn_adapters/flows/stream_deploy_flow.py
@@ -32,7 +32,7 @@ from tsn_adapters.blocks.tn_access import TNAccessBlock, task_wait_for_tx
 
 @task(tags=["tn", "tn-write"], retries=3, retry_delay_seconds=5)
 def check_and_deploy_stream(
-    stream_id: str, tn_client: tn_client.TNClient, tna_block: TNAccessBlock
+    stream_id: str, tn_client: tn_client.TNClient, tna_block: TNAccessBlock, is_unix: bool = False
 ) -> str:
     """
     Checks if a stream exists using the SDK's stream_exists function.
@@ -47,7 +47,7 @@ def check_and_deploy_stream(
     else:
         # Create the deployment transaction without waiting.
         logger.info(f"Deploying stream {stream_id}.")
-        tx_deploy = task_deploy_primitive(stream_id=stream_id, client=tn_client, wait=False)
+        tx_deploy = task_deploy_primitive(stream_id=stream_id, client=tn_client, wait=False, is_unix=is_unix)
         # Wait for deployment confirmation using the TNAccessBlock (tn-read concurrency).
         task_wait_for_tx(block=tna_block, tx_hash=tx_deploy)
         logger.debug(f"Deployed stream {stream_id}.")


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-data-provider/issues/454

This pull request includes several updates and improvements to the `docker-compose.yaml`, `pyproject.toml`, and various Python files in the `src/tsn_adapters` directory. The most important changes include updating the Prefect image versions, modifying dependencies, and adding a new parameter to the `task_deploy_primitive` function and related calls.

Dependency and configuration updates:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L16-R16): Updated Prefect image versions from `3.1.12` to `3.2.1` for both `prefect` and `prefect-worker` services. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L16-R16) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L32-R32)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L11-R11): Updated the `prefect-client` dependency version to `3.2.1`.

Code improvements:

* [`src/tsn_adapters/blocks/tn_access.py`](diffhunk://#diff-e13ae36ae533c5ca006ffba34c3c9a23d1f9eed153e17e507bcbc05b1ef27e46L76-R76): Modified `helper_contract_stream_id` to return `self.helper_contract_name` directly instead of calling `generate_stream_id`.

Function enhancements:

* [`src/tsn_adapters/common/trufnetwork/tn.py`](diffhunk://#diff-242c6777a1982296ba60f46863874e48eece8a1137810fa528aa47107efc42e3L82-R92): Added `is_unix` parameter to `task_deploy_primitive` and `deploy_primitive` functions to support deploying Unix-type streams.
* [`src/tsn_adapters/flows/stream_deploy_flow.py`](diffhunk://#diff-6533539a96359e2d2740083fd3022f2ed66c4c2f6a4ec3d9d9abeebe8308ccd5L35-R35): Updated `check_and_deploy_stream` to include the `is_unix` parameter and passed it to `task_deploy_primitive`. [[1]](diffhunk://#diff-6533539a96359e2d2740083fd3022f2ed66c4c2f6a4ec3d9d9abeebe8308ccd5L35-R35) [[2]](diffhunk://#diff-6533539a96359e2d2740083fd3022f2ed66c4c2f6a4ec3d9d9abeebe8308ccd5L50-R50)