### PR TITLE
feat: Add Deployment State Tracking Block

### DIFF
--- a/src/tsn_adapters/blocks/deployment_state.py
+++ b/src/tsn_adapters/blocks/deployment_state.py
@@ -1,10 +1,16 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone
+import io
 
 import pandas as pd
-from pandera import DataFrameModel, Field
+from pandera import DataFrameModel, Field  # type: ignore
 from pandera.typing import DataFrame, Series
+from prefect import Task
 from prefect.blocks.core import Block
+from prefect_aws import S3Bucket  # type: ignore
+from pydantic import ConfigDict
+
+from tsn_adapters.utils.deroutine import deroutine
 
 
 class DeploymentStateModel(DataFrameModel):
@@ -23,6 +29,8 @@ class DeploymentStateModel(DataFrameModel):
 
 
 class DeploymentStateBlock(Block, ABC):
+    model_config = ConfigDict(ignored_types=(Task,))
+
     @abstractmethod
     def has_been_deployed(self, stream_id: str) -> bool:
         """Check if the deployment has been performed for a given stream_id."""
@@ -51,4 +59,235 @@ class DeploymentStateBlock(Block, ABC):
     @abstractmethod
     def update_deployment_states(self, states: DataFrame[DeploymentStateModel]) -> None:
         """Update the deployment states with the provided DataFrame of DeploymentStateModel."""
