### PR TITLE
chore: serializeable deploy flow

### DIFF
--- a/src/tsn_adapters/flows/stream_deploy_flow.py
+++ b/src/tsn_adapters/flows/stream_deploy_flow.py
@@ -40,7 +40,8 @@ def check_and_deploy_stream(
     Returns a message indicating the action taken.
     """
     logger = get_run_logger()
-    if tna_block.stream_exists(stream_id):
+    account = tna_block.get_client().get_current_account()
+    if tna_block.stream_exists(account, stream_id):
         message = f"Stream {stream_id} already exists. Skipping deployment."
         logger.info(message)
         return message


### PR DESCRIPTION
- Remove explicit `tn_client` parameter from stream deployment functions
- Use `tna_block.get_client()` to dynamically retrieve the TN client
- Update `check_and_deploy_stream` to use account from TN access block
- Modify `deploy_streams_flow` to remove redundant client parameter
- Adjust method calls to use block-level client methods

- fix #111 