### PR TITLE
fix: unable to deploy primitive stream

### DIFF
--- a/src/tsn_adapters/flows/stream_deploy_flow.py
+++ b/src/tsn_adapters/flows/stream_deploy_flow.py
@@ -40,7 +40,8 @@ def check_and_deploy_stream(
     Returns a message indicating the action taken.
     """
     logger = get_run_logger()
-    account = tna_block.get_client().get_current_account()
+    tn_client = tna_block.client
+    account = tn_client.get_current_account()
     if tna_block.stream_exists(account, stream_id):
         message = f"Stream {stream_id} already exists. Skipping deployment."
         logger.info(message)


### PR DESCRIPTION
the tn_client was removed, making it become null when passed, so we need to assign it again.

resolves: https://github.com/trufnetwork/adapters/issues/116

This pull request includes a small change to the `src/tsn_adapters/flows/stream_deploy_flow.py` file. The change refactors the way the `tn_client` is accessed to improve code readability and maintainability.

Refactoring for readability:

* [`src/tsn_adapters/flows/stream_deploy_flow.py`](diffhunk://#diff-6533539a96359e2d2740083fd3022f2ed66c4c2f6a4ec3d9d9abeebe8308ccd5L43-R44): Refactored the `check_and_deploy_stream` function to directly assign the `tn_client` variable before using it to get the current account.