-        raise NotImplementedError 
+        raise NotImplementedError
+
+
+class S3DeploymentStateBlock(DeploymentStateBlock):
+    """S3-backed deployment state tracking block.
+    
+    This block uses S3 to store deployment states in a unified parquet file.
+    All stream states are stored in a single file for better consistency and atomic updates.
+    """
+    s3_bucket: S3Bucket
+    file_path: str
+    model_config = ConfigDict(ignored_types=(Task,))
+
+    def _validate_timestamp(self, timestamp: datetime) -> None:
+        """Validate that a timestamp is timezone-aware and in UTC.
+        
+        Args:
+            timestamp: The timestamp to validate.
+            
+        Raises:
+            TypeError: If timestamp is not a datetime object.
+            ValueError: If the timestamp is not timezone-aware or not in UTC.
+        """
+        if timestamp.tzinfo is None:
+            raise ValueError("Timestamp must be timezone-aware")
+        if timestamp.tzinfo != timezone.utc:
+            raise ValueError("Timestamp must be in UTC")
+
+    def _validate_stream_id(self, stream_id: str) -> None:
+        """Validate that a stream ID is a non-empty string.
+        
+        Args:
+            stream_id: The stream ID to validate.
+            
+        Raises:
+            TypeError: If stream_id is not a string.
+            ValueError: If stream_id is empty.
+        """
+        if not stream_id:
+            raise ValueError("Stream ID cannot be empty")
+
+    def _validate_stream_ids(self, stream_ids: list[str]) -> None:
+        """Validate that a list of stream IDs contains only non-empty strings.
+        
+        Args:
+            stream_ids: The list of stream IDs to validate.
+            
+        Raises:
+            TypeError: If stream_ids is not a list or if any stream ID is not a string.
+            ValueError: If any stream ID is empty.
+        """
+        for stream_id in stream_ids:
+            self._validate_stream_id(stream_id)
+
+    def mark_as_deployed(self, stream_id: str, timestamp: datetime) -> None:
+        self._validate_timestamp(timestamp)
+        self._validate_stream_id(stream_id)
+
+        # Attempt to load existing data from S3
+        try:
+            content = deroutine(self.s3_bucket.read_path(self.file_path))
+            buffer = io.BytesIO(content)
+            df = pd.read_parquet(buffer, engine='pyarrow')
+        except Exception:
+            # If file doesn't exist or can't be read, create a new DataFrame
+            df = pd.DataFrame(columns=['stream_id', 'deployment_timestamp'])
+
+        # Append the new deployment record
+        new_row = {'stream_id': stream_id, 'deployment_timestamp': timestamp}
+        df = pd.concat([df, pd.DataFrame([new_row])], ignore_index=True)
+
+        # Write the updated DataFrame back to S3
+        buffer = io.BytesIO()
+        df.to_parquet(buffer, engine='pyarrow', compression='snappy', index=False)
+        buffer.seek(0)
+        try:
+            deroutine(self.s3_bucket.write_path(self.file_path, buffer.getvalue()))
+        except Exception as exc:
+            raise Exception(f"Failed to write deployment state to S3: {exc}")
+
+    def has_been_deployed(self, stream_id: str) -> bool:
+        """Check if the deployment has been performed for a given stream_id.
+        
+        Args:
+            stream_id: The stream ID to check.
+            
+        Returns:
+            bool: True if the stream has been deployed, False otherwise.
+            
+        Raises:
+            TypeError: If the stream ID is not a string.
+            ValueError: If the stream ID is empty.
+        """
+        self._validate_stream_id(stream_id)
+        try:
+            content = deroutine(self.s3_bucket.read_path(self.file_path))
+            buffer = io.BytesIO(content)
+            df = pd.read_parquet(buffer, engine='pyarrow')
+            return stream_id in df['stream_id'].values
+        except ValueError:  # File doesn't exist
+            return False
+        except Exception as exc:
+            raise Exception(f"Failed to read deployment states from S3: {exc}")
+
+    def check_multiple_streams(self, stream_ids: list[str]) -> dict[str, bool]:
+        """Check deployment status for multiple stream_ids.
+        
+        Args:
+            stream_ids: List of stream IDs to check.
+            
+        Returns:
+            dict[str, bool]: A dictionary mapping each stream_id to its deployment status.
+            
+        Raises:
+            TypeError: If stream_ids is not a list or if any stream ID is not a string.
+            ValueError: If any stream ID is empty.
+            Exception: If there is an error reading from S3.
+        """
+        self._validate_stream_ids(stream_ids)
+        if not stream_ids:
+            return {}
+
+        try:
+            content = deroutine(self.s3_bucket.read_path(self.file_path))
+            buffer = io.BytesIO(content)
+            df = pd.read_parquet(buffer, engine='pyarrow')
+            deployed_streams = set(df['stream_id'].values)
+            return {stream_id: stream_id in deployed_streams for stream_id in stream_ids}
+        except ValueError:  # File doesn't exist
+            return {stream_id: False for stream_id in stream_ids}
+        except Exception as exc:
+            raise Exception(f"Failed to read deployment states from S3: {exc}")
+
+    def mark_multiple_as_deployed(self, stream_ids: list[str], timestamp: datetime) -> None:
+        """Mark multiple stream_ids as deployed at the given timestamp.
+        
+        Args:
+            stream_ids: List of stream IDs to mark as deployed.
+            timestamp: The UTC timestamp when the streams were deployed.
+            
+        Raises:
+            TypeError: If stream_ids is not a list, if any stream ID is not a string,
+                    or if timestamp is not a datetime object.
+            ValueError: If any stream ID is empty, or if the timestamp is not in UTC.
+            Exception: If there is an error reading from or writing to S3.
+        """
+        self._validate_stream_ids(stream_ids)
+        self._validate_timestamp(timestamp)
+
+        if not stream_ids:
+            return
+
+        try:
+            content = deroutine(self.s3_bucket.read_path(self.file_path))
+            buffer = io.BytesIO(content)
+            df = pd.read_parquet(buffer, engine='pyarrow')
+        except ValueError:  # File doesn't exist
+            df = pd.DataFrame(columns=['stream_id', 'deployment_timestamp'])
+        except Exception as exc:
+            raise Exception(f"Failed to read deployment states from S3: {exc}")
+
+        # Create new rows for all stream IDs
+        new_rows = [{'stream_id': stream_id, 'deployment_timestamp': timestamp} for stream_id in stream_ids]
+        df = pd.concat([df, pd.DataFrame(new_rows)], ignore_index=True)
+
+        # Write the updated DataFrame back to S3
+        buffer = io.BytesIO()
+        df.to_parquet(buffer, engine='pyarrow', compression='snappy', index=False)
+        buffer.seek(0)
+        try:
+            deroutine(self.s3_bucket.write_path(self.file_path, buffer.getvalue()))
+        except Exception as exc:
+            raise Exception(f"Failed to write deployment states to S3: {exc}")
+
+    def get_deployment_states(self) -> DataFrame[DeploymentStateModel]:
+        """Retrieve the deployment states as a Pandera DataFrameModel.
+        
+        Returns:
+            DataFrame[DeploymentStateModel]: A DataFrame containing all deployment states.
+            If no states exist, returns an empty DataFrame with the correct schema.
+        
+        Raises:
+            Exception: If there is an error reading from S3 (except for non-existent file).
+        """
+        try:
+            content = deroutine(self.s3_bucket.read_path(self.file_path))
+            buffer = io.BytesIO(content)
+            df = pd.read_parquet(buffer, engine='pyarrow')
+            # Convert timestamps to timezone-aware UTC if they aren't already
+            if df['deployment_timestamp'].dt.tz is None:
+                df['deployment_timestamp'] = pd.to_datetime(df['deployment_timestamp']).dt.tz_localize('UTC')
+            else:
+                df['deployment_timestamp'] = pd.to_datetime(df['deployment_timestamp']).dt.tz_convert('UTC')
+            # Ensure the DataFrame matches our model schema
+            return DataFrame[DeploymentStateModel](df)
+        except ValueError:  # File doesn't exist
+            # Create an empty DataFrame with the correct schema
+            empty_df = pd.DataFrame(columns=['stream_id', 'deployment_timestamp'])
+            return DataFrame[DeploymentStateModel](empty_df)
+        except Exception as exc:
+            raise Exception(f"Failed to read deployment states from S3: {exc}")
+
+    def update_deployment_states(self, states: DataFrame[DeploymentStateModel]) -> None:
+        """Update the deployment states with the provided DataFrame of DeploymentStateModel.
+        
+        This method completely replaces the existing deployment states with the new ones.
+        The provided DataFrame must conform to the DeploymentStateModel schema.
+        
+        Args:
+            states: DataFrame[DeploymentStateModel] containing the new deployment states.
+            Must have 'stream_id' and 'deployment_timestamp' columns with correct types.
+        
+        Raises:
+            Exception: If there is an error writing to S3 or if the DataFrame doesn't match the schema.
+        """
+        # The type annotation already ensures states is a DataFrame[DeploymentStateModel]
+        # which means it has already been validated against the schema
+        
+        # Write the DataFrame to S3, ensuring timestamps are in UTC
+        df = states.copy()
+        if df['deployment_timestamp'].dt.tz is None:
+            df['deployment_timestamp'] = pd.to_datetime(df['deployment_timestamp']).dt.tz_localize('UTC')
+        else:
+            df['deployment_timestamp'] = pd.to_datetime(df['deployment_timestamp']).dt.tz_convert('UTC')
+        
+        buffer = io.BytesIO()
+        df.to_parquet(buffer, engine='pyarrow', compression='snappy', index=False)
+        buffer.seek(0)
+        try:
+            deroutine(self.s3_bucket.write_path(self.file_path, buffer.getvalue()))
+        except Exception as exc:
+            raise Exception(f"Failed to write deployment states to S3: {exc}") 

