### PR TITLE
feat(deploy_flow): include batching mechanism to avoid threads error

### DIFF
--- a/src/tsn_adapters/common/trufnetwork/__init__.py
+++ b/src/tsn_adapters/common/trufnetwork/__init__.py
@@ -1,5 +1,0 @@
-from tsn_adapters.common.trufnetwork.tn import task_get_all_tsn_records
-from tsn_adapters.common.trufnetwork.tn import task_insert_tsn_records
-
-
-__all__ = ["task_insert_tsn_records", "task_get_all_tsn_records"]

--- a/src/tsn_adapters/common/trufnetwork/models/tn_models.py
+++ b/src/tsn_adapters/common/trufnetwork/models/tn_models.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 import pandera as pa
 from pandera.typing import DataFrame, Series

--- a/src/tsn_adapters/flows/stream_deploy_flow.py
+++ b/src/tsn_adapters/flows/stream_deploy_flow.py
@@ -8,32 +8,32 @@ does not exist, it creates a deployment transaction (with wait=False) under a tn
 concurrency limiter and then waits for confirmation using tn-read concurrency via TNAccessBlock.
 """
 
-from typing import List
-import pandas as pd
+import time
+from typing import Literal
+
 from pandera.typing import DataFrame
-from prefect import flow, get_run_logger, task, unmapped
+from prefect import flow, get_run_logger, task
+
+# Import the TN client types and the task to deploy a primitive stream.
+from typing_extensions import TypedDict
 
 # Import the primitive source descriptor interface and data model
 from tsn_adapters.blocks.primitive_source_descriptor import (
-    PrimitiveSourcesDescriptorBlock,
     PrimitiveSourceDataModel,
-)
-
-# Import the TN client types and the task to deploy a primitive stream.
-import trufnetwork_sdk_py.client as tn_client
-from tsn_adapters.common.trufnetwork.tn import (
-    task_deploy_primitive,
-    task_init_stream
+    PrimitiveSourcesDescriptorBlock,
 )
 
 # Import TNAccessBlock and task_wait_for_tx so that we can use its waiting functionality.
 from tsn_adapters.blocks.tn_access import TNAccessBlock, task_wait_for_tx
+from tsn_adapters.common.trufnetwork.tn import task_deploy_primitive, task_init_stream
 
+
+class DeployStreamResult(TypedDict):
+    stream_id: str
+    status: Literal["deployed", "skipped"]
 
 @task(tags=["tn", "tn-write"], retries=3, retry_delay_seconds=5)
-def check_and_deploy_stream(
-    stream_id: str, tna_block: TNAccessBlock, is_unix: bool = False
-) -> str:
+def check_and_deploy_stream(stream_id: str, tna_block: TNAccessBlock, is_unix: bool = False) -> DeployStreamResult:
     """
     Checks if a stream exists using the SDK's stream_exists function.
     If the stream does not exist, deploys it using task_deploy_primitive.
