### PR TITLE
feat(tn_access): Add support for external created_at in record insertion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 dependencies = [
     "prefect-client==3.2.1",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
-    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@6a6cd539714e301e9b2058fc24640f52a91b7937",
+    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@e5726aa6f59d033ba3b1b37cd9e33d4df8610b05",
     "PyGithub",
     "pandera",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 dependencies = [
     "prefect-client==3.2.1",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
-    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@e5726aa6f59d033ba3b1b37cd9e33d4df8610b05",
+    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@20e17cff4172e171c5238e3b6dc086d6046e6967",
     "PyGithub",
     "pandera",
     "pandas",

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -318,13 +318,13 @@ class TNAccessBlock(Block):
 
         # format yyyy-mm-ddTHH:MM:SSZ
         created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        data_provider = self.client.get_current_account()
+        fallback_data_provider = self.client.get_current_account()
 
         args = []
         for batch in batches:
             for record in batch["inputs"]:
                 # expected: $data_provider text, $stream_id text, $date_values text[], $values decimal(36,18)[], $external_created_at text[]
-                args.append([data_provider, batch["stream_id"], record["date"], record["value"], created_at])
+                args.append([batch.get("data_provider", fallback_data_provider), batch["stream_id"], record["date"], record["value"], created_at])
 
         tx_hash = self.get_client().execute_procedure(
             stream_id=helper_contract_stream_id,

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -320,24 +320,25 @@ class TNAccessBlock(Block):
         created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         fallback_data_provider = self.client.get_current_account()
 
-        args = []
+        data_providers = []
+        stream_ids = []
+        date_values = []
+        values = []
+        external_created_at = []
+
         for batch in batches:
             for record in batch["inputs"]:
                 # expected: $data_providers text[], $stream_ids text[], $date_values text[], $values decimal(36,18)[], $external_created_at text[]
-                args.append(
-                    [
-                        batch.get("data_provider", fallback_data_provider),
-                        batch["stream_id"],
-                        record["date"],
-                        str(record["value"]),
-                        created_at,
-                    ]
-                )
+                data_providers.append(batch.get("data_provider", fallback_data_provider))
+                stream_ids.append(batch["stream_id"])
+                date_values.append(record["date"])
+                values.append(str(record["value"]))
+                external_created_at.append(created_at)
 
         tx_hash = self.get_client().execute_procedure(
             stream_id=helper_contract_stream_id,
             procedure="insert_records_truflation",
-            args=args,
+            args=[ [data_providers, stream_ids, date_values, values, external_created_at] ],
             wait=wait,
             data_provider=helper_contract_provider,
         )

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -439,7 +439,7 @@ class TNAccessBlock(Block):
     @staticmethod
     def split_records(
         records: DataFrame[TnDataRowModel],
-        max_batch_size: int = 50000,
+        max_batch_size: int = 25000,
     ) -> list[DataFrame[TnDataRowModel]]:
         return [
             DataFrame[TnDataRowModel](records.iloc[i : i + max_batch_size])
@@ -688,7 +688,7 @@ def task_filter_deployed_streams(block: TNAccessBlock, records: DataFrame[TnData
 def task_split_and_insert_records(
     block: TNAccessBlock,
     records: DataFrame[TnDataRowModel],
-    max_batch_size: int = 50000,
+    max_batch_size: int = 25000,
     wait: bool = True,
     is_unix: bool = False,
     fail_on_batch_error: bool = False,

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -350,11 +350,12 @@ class TNAccessBlock(Block):
         is_unix: bool = False,
         has_external_created_at: bool = False,
     ) -> Optional[str]:
-        """Batch insert records with unix timestamps into multiple streams.
+        """Batch insert records into multiple streams.
 
         Args:
             records: DataFrame containing records with stream_id column
-            data_provider: Optional data provider name
+            is_unix: If True, insert records with unix timestamps
+            has_external_created_at: If True, insert records with an external created_at timestamp
 
         Returns:
             Transaction hash if successful, None otherwise
@@ -637,7 +638,7 @@ def task_batch_insert_tn_records(
     """
     logging = get_run_logger()
 
-    logging.info(f"Batch inserting {len(records)} unix records across {len(records['stream_id'].unique())} streams")
+    logging.info(f"Batch inserting {len(records)} records across {len(records['stream_id'].unique())} streams")
     # we use task so it may retry on network or nonce errors
     tx_or_none = _task_only_batch_insert_records(
         block=block, records=records, is_unix=is_unix, has_external_created_at=has_external_created_at

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -324,7 +324,15 @@ class TNAccessBlock(Block):
         for batch in batches:
             for record in batch["inputs"]:
                 # expected: $data_provider text, $stream_id text, $date_values text[], $values decimal(36,18)[], $external_created_at text[]
-                args.append([batch.get("data_provider", fallback_data_provider), batch["stream_id"], record["date"], record["value"], created_at])
+                args.append(
+                    [
+                        batch.get("data_provider", fallback_data_provider),
+                        batch["stream_id"],
+                        record["date"],
+                        str( record["value"] ),
+                        created_at,
+                    ]
+                )
 
         tx_hash = self.get_client().execute_procedure(
             stream_id=helper_contract_stream_id,

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -323,7 +323,7 @@ class TNAccessBlock(Block):
         args = []
         for batch in batches:
             for record in batch["inputs"]:
-                # expected: $data_provider text, $stream_id text, $date_values text[], $values decimal(36,18)[], $external_created_at text[]
+                # expected: $data_providers text[], $stream_ids text[], $date_values text[], $values decimal(36,18)[], $external_created_at text[]
                 args.append(
                     [
                         batch.get("data_provider", fallback_data_provider),
@@ -337,7 +337,7 @@ class TNAccessBlock(Block):
         tx_hash = self.get_client().execute_procedure(
             stream_id=helper_contract_stream_id,
             procedure="insert_records_truflation",
-            args=args,
+            args=[args],
             wait=wait,
             data_provider=helper_contract_provider,
         )

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -329,7 +329,7 @@ class TNAccessBlock(Block):
                         batch.get("data_provider", fallback_data_provider),
                         batch["stream_id"],
                         record["date"],
-                        str( record["value"] ),
+                        str(record["value"]),
                         created_at,
                     ]
                 )
@@ -337,7 +337,7 @@ class TNAccessBlock(Block):
         tx_hash = self.get_client().execute_procedure(
             stream_id=helper_contract_stream_id,
             procedure="insert_records_truflation",
-            args=[args],
+            args=args,
             wait=wait,
             data_provider=helper_contract_provider,
         )

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -597,9 +597,10 @@ def _task_only_batch_insert_records(
     block: TNAccessBlock,
     records: DataFrame[TnDataRowModel],
     is_unix: bool = False,
+    has_external_created_at: bool = False,
 ) -> Optional[str]:
     """Insert records into TSN without waiting for transaction confirmation"""
-    return block.batch_insert_tn_records(records=records, is_unix=is_unix)
+    return block.batch_insert_tn_records(records=records, is_unix=is_unix, has_external_created_at=has_external_created_at)
 
 
 # we don't use retries here because their individual tasks already have retries
@@ -609,6 +610,7 @@ def task_batch_insert_tn_records(
     records: DataFrame[TnDataRowModel],
     is_unix: bool = False,
     wait: bool = False,
+    has_external_created_at: bool = False,
 ) -> Optional[str]:
     """Batch insert records into multiple streams
 
@@ -625,7 +627,7 @@ def task_batch_insert_tn_records(
 
     logging.info(f"Batch inserting {len(records)} unix records across {len(records['stream_id'].unique())} streams")
     # we use task so it may retry on network or nonce errors
-    tx_or_none = _task_only_batch_insert_records(block=block, records=records, is_unix=is_unix)
+    tx_or_none = _task_only_batch_insert_records(block=block, records=records, is_unix=is_unix, has_external_created_at=has_external_created_at)
 
     if wait and tx_or_none is not None:
         # we need to use task so it may retry on network errors

--- a/src/tsn_adapters/tasks/argentina/flows/ingest_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/ingest_flow.py
@@ -91,6 +91,7 @@ class IngestFlow(ArgentinaFlowController):
             provider_getter=self.processed_provider,
             target_client=target_client,
             data_provider=self.data_provider,
+            return_state=True,
         ).result()
 
         # Step 3: Process each date

--- a/src/tsn_adapters/tasks/argentina/flows/preprocess_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/preprocess_flow.py
@@ -115,7 +115,12 @@ class PreprocessFlow(ArgentinaFlowController):
 
         # Process the data
         logger.info("Processing data")
-        processed_data, uncategorized = process_raw_data(raw_data=raw_data, category_map_df=category_map_df)
+        processed_data, uncategorized = process_raw_data(
+            raw_data=raw_data,
+            category_map_df=category_map_df,
+            date=date,
+            return_state=True,
+        ).result()
 
         # Save to S3
         logger.info("Saving processed data")

--- a/src/tsn_adapters/tasks/argentina/target/trufnetwork.py
+++ b/src/tsn_adapters/tasks/argentina/target/trufnetwork.py
@@ -95,6 +95,7 @@ class TrufNetworkClient(ITargetClient[StreamId]):
             records=data,
             is_unix=False,
             wait=True,
+            has_external_created_at=True,
         )
 
         if results["failed_records"] is not None and not results["failed_records"].empty:


### PR DESCRIPTION
- Introduced `batch_insert_records_with_external_created_at` method for Truflation streams
- Updated insert tasks to support external created_at flag
- Implemented UTC timestamp generation for external created_at records

note: the place this PR is introducing data-provider specific code isn't the best. This path was taken to accelerate deploying of recent works

- fix #107 