### PR TITLE
chore(fmp): add logs and correct get earliest date boolean

### DIFF
--- a/tests/blocks/test_split_and_insert_records.py
+++ b/tests/blocks/test_split_and_insert_records.py
@@ -10,32 +10,13 @@ import time
 
 import pandas as pd
 from pandera.typing import DataFrame
+from prefect import flow
 import pytest
 import trufnetwork_sdk_c_bindings.exports as truf_sdk
 from trufnetwork_sdk_py.utils import generate_stream_id
-from prefect import flow
 
 from tsn_adapters.blocks.tn_access import TNAccessBlock, task_split_and_insert_records
-from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel, StreamLocatorModel
-
-
-@pytest.fixture(scope="session")
-def helper_contract_id(tn_block: TNAccessBlock) -> Generator[str, None, None]:
-    """Create and manage the helper contract."""
-    helper_stream_id = tn_block.helper_contract_stream_name
-    client = tn_block.get_client()
-
-    # Try to deploy helper contract
-    try:
-        # we don't need to initialize helper contracts
-        client.deploy_stream(helper_stream_id, stream_type=truf_sdk.StreamTypeHelper, wait=True)
-    except Exception as e:
-        if "dataset exists" not in str(e) and "already exists" not in str(e):
-            raise e
-
-    yield helper_stream_id
-
-    # Don't cleanup helper contract as it might be used by other tests
+from tsn_adapters.common.trufnetwork.models.tn_models import StreamLocatorModel, TnDataRowModel
 
 
 @pytest.fixture
@@ -91,17 +72,17 @@ def sample_records(test_stream_ids: list[str]) -> DataFrame[TnDataRowModel]:
 def helper_split_small_batches_flow(tn_block: TNAccessBlock, records: DataFrame[TnDataRowModel], max_batch_size: int):
     """Flow wrapper for split_and_insert_records with small batches."""
     return task_split_and_insert_records(
-        tn_block, records, max_batch_size=max_batch_size, is_unix=True, 
-        filter_deployed_streams=False, wait=False
+        tn_block, records, max_batch_size=max_batch_size, is_unix=True, filter_deployed_streams=False, wait=False
     )
+
 
 @flow(name="helper-split-single-batch-flow")
 def helper_split_single_batch_flow(tn_block: TNAccessBlock, records: DataFrame[TnDataRowModel], max_batch_size: int):
     """Flow wrapper for split_and_insert_records with a single batch."""
     return task_split_and_insert_records(
-        tn_block, records, max_batch_size=max_batch_size, is_unix=True, 
-        filter_deployed_streams=False, wait=False
+        tn_block, records, max_batch_size=max_batch_size, is_unix=True, filter_deployed_streams=False, wait=False
     )
+
 
 @flow(name="helper-split-empty-records-flow")
 def helper_split_empty_records_flow(tn_block: TNAccessBlock, empty_records: DataFrame[TnDataRowModel]):
@@ -110,6 +91,7 @@ def helper_split_empty_records_flow(tn_block: TNAccessBlock, empty_records: Data
         tn_block, empty_records, is_unix=True, filter_deployed_streams=False, wait=False
     )
 
+
 @flow(name="helper-split-with-failures-flow")
 def helper_split_with_failures_flow(tn_block: TNAccessBlock, mixed_records: DataFrame[TnDataRowModel]):
     """Flow wrapper for split_and_insert_records with failures."""
@@ -117,43 +99,35 @@ def helper_split_with_failures_flow(tn_block: TNAccessBlock, mixed_records: Data
         tn_block, mixed_records, is_unix=True, filter_deployed_streams=False, wait=True
     )
 
+
 @flow(name="helper-filter-deployed-streams-flow")
 def helper_filter_deployed_streams_flow(tn_block: TNAccessBlock, all_records: DataFrame[TnDataRowModel]):
     """Flow wrapper for split_and_insert_records with filter_deployed_streams=True."""
-    return task_split_and_insert_records(
-        tn_block,
-        all_records,
-        is_unix=True,
-        filter_deployed_streams=True,
-        wait=True
-    )
+    return task_split_and_insert_records(tn_block, all_records, is_unix=True, filter_deployed_streams=True, wait=True)
+
 
 @flow(name="helper-filter-deployed-streams-empty-flow")
 def helper_filter_deployed_streams_empty_flow(tn_block: TNAccessBlock, empty_records: DataFrame[TnDataRowModel]):
     """Flow wrapper for split_and_insert_records with empty records and filter_deployed_streams=True."""
