### PR TITLE
chore: retry on network error even without the 'dial' text

### DIFF
--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -71,7 +71,7 @@ class TNNodeNetworkError(Exception):
     def from_error(cls, error: Exception) -> "TNNodeNetworkError":
         if isinstance(error, TNNodeNetworkError):
             return error
-        if isinstance(error, RuntimeError) and "http post failed" in str(error) and "dial tcp" in str(error):
+        if isinstance(error, RuntimeError) and "http post failed" in str(error) and "tcp" in str(error):
             return cls(str(error))
         raise error
 


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/adapters/issues/135

This pull request includes a minor change to the error handling logic in the `TNNodeNetworkError` class within the `tn_access.py` file. The change simplifies the condition that checks for specific error messages in `RuntimeError` instances.

* [`src/tsn_adapters/blocks/tn_access.py`](diffhunk://#diff-e13ae36ae533c5ca006ffba34c3c9a23d1f9eed153e17e507bcbc05b1ef27e46L74-R74): Modified the condition to check for the presence of "tcp" instead of "dial tcp" in the error message string.