### PR TITLE
chore: retry the failed tasks

### DIFF
--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -551,7 +551,7 @@ class TNAccessBlock(Block):
 
 
 # --- Top Level Task Functions ---
-@task()
+@task(retries=UNUSED_INFINITY_RETRIES, retry_delay_seconds=10, retry_condition_fn=tn_special_retry_condition(5))
 def task_read_all_records(block: TNAccessBlock, stream_id: str, data_provider: Optional[str] = None) -> pd.DataFrame:
     return block.read_all_records(stream_id, data_provider)
 
@@ -580,7 +580,7 @@ def task_read_records(
 ) -> DataFrame[TnRecordModel]: ...
 
 
-@task()
+@task(retries=UNUSED_INFINITY_RETRIES, retry_delay_seconds=10, retry_condition_fn=tn_special_retry_condition(5))
 def task_read_records(
     block: TNAccessBlock,
     stream_id: str,
@@ -621,7 +621,7 @@ def task_read_records(
         )
 
 
-@task()
+@task(retries=UNUSED_INFINITY_RETRIES, retry_delay_seconds=10, retry_condition_fn=tn_special_retry_condition(5))
 def task_insert_tn_records(
     block: TNAccessBlock,
     stream_id: str,
@@ -631,7 +631,7 @@ def task_insert_tn_records(
     return block.insert_tn_records(stream_id, records, data_provider)
 
 
-@task()
+@task(retries=UNUSED_INFINITY_RETRIES, retry_delay_seconds=10, retry_condition_fn=tn_special_retry_condition(5))
 def task_insert_unix_tn_records(
     block: TNAccessBlock,
     stream_id: str,
@@ -856,7 +856,7 @@ def task_split_and_insert_records(
     )
 
 
-@task()
+@task(retries=UNUSED_INFINITY_RETRIES, retry_delay_seconds=10, retry_condition_fn=tn_special_retry_condition(5))
 def task_destroy_stream(block: TNAccessBlock, stream_id: str, wait: bool = True) -> str:
     """Task to destroy a stream with the given stream ID.
 


### PR DESCRIPTION
Resolves: https://github.com/trufnetwork/truf-data-provider/issues/491

This pull request includes changes to the `src/tsn_adapters/blocks/tn_access.py` file to enhance the retry mechanism for several task functions. The most important changes involve adding retry parameters to the `@task` decorator to improve fault tolerance.

Enhancements to retry mechanism:

* [`src/tsn_adapters/blocks/tn_access.py`](diffhunk://#diff-e13ae36ae533c5ca006ffba34c3c9a23d1f9eed153e17e507bcbc05b1ef27e46L554-R554): Updated the `@task` decorator for `task_read_all_records` to include `retries=UNUSED_INFINITY_RETRIES`, `retry_delay_seconds=10`, and `retry_condition_fn=tn_special_retry_condition(5)`.
* [`src/tsn_adapters/blocks/tn_access.py`](diffhunk://#diff-e13ae36ae533c5ca006ffba34c3c9a23d1f9eed153e17e507bcbc05b1ef27e46L583-R583): Updated the `@task` decorator for `task_read_records` to include `retries=UNUSED_INFINITY_RETRIES`, `retry_delay_seconds=10`, and `retry_condition_fn=tn_special_retry_condition(5)`.
* [`src/tsn_adapters/blocks/tn_access.py`](diffhunk://#diff-e13ae36ae533c5ca006ffba34c3c9a23d1f9eed153e17e507bcbc05b1ef27e46L624-R624): Updated the `@task` decorator for `task_insert_tn_records` to include `retries=UNUSED_INFINITY_RETRIES`, `retry_delay_seconds=10`, and `retry_condition_fn=tn_special_retry_condition(5)`.
* [`src/tsn_adapters/blocks/tn_access.py`](diffhunk://#diff-e13ae36ae533c5ca006ffba34c3c9a23d1f9eed153e17e507bcbc05b1ef27e46L634-R634): Updated the `@task` decorator for `task_insert_unix_tn_records` to include `retries=UNUSED_INFINITY_RETRIES`, `retry_delay_seconds=10`, and `retry_condition_fn=tn_special_retry_condition(5)`.
* [`src/tsn_adapters/blocks/tn_access.py`](diffhunk://#diff-e13ae36ae533c5ca006ffba34c3c9a23d1f9eed153e17e507bcbc05b1ef27e46L859-R859): Updated the `@task` decorator for `task_destroy_stream` to include `retries=UNUSED_INFINITY_RETRIES`, `retry_delay_seconds=10`, and `retry_condition_fn=tn_special_retry_condition(5)`.