-    return task_split_and_insert_records(
-        tn_block,
-        empty_records,
-        is_unix=True,
-        filter_deployed_streams=True,
-        wait=True
-    )
+    return task_split_and_insert_records(tn_block, empty_records, is_unix=True, filter_deployed_streams=True, wait=True)
+
 
 @flow(name="helper-direct-filter-streams-flow")
-def helper_direct_filter_streams_flow(tn_block: TNAccessBlock, records: DataFrame[TnDataRowModel], max_depth: int, max_filter_size: int):
+def helper_direct_filter_streams_flow(
+    tn_block: TNAccessBlock, records: DataFrame[TnDataRowModel], max_depth: int, max_filter_size: int
+):
     """Flow wrapper for directly calling task_filter_initialized_streams."""
     from tsn_adapters.blocks.tn_access import task_filter_initialized_streams
-    filter_results = task_filter_initialized_streams.with_options(retries=0, cache_key_fn=None, cache_expiration=None, retry_condition_fn=None)(
-        block=tn_block,
-        records=records,
-        max_depth=max_depth,
-        max_filter_size=max_filter_size
-    )
+
+    filter_results = task_filter_initialized_streams.with_options(
+        retries=0, cache_key_fn=None, cache_expiration=None, retry_condition_fn=None
+    )(block=tn_block, records=records, max_depth=max_depth, max_filter_size=max_filter_size)
     # Ensure we return a non-None value for type checking
     if filter_results is None:
         empty_df = DataFrame[StreamLocatorModel](pd.DataFrame(columns=["stream_id", "data_provider"]))
         return {"existent_streams": empty_df, "missing_streams": empty_df}
     return filter_results
+
 
 class TestSplitAndInsertRecords:
     """Integration tests for split_and_insert_records functionality."""
@@ -228,7 +202,7 @@ class TestSplitAndInsertRecords:
         assert len(results["success_tx_hashes"]) == 0
         assert len(results["failed_records"]) > 0
         assert "invalid_stream_id" in results["failed_records"]["stream_id"].values
-        
+
         # Verify error messages without iterating over potentially None value
         if isinstance(results.get("failed_reasons"), list) and len(results.get("failed_reasons", [])) > 0:
             # At least one error message should contain "invalid stream id"
@@ -247,95 +221,109 @@ class TestSplitAndInsertRecords:
         base_timestamp = int(datetime.now().timestamp())
         client = tn_block.get_client()
         test_name = f"filter_init_{base_timestamp}"
-        
+
         # 1. Set up test streams with different statuses
         # Already initialized streams from fixture
         initialized_stream_ids = test_stream_ids
-        
+
         # Create uninitialized streams (deployed but not initialized)
         uninitialized_stream_ids = [
             generate_stream_id(f"{test_name}_uninit_1"),
             generate_stream_id(f"{test_name}_uninit_2"),
             generate_stream_id(f"{test_name}_uninit_3"),
         ]
-        
+
         for stream_id in uninitialized_stream_ids:
             client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitiveUnix, wait=True)
             # Deliberately not initializing these streams
-        
+
         # Generate non-existent stream IDs
         non_existent_stream_ids = [
             generate_stream_id(f"{test_name}_nonexistent_1"),
             generate_stream_id(f"{test_name}_nonexistent_2"),
             generate_stream_id(f"{test_name}_nonexistent_3"),
         ]
-        
+
         # 2. Create records for all streams
         all_records = []
-        
+
         # Add records for initialized streams
         for stream_id in initialized_stream_ids:
-            all_records.append({
-                "stream_id": stream_id,
-                "data_provider": tn_block.current_account,
-                "date": base_timestamp,
-                "value": 100.0,
-            })
-        
+            all_records.append(
+                {
+                    "stream_id": stream_id,
+                    "data_provider": tn_block.current_account,
+                    "date": base_timestamp,
+                    "value": 100.0,
+                }
+            )
+
         # Add records for uninitialized streams
         for stream_id in uninitialized_stream_ids:
