### PR TITLE
chore: additional concurrency manager and remove argentina param

### DIFF
--- a/src/tsn_adapters/tasks/argentina/flows/preprocess_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/preprocess_flow.py
@@ -118,7 +118,6 @@ class PreprocessFlow(ArgentinaFlowController):
         processed_data, uncategorized = process_raw_data(
             raw_data=raw_data,
             category_map_df=category_map_df,
-            date=date,
             return_state=True,
         ).result()
 


### PR DESCRIPTION
## Description

This PR introduces concurrency improvements and refactors Argentina's preprocessing flow:

Core Changes:
- Add concurrency context managers for thread-safe access to TN resources
- Remove unnecessary parameter from Argentina preprocessing flow

## Related Problem
- fix https://github.com/trufnetwork/adapters/issues/138

## How Has This Been Tested?
- Existing tests pass with the new concurrency managers
- Argentina preprocessing flow continues to work as expected after parameter removal 