--- a/src/tsn_adapters/blocks/deployment_state.py
+++ b/src/tsn_adapters/blocks/deployment_state.py
@@ -7,16 +7,28 @@ S3DeploymentStateBlock that uses an S3 bucket to store deployment state informat
 in a unified parquet file.
 
 Usage Example:
+    Before using this block:
+    1. Create an S3Bucket block in Prefect (UI or programmatically)
+    2. Register this DeploymentState block in Prefect (UI or programmatically)
+    3. Configure an instance with your S3 bucket details
+
+    # Example using Prefect's recommended loading method:
     from prefect_aws import S3Bucket
     from tsn_adapters.blocks.deployment_state import S3DeploymentStateBlock
     from datetime import datetime, timezone
 
-    # Initialize your S3 bucket (details omitted)
-    s3_bucket = S3Bucket( /* initialize your bucket here */ )
-    file_path = "deployment_states/all_streams.parquet"
-    deployment_block = S3DeploymentStateBlock(s3_bucket=s3_bucket, file_path=file_path)
+    # Load your pre-configured blocks
+    deployment_block = S3DeploymentStateBlock.load("your-deployment-block-name")
     timestamp = datetime.now(timezone.utc)
     deployment_block.mark_as_deployed("stream_id_example", timestamp)
+
+    # Alternatively, if creating programmatically:
+    s3_bucket = S3Bucket.load("your-bucket-block-name")
+    deployment_block = S3DeploymentStateBlock(
+        s3_bucket=s3_bucket,
+        file_path="deployment_states/all_streams.parquet"
+    )
+    deployment_block.save("your-deployment-block-name")
 """
 
 from abc import ABC, abstractmethod

--- a/src/tsn_adapters/blocks/deployment_state.py
+++ b/src/tsn_adapters/blocks/deployment_state.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+import pandas as pd
+from pandera import DataFrameModel, Field
+from pandera.typing import DataFrame, Series
+from prefect.blocks.core import Block
+
+
+class DeploymentStateModel(DataFrameModel):
+    """Pandera DataFrameModel for tracking deployment state.
+
+    Fields:
+        stream_id: Non-nullable string identifier for the stream.
+        deployment_timestamp: Non-nullable pandas Timestamp. Must be timezone-aware (UTC).
+    """
+    stream_id: Series[str] = Field(nullable=False)
+    deployment_timestamp: Series[pd.Timestamp] = Field(nullable=False)
+
+    class Config:  # type: ignore
+        strict = "filter"
+        coerce = True
+
+
+class DeploymentStateBlock(Block, ABC):
+    @abstractmethod
+    def has_been_deployed(self, stream_id: str) -> bool:
+        """Check if the deployment has been performed for a given stream_id."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def check_multiple_streams(self, stream_ids: list[str]) -> dict[str, bool]:
+        """Check deployment status for multiple stream_ids and return a dictionary mapping each stream_id to its deployment status."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def mark_as_deployed(self, stream_id: str, timestamp: datetime) -> None:
+        """Mark a single stream_id as deployed at the given timestamp."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def mark_multiple_as_deployed(self, stream_ids: list[str], timestamp: datetime) -> None:
+        """Mark multiple stream_ids as deployed at the given timestamp."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_deployment_states(self) -> DataFrame[DeploymentStateModel]:
+        """Retrieve the deployment states as a Pandera DataFrameModel."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_deployment_states(self, states: DataFrame[DeploymentStateModel]) -> None:
+        """Update the deployment states with the provided DataFrame of DeploymentStateModel."""
+        raise NotImplementedError 