@@ -43,31 +43,38 @@ def check_and_deploy_stream(
     account = tna_block.get_client().get_current_account()
     if tna_block.stream_exists(account, stream_id):
         message = f"Stream {stream_id} already exists. Skipping deployment."
-        logger.info(message)
-        return message
+        logger.debug(message)
+        return DeployStreamResult(stream_id=stream_id, status="skipped")
     else:
         # Create the deployment transaction without waiting.
-        logger.info(f"Deploying stream {stream_id}.")
-        tx_deploy = task_deploy_primitive(stream_id=stream_id, client=tn_client, wait=False, is_unix=is_unix)
+        logger.debug(f"Deploying stream {stream_id}.")
+        tx_deploy = task_deploy_primitive(block=tna_block, stream_id=stream_id, wait=False, is_unix=is_unix)
         # Wait for deployment confirmation using the TNAccessBlock (tn-read concurrency).
         task_wait_for_tx(block=tna_block, tx_hash=tx_deploy)
         logger.debug(f"Deployed stream {stream_id}.")
 
         # Create the initialization transaction without waiting.
-        tx_init = task_init_stream(stream_id=stream_id, client=tn_client, wait=False)
+        tx_init = task_init_stream(block=tna_block, stream_id=stream_id, wait=False)
         logger.debug(f"Initialize stream {stream_id}.")
         # Wait for initialization confirmation.
         task_wait_for_tx(block=tna_block, tx_hash=tx_init)
         logger.debug(f"Initialized stream {stream_id}.")
 
-        return f"Deployed and initialized stream {stream_id}."
+        return DeployStreamResult(stream_id=stream_id, status="deployed")
+
+
+class DeployStreamResults(TypedDict):
+    deployed_count: int
+    skipped_count: int
+
 
 @flow(name="Stream Deployment Flow")
 def deploy_streams_flow(
     psd_block: PrimitiveSourcesDescriptorBlock,
     tna_block: TNAccessBlock,
     is_unix: bool = False,
-) -> List[str]:
+    batch_size: int = 500,
+) -> DeployStreamResults:
     """
     Deploys primitive streams defined in the provided primitive source descriptor.
 
@@ -80,6 +87,7 @@ def deploy_streams_flow(
         psd_block: A PrimitiveSourcesDescriptorBlock providing the stream descriptors.
         tn_client: A TNClient instance for deployment interactions.
         tna_block: A TNAccessBlock instance used to wait for transaction confirmation.
+        batch_size: The number of streams to deploy in each batch. Defaults to 500.
 
     Returns:
         A list of messages indicating whether each stream was deployed or skipped.
@@ -91,16 +99,32 @@ def deploy_streams_flow(
     descriptor_df: DataFrame[PrimitiveSourceDataModel] = psd_block.get_descriptor()
     if descriptor_df.empty:
         logger.info("No stream descriptors found. Exiting flow.")
-        return []
+        return DeployStreamResults(deployed_count=0, skipped_count=0)
 
     # Extract stream_ids from the descriptor.
     stream_ids = descriptor_df["stream_id"].tolist()
     logger.info(f"Found {len(stream_ids)} stream descriptors.")
 
-    # Map over the stream IDs using the check/deploy task.
-    deployment_messages = check_and_deploy_stream.map(
-        stream_id=stream_ids, tna_block=unmapped(tna_block), is_unix=is_unix
-    )
+    # we will deploy in batches of 500 to avoid infinite threads creation
+    batches = [stream_ids[i:i+batch_size] for i in range(0, len(stream_ids), batch_size)]
 
-    logger.info(f"Deployment results: {deployment_messages}")
-    return deployment_messages.result()
+    aggregated_results: list[DeployStreamResult] = []
+    for batch in batches:
+        # for each batch, we will completely deploy -> iniialize and wait for each confirmation
+        futures = []
+        # Map over the stream IDs using the check/deploy task.
+        for stream_id in batch:
+            futures.append(check_and_deploy_stream.submit(stream_id=stream_id, tna_block=tna_block, is_unix=is_unix))
+
+        # Wait for all futures to complete
+        results: list[DeployStreamResult] = []
+        for future in futures:
+            results.append(future.result())
+        aggregated_results.extend(results)
+
+    # aggregate results to print
+    deployed = [result for result in aggregated_results if result["status"] == "deployed"]
+    skipped = [result for result in aggregated_results if result["status"] == "skipped"]
+    summary_results = DeployStreamResults(deployed_count=len(deployed), skipped_count=len(skipped))
+    logger.info(summary_results)
+    return summary_results

--- a/tests/blocks/test_stream_deployment_initialization.py
+++ b/tests/blocks/test_stream_deployment_initialization.py
@@ -1,0 +1,47 @@
+import pytest
+from datetime import datetime
+
+from tsn_adapters.blocks.tn_access import TNAccessBlock
+from trufnetwork_sdk_py.utils import generate_stream_id
+
+
+@pytest.fixture
+def test_stream_id() -> str:
+    """Generate a unique stream ID for deployment tests."""
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    return generate_stream_id(f"deploy_test_{timestamp}")
+
+
+def test_deploy_stream(tn_block: TNAccessBlock, test_stream_id: str):
+    """Test deploying a stream successfully."""
+    # Deploy the stream
+    tx_hash = tn_block.deploy_stream(test_stream_id, wait=True)
+    assert tx_hash is not None, "Deploy transaction hash should be returned"
+
+    # Verify that the stream exists
+    # data_provider is set to empty string if not otherwise specified
+    exists = tn_block.stream_exists(data_provider="", stream_id=test_stream_id)
+    assert exists, "The stream should exist after deployment"
+
+    # Clean up: destroy the deployed stream
+    destroy_tx = tn_block.destroy_stream(test_stream_id, wait=True)
+    assert destroy_tx is not None, "Stream destruction should return a transaction hash"
+
+
+def test_init_stream(tn_block: TNAccessBlock, test_stream_id: str):
+    """Test initializing a deployed stream."""
+    # First deploy the stream
+    deploy_tx = tn_block.deploy_stream(test_stream_id, wait=True)
+    assert deploy_tx is not None, "Deploy transaction hash should be returned"
+    
+    # Initialize the stream
+    init_tx = tn_block.init_stream(test_stream_id, wait=True)
+    assert init_tx is not None, "Init transaction hash should be returned"
+    
+    # After initialization, the stream should be empty
+    record = tn_block.get_first_record(test_stream_id)
+    assert record is None, "The stream should be empty after initialization"
+    
+    # Clean up: destroy the stream
+    destroy_tx = tn_block.destroy_stream(test_stream_id, wait=True)
+    assert destroy_tx is not None, "Stream destruction should return a transaction hash" 

--- a/tests/flows/test_stream_deploy_flow.py
+++ b/tests/flows/test_stream_deploy_flow.py
@@ -1,14 +1,20 @@
+from time import sleep
+from typing import Optional, cast
+
 import pandas as pd
-import pytest
 from pandera.typing import DataFrame
-import trufnetwork_sdk_py.client as tn_client
-from tsn_adapters.blocks.primitive_source_descriptor import (
-    PrimitiveSourcesDescriptorBlock,
-    PrimitiveSourceDataModel,
-)
-from tsn_adapters.flows.stream_deploy_flow import deploy_streams_flow
-from tsn_adapters.blocks.tn_access import TNAccessBlock
 from pydantic import SecretStr
+import pytest
+from pytest import MonkeyPatch
+import trufnetwork_sdk_c_bindings.exports as truf_sdk
+import trufnetwork_sdk_py.client as tn_client
+
+from tsn_adapters.blocks.primitive_source_descriptor import (
+    PrimitiveSourceDataModel,
+    PrimitiveSourcesDescriptorBlock,
+)
+from tsn_adapters.blocks.tn_access import TNAccessBlock
+from tsn_adapters.flows.stream_deploy_flow import DeployStreamResults, deploy_streams_flow
 
 
 class FakePrimitiveSourcesDescriptor(PrimitiveSourcesDescriptorBlock):
@@ -23,12 +29,12 @@ class FakePrimitiveSourcesDescriptor(PrimitiveSourcesDescriptorBlock):
 
 
 class FakeTNClient(tn_client.TNClient):
-    def __init__(self, existing_streams=None):
+    def __init__(self, existing_streams: set[str] | None = None):
         # We do not call the real TNClient __init__ to avoid any side effects.
         if existing_streams is None:
             existing_streams = set()
-        self.existing_streams = set(existing_streams)
-        self.deployed_streams = []
+        self.existing_streams = existing_streams
+        self.deployed_streams: list[str] = []
         # Instead of self.client = self (which is recursive), we set it to a dummy object.
         self.client = object()
 
@@ -42,12 +48,16 @@ class FakeTNClient(tn_client.TNClient):
             del state["client"]
         return state
 
-    def stream_exists(self, stream_id: str) -> bool:
+    def get_current_account(self):
+        return "dummy_account"
+
+    def stream_exists(self, stream_id: str, data_provider: Optional[str] = None) -> bool:
         return stream_id in self.existing_streams
 
-    def deploy_stream(self, stream_id: str, stream_type, wait: bool = True):
+    def deploy_stream(self, stream_id: str, stream_type: str = truf_sdk.StreamTypePrimitive, wait: bool = True):
         # Instead of calling the real SDK, we simulate deployment by calling our fake init_stream.
         self.init_stream(stream_id, wait=wait)
+        return "dummy_tx_hash"
 
     def init_stream(self, stream_id: str, wait: bool = True):
         # Simulate a successful stream initialization.
@@ -55,16 +65,22 @@ class FakeTNClient(tn_client.TNClient):
         self.existing_streams.add(stream_id)
         return "dummy_tx_hash"
 
+
 # --- Fake TNAccessBlock that returns our FakeTNClient ---
 class FakeTNAccessBlock(TNAccessBlock):
     def __init__(self, fake_client: FakeTNClient):
         # Provide dummy values for required fields.
-        super().__init__(tn_provider="2b5ad5c4795c026514f8317c7a215e218dccd6cf", tn_private_key=SecretStr("0000000000000000000000000000000000000000000000000000000000000001"))
+        super().__init__(
+            tn_provider="2b5ad5c4795c026514f8317c7a215e218dccd6cf",
+            tn_private_key=SecretStr("0000000000000000000000000000000000000000000000000000000000000001"),
+        )
         self._fake_client = fake_client
 
     def get_client(self):
         return self._fake_client
 
+
+@pytest.mark.usefixtures("prefect_test_fixture")
 def test_deploy_streams_flow_all_new():
     """
     When none of the streams exist, all should be deployed.