-            all_records.append({
-                "stream_id": stream_id,
-                "data_provider": tn_block.current_account,
-                "date": base_timestamp,
-                "value": 200.0,
-            })
-        
+            all_records.append(
+                {
+                    "stream_id": stream_id,
+                    "data_provider": tn_block.current_account,
+                    "date": base_timestamp,
+                    "value": 200.0,
+                }
+            )
+
         # Add records for non-existent streams
         for stream_id in non_existent_stream_ids:
-            all_records.append({
-                "stream_id": stream_id,
-                "data_provider": tn_block.current_account,
-                "date": base_timestamp,
-                "value": 300.0,
-            })
-        
+            all_records.append(
+                {
+                    "stream_id": stream_id,
+                    "data_provider": tn_block.current_account,
+                    "date": base_timestamp,
+                    "value": 300.0,
+                }
+            )
+
         # Convert to DataFrame
         records_df = DataFrame[TnDataRowModel](pd.DataFrame(all_records))
-        
+
         # 3. Test the filter function directly with different parameters
-        
+
         # Test with normal parameters
         filter_results = helper_direct_filter_streams_flow(tn_block, records_df, max_depth=10, max_filter_size=5000)
-        
+
         # Verify results
         assert len(filter_results["initialized_streams"]) == len(initialized_stream_ids)