--- a/tests/blocks/test_deployment_state.py
+++ b/tests/blocks/test_deployment_state.py
@@ -157,9 +157,11 @@ def test_get_deployment_states_with_data(s3_block: S3DeploymentStateBlock) -> No
     df = s3_block.get_deployment_states()
     assert len(df) == 2
     assert set(df['stream_id'].values) == set(stream_ids)
-    # Convert timestamps to UTC for comparison
-    df_timestamps = pd.to_datetime(df['deployment_timestamp']).dt.tz_localize('UTC')
-    assert all(df_timestamps == timestamp)
+    # Compare timestamps using pandas Series equality
+    expected_ts = pd.Series([timestamp] * len(df))
+    expected_ts = expected_ts.dt.tz_localize(None)  # Convert to naive timestamps for comparison
+    actual_ts = df['deployment_timestamp'].dt.tz_localize(None)
+    pd.testing.assert_series_equal(actual_ts, expected_ts, check_names=False)
 
 
 def test_update_deployment_states_valid(s3_block: S3DeploymentStateBlock) -> None:

--- a/tests/blocks/test_deployment_state.py
+++ b/tests/blocks/test_deployment_state.py
@@ -1,0 +1,204 @@
+import pandas as pd
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+import io
+
+from prefect_aws import S3Bucket  # type: ignore
+
+from src.tsn_adapters.blocks.deployment_state import S3DeploymentStateBlock
+
+
+@pytest.fixture
+def mock_s3_bucket() -> S3Bucket:
+    mock_bucket = MagicMock(spec=S3Bucket)
+    stored_content: dict[str, bytes] = {}
+
+    def sync_write_path(path: str, content: bytes) -> str:
+        stored_content[path] = content
+        return path
+
+    def sync_read_path(path: str) -> bytes:
+        if path not in stored_content:
+            raise ValueError("No content stored")
+        return stored_content[path]
+
+    mock_bucket.write_path = MagicMock(side_effect=sync_write_path)
+    mock_bucket.read_path = MagicMock(side_effect=sync_read_path)
+    return mock_bucket
+
+
+@pytest.fixture
+def s3_block(mock_s3_bucket: S3Bucket) -> S3DeploymentStateBlock:
+    return S3DeploymentStateBlock(s3_bucket=mock_s3_bucket, file_path="deployment_states/all_streams.parquet")
+
+
+def test_mark_as_deployed_valid_timestamp(s3_block: S3DeploymentStateBlock) -> None:
+    valid_timestamp = datetime(2023, 10, 10, 12, 0, tzinfo=timezone.utc)
+    s3_block.mark_as_deployed("test_stream", valid_timestamp)
+
+    # Verify that write_path was called with the correct path
+    s3_block.s3_bucket.write_path.assert_called_once()  # type: ignore
+    assert s3_block.s3_bucket.write_path.call_args[0][0] == "deployment_states/all_streams.parquet"  # type: ignore
+
+    # Read back the data to verify it was written correctly
+    content: bytes = s3_block.s3_bucket.read_path("deployment_states/all_streams.parquet")  # type: ignore
+    buffer = io.BytesIO(content)
+    df = pd.read_parquet(buffer, engine='pyarrow')
+    
+    assert len(df) == 1
+    assert df.iloc[0]['stream_id'] == "test_stream"
+    assert df.iloc[0]['deployment_timestamp'] == valid_timestamp
+
+
+def test_mark_as_deployed_invalid_timestamp(s3_block: S3DeploymentStateBlock) -> None:
+    # Create a timestamp without timezone info
+    invalid_timestamp = datetime(2023, 10, 10, 12, 0)
+    with pytest.raises(ValueError, match="Timestamp must be timezone-aware and in UTC."):
+        s3_block.mark_as_deployed("test_stream", invalid_timestamp)
+
+
+def test_has_been_deployed_true(s3_block: S3DeploymentStateBlock) -> None:
+    # First mark a stream as deployed
+    timestamp = datetime(2023, 10, 10, 12, 0, tzinfo=timezone.utc)
+    s3_block.mark_as_deployed("test_stream", timestamp)
+    
+    # Then check if it's deployed
+    result = s3_block.has_been_deployed("test_stream")
+    assert result is True
+
+
+def test_has_been_deployed_false(s3_block: S3DeploymentStateBlock) -> None:
+    # Check a stream that hasn't been deployed
+    result = s3_block.has_been_deployed("nonexistent_stream")
+    assert result is False
+
+
+def test_mark_multiple_as_deployed_valid_timestamp(s3_block: S3DeploymentStateBlock) -> None:
+    valid_timestamp = datetime(2023, 10, 10, 12, 0, tzinfo=timezone.utc)
+    stream_ids = ["test_stream_1", "test_stream_2", "test_stream_3"]
+    s3_block.mark_multiple_as_deployed(stream_ids, valid_timestamp)
+
+    # Verify that write_path was called with the correct path
+    s3_block.s3_bucket.write_path.assert_called_once()  # type: ignore
+    assert s3_block.s3_bucket.write_path.call_args[0][0] == "deployment_states/all_streams.parquet"  # type: ignore
+
+    # Read back the data to verify it was written correctly
+    content: bytes = s3_block.s3_bucket.read_path("deployment_states/all_streams.parquet")  # type: ignore
+    buffer = io.BytesIO(content)
+    df = pd.read_parquet(buffer, engine='pyarrow')
+    
+    assert len(df) == 3
+    assert set(df['stream_id'].values) == set(stream_ids)
+    assert all(df['deployment_timestamp'] == valid_timestamp)
+
+
+def test_mark_multiple_as_deployed_invalid_timestamp(s3_block: S3DeploymentStateBlock) -> None:
+    # Create a timestamp without timezone info
+    invalid_timestamp = datetime(2023, 10, 10, 12, 0)
+    stream_ids = ["test_stream_1", "test_stream_2"]
+    with pytest.raises(ValueError, match="Timestamp must be timezone-aware and in UTC."):
+        s3_block.mark_multiple_as_deployed(stream_ids, invalid_timestamp)
+
+
+def test_mark_multiple_as_deployed_empty_list(s3_block: S3DeploymentStateBlock) -> None:
+    valid_timestamp = datetime(2023, 10, 10, 12, 0, tzinfo=timezone.utc)
+    s3_block.mark_multiple_as_deployed([], valid_timestamp)
+    
+    # Verify that write_path was not called
+    s3_block.s3_bucket.write_path.assert_not_called()  # type: ignore
+
+
+def test_check_multiple_streams_mixed_status(s3_block: S3DeploymentStateBlock) -> None:
+    # First mark some streams as deployed
+    timestamp = datetime(2023, 10, 10, 12, 0, tzinfo=timezone.utc)
+    deployed_streams = ["test_stream_1", "test_stream_2"]
+    s3_block.mark_multiple_as_deployed(deployed_streams, timestamp)
+    
+    # Check a mix of deployed and non-deployed streams
+    check_streams = ["test_stream_1", "test_stream_3", "test_stream_2"]
+    result = s3_block.check_multiple_streams(check_streams)
+    
+    assert result == {
+        "test_stream_1": True,
+        "test_stream_2": True,
+        "test_stream_3": False
+    }
+
+
+def test_check_multiple_streams_empty_list(s3_block: S3DeploymentStateBlock) -> None:
+    result = s3_block.check_multiple_streams([])
+    assert result == {}
+
+
+def test_check_multiple_streams_none_deployed(s3_block: S3DeploymentStateBlock) -> None:
+    stream_ids = ["test_stream_1", "test_stream_2"]
+    result = s3_block.check_multiple_streams(stream_ids)
+    assert result == {
+        "test_stream_1": False,
+        "test_stream_2": False
+    }
+
+
+def test_get_deployment_states_empty(s3_block: S3DeploymentStateBlock) -> None:
+    # Get states when no file exists
+    df = s3_block.get_deployment_states()
+    assert len(df) == 0
+    assert list(df.columns) == ['stream_id', 'deployment_timestamp']
+
+
+def test_get_deployment_states_with_data(s3_block: S3DeploymentStateBlock) -> None:
+    # First add some deployment states
+    timestamp = datetime(2023, 10, 10, 12, 0, tzinfo=timezone.utc)
+    stream_ids = ["test_stream_1", "test_stream_2"]
+    s3_block.mark_multiple_as_deployed(stream_ids, timestamp)
+    
+    # Get the states
+    df = s3_block.get_deployment_states()
+    assert len(df) == 2
+    assert set(df['stream_id'].values) == set(stream_ids)
+    # Convert timestamps to UTC for comparison
+    df_timestamps = pd.to_datetime(df['deployment_timestamp']).dt.tz_localize('UTC')
+    assert all(df_timestamps == timestamp)
+
+
+def test_update_deployment_states_valid(s3_block: S3DeploymentStateBlock) -> None:
+    # Create a valid DataFrame with deployment states
+    timestamp = datetime(2023, 10, 10, 12, 0, tzinfo=timezone.utc)
+    data = {
+        'stream_id': ['test_stream_1', 'test_stream_2'],
+        'deployment_timestamp': [timestamp, timestamp]
+    }
+    df = pd.DataFrame(data)
+    from src.tsn_adapters.blocks.deployment_state import DataFrame, DeploymentStateModel
+    states = DataFrame[DeploymentStateModel](df)
+    
+    # Update the states
+    s3_block.update_deployment_states(states)
+    
+    # Verify the states were written correctly
+    content: bytes = s3_block.s3_bucket.read_path("deployment_states/all_streams.parquet")  # type: ignore
+    buffer = io.BytesIO(content)
+    read_df = pd.read_parquet(buffer, engine='pyarrow')
+    
+    assert len(read_df) == 2
+    assert set(read_df['stream_id'].values) == {'test_stream_1', 'test_stream_2'}
+    assert all(read_df['deployment_timestamp'] == timestamp)
+
+
+def test_update_deployment_states_empty(s3_block: S3DeploymentStateBlock) -> None:
+    # Create an empty DataFrame with the correct schema
+    df = pd.DataFrame(columns=['stream_id', 'deployment_timestamp'])
+    from src.tsn_adapters.blocks.deployment_state import DataFrame, DeploymentStateModel
+    states = DataFrame[DeploymentStateModel](df)
+    
+    # Update with empty states
+    s3_block.update_deployment_states(states)
+    
+    # Verify the states were written correctly
+    content: bytes = s3_block.s3_bucket.read_path("deployment_states/all_streams.parquet")  # type: ignore
+    buffer = io.BytesIO(content)
+    read_df = pd.read_parquet(buffer, engine='pyarrow')
+    
+    assert len(read_df) == 0
+    assert list(read_df.columns) == ['stream_id', 'deployment_timestamp'] 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Introduces a new Prefect Block for tracking deployment states of streams.
- Provides an abstract base class `DeploymentStateBlock` and a concrete implementation `S3DeploymentStateBlock`.
- `S3DeploymentStateBlock` uses an S3 bucket to store deployment states in a unified Parquet file, ensuring consistency.
- Uses Pandera DataFrameModel (`DeploymentStateModel`) to enforce schema validation for deployment state data.
- Includes comprehensive unit tests covering all key functionalities of `S3DeploymentStateBlock`.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix https://github.com/trufnetwork/truf-data-provider/issues/483

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests were added using `pytest` and `unittest.mock.MagicMock` to simulate S3 interactions.
- Tests cover marking single and multiple streams as deployed, checking deployment status, updating states, and handling edge cases (e.g., empty stream IDs, invalid timestamps).
- The tests verify that the `S3DeploymentStateBlock` correctly interacts with the mocked S3 bucket and handles data persistence and retrieval as expected.