@@ -73,27 +89,101 @@ def test_deploy_streams_flow_all_new():
     fake_client = FakeTNClient(existing_streams=set())
     fake_tna = FakeTNAccessBlock(fake_client=fake_client)
 
-    results = deploy_streams_flow(psd_block=fake_psd, tn_client=fake_client, tna_block=fake_tna)
-
-    # Because the flow returns Prefect task "future" objects,
-    # extract the underlying result from each.
-    resolved_messages = []
-    for res in results:
-        if hasattr(res, "result"):
-            val = res.result
-            if callable(val):
-                val = val()
-            resolved_messages.append(val)
-        else:
-            resolved_messages.append(res)
+    results = deploy_streams_flow(
+        psd_block=fake_psd, tna_block=fake_tna
+    )
 
     # All three streams should be deployed.
     assert set(fake_client.deployed_streams) == {"stream1", "stream2", "stream3"}
 
     # Each message should indicate that the stream was deployed (or possibly "already exists"
     # if, for example, a retry ran).
-    for message in resolved_messages:
+    for message in results:
         assert "Deployed and initialized stream" in message or "already exists" in message
+
+
+# Dummy implementation for the primitive source descriptor block
+class DummyPrimitiveSourcesDescriptorBlock(PrimitiveSourcesDescriptorBlock):
+    num_streams: int = 10000
+
+    def get_descriptor(self) -> DataFrame[PrimitiveSourceDataModel]:
+        # Create a DataFrame with 10,000 stream descriptors
+        data = {
+            "stream_id": [f"stream_{i}" for i in range(self.num_streams)],
+            "source_id": [f"src_{i}" for i in range(self.num_streams)],
+            "source_type": ["type1" for _ in range(self.num_streams)],
+        }
+        return DataFrame[PrimitiveSourceDataModel](pd.DataFrame(data))
+
+
+# Dummy TN client to simulate account retrieval
+class DummyTNClient(tn_client.TNClient):
+    def __init__(self):
+        pass
+
+    def get_current_account(self):
+        return "dummy_account"
+
+
+# Dummy TNAccessBlock to simulate tn server behavior
+class DummyTNAccessBlock(TNAccessBlock):
+    def __init__(self):
+        super().__init__(
+            tn_provider="2b5ad5c4795c026514f8317c7a215e218dccd6cf",
+            tn_private_key=SecretStr("0000000000000000000000000000000000000000000000000000000000000001"),
+        )
+
+    @property
+    def client(self):
+        return DummyTNClient()
+
+    def get_client(self):
+        return self.client
+
+    def stream_exists(self, data_provider: str, stream_id: str) -> bool:
+        # For testing, assume the stream never exists
+        return False
+
+    def deploy_stream(self, stream_id: str, stream_type: str = truf_sdk.StreamTypePrimitive, wait: bool = True):
+        # wait 0.01 seconds
+        # sleep(0.01)
+        return f"deploy_tx_{stream_id}"
+
+    def init_stream(self, stream_id: str, wait: bool = True):
+        return f"init_tx_{stream_id}"
+
+    def wait_for_tx(self, tx_hash: str):
+        # wait 0.1 seconds
+        # sleep(0.1)
+        return
+
+
+# Dummy implementations for tn module tasks to avoid real network calls
+
+@pytest.fixture
+def tn_server():
+    # Return our dummy TNAccessBlock instance
+    return DummyTNAccessBlock()
+
+
+@pytest.fixture
+def primitive_descriptor():
+    dummy = DummyPrimitiveSourcesDescriptorBlock(num_streams=5)
+    return dummy
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_deploy_streams_flow(
+    tn_server: DummyTNAccessBlock, primitive_descriptor: DummyPrimitiveSourcesDescriptorBlock
+):
+    # Execute the deployment flow which deploys 5 streams
+    result = deploy_streams_flow(
+        psd_block=primitive_descriptor, tna_block=tn_server
+    )
+
+    # Assert that the result is a list with 5 messages
+    assert result["deployed_count"] == 5
+    assert result["skipped_count"] == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Introduce `deploy_stream` and `init_stream` methods in TNAccessBlock
- Add corresponding test cases for stream deployment and initialization
- Update stream deployment flow to use new block-level methods
- Refactor TN tasks to leverage block-level stream management
- Improve stream deployment flexibility with batched processing

---

- fix #115 