-        assert len(filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(non_existent_stream_ids)
-        
+        assert len(filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(
+            non_existent_stream_ids
+        )
+
         # Verify each initialized stream is in the existent_streams result
         existent_stream_ids = filter_results["initialized_streams"]["stream_id"].tolist()
         for stream_id in initialized_stream_ids:
             assert stream_id in existent_stream_ids
-            
+
         # Verify uninitialized and non-existent streams are in missing_streams
         missing_stream_ids = filter_results["uninitialized_streams"]["stream_id"].tolist()
         for stream_id in uninitialized_stream_ids + non_existent_stream_ids:
             assert stream_id in missing_stream_ids
-        
+
         # 4. Test with small max_filter_size to force divide and conquer
         small_filter_results = helper_direct_filter_streams_flow(tn_block, records_df, max_depth=10, max_filter_size=1)
-        
+
         # Results should be the same even with a small max_filter_size
         assert len(small_filter_results["initialized_streams"]) == len(initialized_stream_ids)
-        assert len(small_filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(non_existent_stream_ids)
-        
+        assert len(small_filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(
+            non_existent_stream_ids
+        )
+
         # 5. Test with small max_depth to force fallback to individual checks
-        fallback_filter_results = helper_direct_filter_streams_flow(tn_block, records_df, max_depth=1, max_filter_size=5000)
-        
+        fallback_filter_results = helper_direct_filter_streams_flow(
+            tn_block, records_df, max_depth=1, max_filter_size=5000
+        )
+
         # Results should be the same even with fallback
         assert len(fallback_filter_results["initialized_streams"]) == len(initialized_stream_ids)
-        assert len(fallback_filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(non_existent_stream_ids)
-        
+        assert len(fallback_filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(
+            non_existent_stream_ids
+        )
+
         # 6. Clean up the uninitialized streams
         for stream_id in uninitialized_stream_ids:
             try:
@@ -348,57 +336,58 @@ class TestSplitAndInsertRecords:
         base_timestamp = int(datetime.now().timestamp())
         client = tn_block.get_client()
         test_name = f"filter_large_{base_timestamp}"
-        
+
         # Use streams from fixture as initialized streams
         initialized_stream_ids = test_stream_ids
-        
+
         # Print debug info about test_stream_ids
         print("\nDEBUG: test_stream_ids fixture:")
         print(f"Type: {type(test_stream_ids)}")
         print(f"Content: {test_stream_ids}")
         print(f"Length: {len(test_stream_ids)}")
-        
+
         # Create a larger set of records to test the divide-and-conquer algorithm
         # We'll use mostly non-existent streams as they don't require deployment
         num_nonexistent_streams = 20  # Adjust based on desired test size
         non_existent_stream_ids = [
-            generate_stream_id(f"{test_name}_nonexist_{i}")
-            for i in range(num_nonexistent_streams)
+            generate_stream_id(f"{test_name}_nonexist_{i}") for i in range(num_nonexistent_streams)
         ]
-        
+
         # Create a few uninitialized streams
         uninitialized_stream_ids = [
             generate_stream_id(f"{test_name}_uninit_1"),
             generate_stream_id(f"{test_name}_uninit_2"),
         ]
-        
+
         for stream_id in uninitialized_stream_ids:
             client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitiveUnix, wait=True)
             # Deliberately not initializing
-        
+
         # Combine all stream ids
         all_stream_ids = initialized_stream_ids + uninitialized_stream_ids + non_existent_stream_ids
-        
+
         # Create records for all streams
         all_records = []
         for i, stream_id in enumerate(all_stream_ids):
-            all_records.append({
-                "stream_id": stream_id,
-                "data_provider": tn_block.current_account,
-                "date": base_timestamp + i,
-                "value": float(i * 10),
-            })
-        
+            all_records.append(
+                {
+                    "stream_id": stream_id,
+                    "data_provider": tn_block.current_account,
+                    "date": base_timestamp + i,
+                    "value": float(i * 10),
+                }
+            )
+
         # Convert to DataFrame
         records_df = DataFrame[TnDataRowModel](pd.DataFrame(all_records))
-        
+
         # --- Measure performance with different configurations ---
-        
+
         # Test with default parameters
         start_time = time.time()
         filter_results = helper_direct_filter_streams_flow(tn_block, records_df, max_depth=10, max_filter_size=5000)
         default_duration = time.time() - start_time
-        
+
         # Debug prints to understand the issue
         print("\nDEBUG: Filter results:")
         print(f"initialized_stream_ids: {initialized_stream_ids}")
@@ -406,47 +395,55 @@ class TestSplitAndInsertRecords:
         print(f"filter_results['initialized_streams']:\n{filter_results['initialized_streams']}")
         print(f"Number of initialized streams: {len(filter_results['initialized_streams'])}")
         print(f"Number of expected streams: {len(initialized_stream_ids)}")
-        
+
         # Check for duplicates in initialized_streams
-        if len(filter_results['initialized_streams']) > 0:
-            stream_id_counts = filter_results['initialized_streams']['stream_id'].value_counts()
+        if len(filter_results["initialized_streams"]) > 0:
+            stream_id_counts = filter_results["initialized_streams"]["stream_id"].value_counts()
             print(f"Stream ID counts: {stream_id_counts}")
             duplicates = stream_id_counts[stream_id_counts > 1]
             if not duplicates.empty:
                 print(f"Duplicate stream IDs found: {duplicates}")
                 # Print the full rows for duplicated stream IDs
                 for dup_id in duplicates.index:
-                    dup_rows = filter_results['initialized_streams'][filter_results['initialized_streams']['stream_id'] == dup_id]
+                    dup_rows = filter_results["initialized_streams"][
+                        filter_results["initialized_streams"]["stream_id"] == dup_id
+                    ]
                     print(f"Rows for duplicate stream ID {dup_id}:\n{dup_rows}")
-        
+
         # Verify correct number of streams in each category
         assert len(filter_results["initialized_streams"]) == len(initialized_stream_ids)
-        assert len(filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(non_existent_stream_ids)
-        
+        assert len(filter_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(
+            non_existent_stream_ids
+        )
+
         # Force divide and conquer with small max_filter_size
         start_time = time.time()
         small_batch_results = helper_direct_filter_streams_flow(tn_block, records_df, max_depth=10, max_filter_size=3)
         small_batch_duration = time.time() - start_time
-        
+
         # Results should be consistent regardless of batch size
         assert len(small_batch_results["initialized_streams"]) == len(initialized_stream_ids)
-        assert len(small_batch_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(non_existent_stream_ids)
-        
+        assert len(small_batch_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(
+            non_existent_stream_ids
+        )
+
         # Force fallback method with small max_depth
         start_time = time.time()
         fallback_results = helper_direct_filter_streams_flow(tn_block, records_df, max_depth=1, max_filter_size=5000)
         fallback_duration = time.time() - start_time
-        
+
         # Results should be consistent regardless of approach
         assert len(fallback_results["initialized_streams"]) == len(initialized_stream_ids)
-        assert len(fallback_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(non_existent_stream_ids)
-        
+        assert len(fallback_results["uninitialized_streams"]) == len(uninitialized_stream_ids) + len(
+            non_existent_stream_ids
+        )
+
         # Log performance results
         print(f"\nPerformance results for filter_initialized_streams with {len(all_stream_ids)} streams:")
         print(f"Default parameters: {default_duration:.4f} seconds")
         print(f"Small batch size: {small_batch_duration:.4f} seconds")
         print(f"Fallback method: {fallback_duration:.4f} seconds\n")
-        
+
         # Clean up uninitialized streams
         for stream_id in uninitialized_stream_ids:
             try:
@@ -457,22 +454,24 @@ class TestSplitAndInsertRecords:
     def test_filter_deployed_streams(self, tn_block: TNAccessBlock, test_stream_ids: list[str]):
         """Test that filter_deployed_streams correctly filters out non-deployed and uninitialized streams."""
         base_timestamp = int(datetime.now().timestamp())
-        
+
         # Create records for deployed, initialized, and non-existent streams
         deployed_records = []
         for stream_id in test_stream_ids:  # These are already deployed and initialized by the fixture
-            deployed_records.append({
-                "stream_id": stream_id,
-                "date": base_timestamp,
-                "value": 100.0,
-            })
-            
+            deployed_records.append(
+                {
+                    "stream_id": stream_id,
+                    "date": base_timestamp,
+                    "value": 100.0,
+                }
+            )
+
         # Create a stream that exists but isn't initialized
         uninitialized_stream_id = generate_stream_id("uninitialized_test_stream")
         client = tn_block.get_client()
         client.deploy_stream(uninitialized_stream_id, stream_type=truf_sdk.StreamTypePrimitiveUnix, wait=True)
         # Don't initialize it
-        
+
         # Create records for uninitialized and non-existent streams
         non_deployed_stream_id = generate_stream_id("non_deployed_test_stream")
         other_records = [
@@ -485,31 +484,31 @@ class TestSplitAndInsertRecords:
                 "stream_id": non_deployed_stream_id,
                 "date": base_timestamp,
                 "value": 300.0,
-            }
+            },
         ]
-        
+
         # Combine all records
         all_records = pd.DataFrame(deployed_records + other_records)
         all_records = DataFrame[TnDataRowModel](all_records)
-        
+
         # Test with filter_deployed_streams=True
         results = helper_filter_deployed_streams_flow(tn_block, all_records)
-        
+
         assert results is not None
         # Should have successfully processed only the deployed and initialized streams
         assert len(results["success_tx_hashes"]) > 0
         # No failed records since non-deployed/uninitialized streams were filtered out
         assert len(results["failed_records"]) == 0
-        
+
         # Verify only deployed and initialized streams were processed
         for stream_id in test_stream_ids:
             records = tn_block.read_records(stream_id, is_unix=True, date_from=base_timestamp)
             assert len(records) == 1
-            
+
         # Verify non-existent streams were not processed
         with pytest.raises(Exception):
             tn_block.read_records(non_deployed_stream_id, is_unix=True, date_from=base_timestamp)
-            
+
         # Clean up the uninitialized stream
         try:
             tn_block.destroy_stream(uninitialized_stream_id)
@@ -520,10 +519,10 @@ class TestSplitAndInsertRecords:
         """Test that filter_deployed_streams handles empty record sets correctly."""
         # Create an empty DataFrame with the correct schema
         empty_records = DataFrame[TnDataRowModel](pd.DataFrame(columns=["stream_id", "data_provider", "date", "value"]))
-        
+
         # Test with filter_deployed_streams=True
         results = helper_filter_deployed_streams_empty_flow(tn_block, empty_records)
-        
+
         assert results is not None
         assert len(results["success_tx_hashes"]) == 0
         assert len(results["failed_records"]) == 0
@@ -532,45 +531,44 @@ class TestSplitAndInsertRecords:
         """Test the streaming capability of the filter function with very large stream batches."""
         base_timestamp = int(datetime.now().timestamp())
         test_name = f"filter_stream_{base_timestamp}"
-        
+
         # Use a small number of real streams (from fixture) and a large number of non-existent streams
         # to create a realistic large-scale test without creating too many real streams
         initialized_stream_ids = test_stream_ids
-        
+
         # Create a large set of non-existent streams (these don't require actual deployment)
         num_streams = 50  # This would create a large batch without overwhelming the test
-        non_existent_stream_ids = [
-            generate_stream_id(f"{test_name}_nonexist_{i}")
-            for i in range(num_streams)
-        ]
-        
+        non_existent_stream_ids = [generate_stream_id(f"{test_name}_nonexist_{i}") for i in range(num_streams)]
+
         # Combine all stream IDs
         all_stream_ids = initialized_stream_ids + non_existent_stream_ids
-        
+
         # Create records for all streams
         all_records = []
         for i, stream_id in enumerate(all_stream_ids):
-            all_records.append({
-                "stream_id": stream_id,
-                "data_provider": tn_block.current_account,
-                "date": base_timestamp + i,
-                "value": float(i * 10),
-            })
-        
+            all_records.append(
+                {
+                    "stream_id": stream_id,
+                    "data_provider": tn_block.current_account,
+                    "date": base_timestamp + i,
+                    "value": float(i * 10),
+                }
+            )
+
         # Convert to DataFrame
         records_df = DataFrame[TnDataRowModel](pd.DataFrame(all_records))
-        
+
         # Test with various max_filter_size settings to see how it affects streaming behavior
         filter_sizes = [5, 10, 20, 50, len(all_stream_ids)]
-        
+
         print(f"\nStreaming performance results for {len(all_stream_ids)} streams:")
         for size in filter_sizes:
             start_time = time.time()
             results = helper_direct_filter_streams_flow(tn_block, records_df, max_depth=10, max_filter_size=size)
             duration = time.time() - start_time
-            
+
             # Verify results are correct
             assert len(results["initialized_streams"]) == len(initialized_stream_ids)
             assert len(results["uninitialized_streams"]) == len(non_existent_stream_ids)
-            
+
             print(f"  max_filter_size={size}: {duration:.4f} seconds")

--- a/tests/blocks/test_tn_access_integration.py
+++ b/tests/blocks/test_tn_access_integration.py
@@ -6,16 +6,17 @@ data insertion, and retrieval. They should only be run when TN access is availab
 and configured.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 from pandera.typing import DataFrame
 from prefect import flow, task
 import pytest
+import trufnetwork_sdk_c_bindings.exports as truf_sdk
 from trufnetwork_sdk_py.utils import generate_stream_id
 
 from tsn_adapters.blocks.tn_access import TNAccessBlock
-from tsn_adapters.common.trufnetwork.models.tn_models import TnRecordModel
+from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel, TnRecordModel
 
 
 @pytest.fixture
@@ -66,6 +67,57 @@ def insert_on_test_flow(block: TNAccessBlock, stream_id: str, records: DataFrame
     insert_records(block, stream_id, records)
 
 
+@pytest.fixture
+def unix_test_stream_id() -> str:
+    """Generate a unique test stream ID for Unix timestamp tests.
+
+    Uses a timestamp to ensure uniqueness across test runs.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    return generate_stream_id(f"unix_{timestamp}")
+
+
+@pytest.fixture
+def deployed_unix_test_stream_id(tn_block: TNAccessBlock, unix_test_stream_id: str, helper_contract_id: str):
+    """Deploys and initializes a test stream for Unix timestamps."""
+    client = tn_block.get_client()
+    client.deploy_stream(unix_test_stream_id, wait=True, stream_type=truf_sdk.StreamTypePrimitiveUnix)
+    client.init_stream(unix_test_stream_id, wait=True)
+    yield unix_test_stream_id
+    tn_block.destroy_stream(unix_test_stream_id)
+
+
+@task
+def insert_unix_records(tn_block: TNAccessBlock, stream_id: str, records: DataFrame[TnRecordModel]) -> None:
+    """Task to insert Unix timestamp records into a stream."""
+    # Convert string timestamps to integers
+    records_copy = records.copy()
+    records_copy["date"] = records_copy["date"].astype(int)
+
+    # Use batch_insert_tn_records with is_unix=True
+    tx_hash = tn_block.batch_insert_tn_records(
+        DataFrame[TnDataRowModel](
+            pd.DataFrame(
+                {
+                    "stream_id": stream_id,
+                    "data_provider": "",
+                    "date": records_copy["date"],
+                    "value": records_copy["value"],
+                }
+            )
+        ),
+        is_unix=True,
+    )
+    assert tx_hash is not None
+    tn_block.wait_for_tx(tx_hash)
+
+
+@flow
+def insert_unix_on_test_flow(block: TNAccessBlock, stream_id: str, records: DataFrame[TnRecordModel]) -> None:
+    """Flow to test Unix timestamp record insertion."""
+    insert_unix_records(block, stream_id, records)
+
+
 class TestTNAccessBlockIntegration:
     """Integration tests for TNAccessBlock requiring live TN connection."""
 
@@ -96,6 +148,69 @@ class TestTNAccessBlockIntegration:
         """Test get_first_record on an empty stream."""
         result = tn_block.get_first_record(deployed_test_stream_id)
         assert result is None
+
+    def test_get_earliest_date_success(
+        self, tn_block: TNAccessBlock, deployed_test_stream_id: str, unix_timestamp_records: DataFrame[TnRecordModel]
+    ):
+        """Test successful retrieval of earliest date after insertion."""
+        # Insert test records (using Prefect flow)
+        insert_on_test_flow(tn_block, deployed_test_stream_id, unix_timestamp_records)
+
+        # Get and verify earliest date
+        earliest_date = tn_block.get_earliest_date(deployed_test_stream_id)
+        assert earliest_date is not None
+        # The first timestamp in unix_timestamp_records is 1704067200 (2024-01-01 00:00:00 UTC)
+        expected_date = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        assert earliest_date == expected_date
+
+    def test_get_earliest_date_inexistent_stream(self, tn_block: TNAccessBlock):
+        """Test get_earliest_date with a well-formatted but non-existent stream ID."""
+        with pytest.raises(TNAccessBlock.StreamNotFoundError, match="Stream .* not found"):
+            tn_block.get_earliest_date(generate_stream_id("inexistent_stream"))
+
+    def test_get_earliest_date_empty_stream(self, tn_block: TNAccessBlock, deployed_test_stream_id: str):
+        """Test get_earliest_date on an empty stream."""
+        result = tn_block.get_earliest_date(deployed_test_stream_id)
+        assert result is None
+
+    @pytest.fixture
+    def unix_timestamp_records(self) -> DataFrame[TnRecordModel]:
+        """Create sample records with Unix timestamps for testing."""
+        # Unix timestamps for 2024-01-01, 2024-01-02, 2024-01-03
+        data = {
+            "date": ["1704067200", "1704153600", "1704240000"],  # Unix timestamps as strings
+            "value": ["100.0", "200.0", "300.0"],
+        }
+        return DataFrame[TnRecordModel](pd.DataFrame(data))
+
+    def test_get_earliest_date_with_unix_timestamps(
+        self,
+        tn_block: TNAccessBlock,
+        deployed_unix_test_stream_id: str,
+        unix_timestamp_records: DataFrame[TnRecordModel],
+    ):
+        """Test get_earliest_date with Unix timestamp dates."""
+        # Insert test records with Unix timestamps
+        insert_unix_on_test_flow(tn_block, deployed_unix_test_stream_id, unix_timestamp_records)
+
+        # Get and verify earliest date
+        earliest_date = tn_block.get_earliest_date(deployed_unix_test_stream_id, is_unix=True)
+        assert earliest_date is not None
+        # The first timestamp in unix_timestamp_records is 1704067200 (2024-01-01 00:00:00 UTC)
+        expected_date = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        assert earliest_date == expected_date
+
+    def test_get_earliest_date_with_iso_format(
+        self, tn_block: TNAccessBlock, deployed_test_stream_id: str, sample_records: DataFrame[TnRecordModel]
+    ):
+        """Test get_earliest_date with ISO format dates."""
+        # Insert test records with ISO format dates
+        insert_on_test_flow(tn_block, deployed_test_stream_id, sample_records)
+
+        # This should fail because get_earliest_date expects Unix timestamps
+        # The error will be caught and wrapped in TNAccessBlock.Error
+        with pytest.raises(TNAccessBlock.Error):
+            _ = tn_block.get_earliest_date(deployed_test_stream_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

- **TNAccessBlock Enhancements**:
  - Added `is_unix: bool = False` parameter to `get_earliest_date` method
  - Modified the method to handle both Unix timestamps and ISO format dates
  - Updated internal call to `get_first_record` to pass the new parameter

- **FMP Historical Flow Updates**:
  - Updated call to `get_earliest_date` to include `is_unix=True` parameter
  - Improved logging message for successful data fetching to include date range

- **Code Formatting and Cleanup**:
  - Reformatted code in test files for better readability
  - Reorganized imports in affected files

## Related Problem
- fix #149 

## How Has This Been Tested? 
already deployed, and tests were added