### PR TITLE
feat: Enhance deploy_streams_flow with `DeploymentStateBlock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A collection of prefect tasks and examples ingesting data into TSN"
 readme = "README.md"
 dependencies = [
-    "prefect-client==3.2.1",
+    "prefect-client==3.2.14",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@bdc4d187add38228b8051ef7faade0d19ee974be",
     "PyGithub",
@@ -25,6 +25,8 @@ argentina = [
     "prefect-aws>=0.5.3",
 ]
 dev = [
+    # we need this for the testing harness
+    "prefect==3.2.14",
     "pytest-timeout",
     "pytest-mock",
     "black",

--- a/src/tsn_adapters/flows/stream_deploy_flow.py
+++ b/src/tsn_adapters/flows/stream_deploy_flow.py
@@ -2,20 +2,29 @@
 Stream Deployment Flow
 
 This module contains a Prefect flow to deploy primitive streams from a generic
-primitive source descriptor. For each stream in the descriptor, the flow verifies
-if the stream exists (using the TN SDK's stream_exists function). If the stream
-does not exist, it creates a deployment transaction (with wait=False) under a tn-write
-concurrency limiter and then waits for confirmation using tn-read concurrency via TNAccessBlock.
+primitive source descriptor. For each stream in the descriptor, the flow:
+
+1. Filters out already deployed streams (using DeploymentStateBlock if provided)
+2. Checks if remaining streams exist using the TN SDK
+3. Deploys non-existent streams with proper transaction handling
+4. Tracks deployment results and updates deployment state
+
+The flow uses concurrency control via Prefect tasks and appropriate wait mechanisms
+for transaction confirmations.
 """
 
-import time
-from typing import Literal
+from datetime import datetime, timezone
+from typing import Dict, List, Literal, Optional, Set, cast
 
+import pandas as pd
 from pandera.typing import DataFrame
 from prefect import flow, get_run_logger, task
+from prefect.futures import PrefectFuture
 
 # Import the TN client types and the task to deploy a primitive stream.
 from typing_extensions import TypedDict
+
+from tsn_adapters.blocks.deployment_state import DeploymentStateBlock
 
 # Import the primitive source descriptor interface and data model
 from tsn_adapters.blocks.primitive_source_descriptor import (
@@ -24,49 +33,260 @@ from tsn_adapters.blocks.primitive_source_descriptor import (
 )
 
 # Import TNAccessBlock and task_wait_for_tx so that we can use its waiting functionality.
-from tsn_adapters.blocks.tn_access import TNAccessBlock, task_wait_for_tx
+from tsn_adapters.blocks.tn_access import TNAccessBlock, task_filter_batch_initialized_streams, task_wait_for_tx
+from ..common.trufnetwork.models.tn_models import StreamLocatorModel
 from tsn_adapters.common.trufnetwork.tn import task_deploy_primitive, task_init_stream
+
+# Configuration constants
+DEFAULT_RETRY_ATTEMPTS = 3
+DEFAULT_RETRY_DELAY_SECONDS = 5
+DEFAULT_BATCH_SIZE = 500
 
 
 class DeployStreamResult(TypedDict):
+    """Result of deploying or checking a single stream."""
+
     stream_id: str
     status: Literal["deployed", "skipped"]
+    # Could add in future:
+    # tx_deploy_hash: Optional[str]
+    # tx_init_hash: Optional[str]
+    # error: Optional[str]
 
-@task(tags=["tn", "tn-write"], retries=3, retry_delay_seconds=5)
-def check_and_deploy_stream(stream_id: str, tna_block: TNAccessBlock, is_unix: bool = False) -> DeployStreamResult:
+
+class DeployStreamResults(TypedDict):
+    """Aggregated results of a stream deployment operation."""
+
+    deployed_count: int
+    skipped_count: int
+
+
+@task(
+    name="Check, Deploy and Initialize Stream",
+    tags=["tn", "tn-write"],
+    retries=DEFAULT_RETRY_ATTEMPTS,
+    retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS,
+)
+def check_deploy_and_init_stream(stream_id: str, tna_block: TNAccessBlock, is_unix: bool = False) -> DeployStreamResult:
     """
-    Checks if a stream exists using the SDK's stream_exists function.
-    If the stream does not exist, deploys it using task_deploy_primitive.
-    Returns a message indicating the action taken.
+    Check if a stream exists and deploy/initialize it if it doesn't.
+
+    Args:
+        stream_id: ID of the stream to check and potentially deploy
+        tna_block: TNAccessBlock instance for TN interactions
+        is_unix: Whether to use Unix timestamps (default: False)
+
+    Returns:
+        A DeployStreamResult indicating whether the stream was deployed or skipped
     """
     logger = get_run_logger()
     tn_client = tna_block.client
     account = tn_client.get_current_account()
+
+    # Skip deployment if stream already exists
     if tna_block.stream_exists(account, stream_id):
-        message = f"Stream {stream_id} already exists. Skipping deployment."
-        logger.debug(message)
+        logger.debug(f"Stream {stream_id} already exists. Skipping deployment.")
         return DeployStreamResult(stream_id=stream_id, status="skipped")
-    else:
-        # Create the deployment transaction without waiting.
-        logger.debug(f"Deploying stream {stream_id}.")
-        tx_deploy = task_deploy_primitive(block=tna_block, stream_id=stream_id, wait=False, is_unix=is_unix)
-        # Wait for deployment confirmation using the TNAccessBlock (tn-read concurrency).
-        task_wait_for_tx(block=tna_block, tx_hash=tx_deploy)
-        logger.debug(f"Deployed stream {stream_id}.")
 
-        # Create the initialization transaction without waiting.
-        tx_init = task_init_stream(block=tna_block, stream_id=stream_id, wait=False)
-        logger.debug(f"Initialize stream {stream_id}.")
-        # Wait for initialization confirmation.
-        task_wait_for_tx(block=tna_block, tx_hash=tx_init)
-        logger.debug(f"Initialized stream {stream_id}.")
+    # Deploy the stream if it doesn't exist
+    logger.debug(f"Deploying stream {stream_id}.")
 
-        return DeployStreamResult(stream_id=stream_id, status="deployed")
+    # Step 1: Create deployment transaction and wait for confirmation
+    tx_deploy = task_deploy_primitive(block=tna_block, stream_id=stream_id, wait=False, is_unix=is_unix)
+    task_wait_for_tx(block=tna_block, tx_hash=tx_deploy)
+    logger.debug(f"Deployed stream {stream_id} (tx: {tx_deploy}).")
+
+    # Step 2: Initialize the stream and wait for confirmation
+    tx_init = task_init_stream(block=tna_block, stream_id=stream_id, wait=False)
+    task_wait_for_tx(block=tna_block, tx_hash=tx_init)
+    logger.debug(f"Initialized stream {stream_id} (tx: {tx_init}).")
+
+    return DeployStreamResult(stream_id=stream_id, status="deployed")
 
 
-class DeployStreamResults(TypedDict):
-    deployed_count: int
-    skipped_count: int
+@task(
+    name="Filter Already Deployed Streams",
+    retries=DEFAULT_RETRY_ATTEMPTS,
+    retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS,
+)
+def filter_deployed_streams_task(
+    descriptor_df: DataFrame[PrimitiveSourceDataModel], deployment_state: DeploymentStateBlock, tna_block: TNAccessBlock
+) -> DataFrame[PrimitiveSourceDataModel]:
+    """
+    Filter out already deployed streams using deployment state and TN verification.
+
+    A stream is considered already deployed if:
+    1. It is marked as deployed in the DeploymentStateBlock AND
+    2. It actually exists in TN (verified with TN client using batch filtering)
+
+    Args:
+        descriptor_df: DataFrame containing streams to filter
+        deployment_state: Block for tracking deployment state
+        tna_block: Block for TN access to verify stream existence
+
+    Returns:
+        Filtered DataFrame containing only streams that need deployment
+    """
+    logger = get_run_logger()
+
+    # Get all stream IDs from the descriptor
+    all_stream_ids: List[str] = [str(sid) for sid in descriptor_df["stream_id"]]
+
+    if not all_stream_ids:
+        logger.info("No streams to filter, returning empty DataFrame.")
+        return descriptor_df
+
+    # Step 1: Check deployment status in deployment state
+    try:
+        deployed_in_state: Dict[str, bool] = deployment_state.check_multiple_streams(all_stream_ids)
+    except Exception as e:
+        logger.warning(f"Failed to check deployment status: {e!s}. Assuming no streams are deployed.", exc_info=True)
+        # If deployment status check fails, assume nothing is deployed
+        deployed_in_state = {stream_id: False for stream_id in all_stream_ids}
+
+    # Step 2: For streams marked as deployed, verify their existence on the network using batch filtering
+    streams_to_verify = [stream_id for stream_id in all_stream_ids if deployed_in_state.get(stream_id, False)]
+
+    # Track streams that are verified to exist on the network
+    streams_verified_on_network: Set[str] = set()
+
+    if streams_to_verify:
+        logger.debug(f"Verifying existence of {len(streams_to_verify)} streams marked as deployed using batch task...")
+        try:
+            account = tna_block.client.get_current_account()
+            # Create DataFrame for batch verification task
+            locators_to_verify_df = DataFrame[StreamLocatorModel](
+                pd.DataFrame({"stream_id": streams_to_verify, "data_provider": account})
+            )
+
+            # Submit the batch verification task
+            filter_future = task_filter_batch_initialized_streams.submit(
+                block=tna_block, stream_locators=locators_to_verify_df
+            )
+            verified_locators_df = filter_future.result()
+
+            # Update the set of verified streams
+            streams_verified_on_network = set(verified_locators_df["stream_id"].tolist())
+            logger.debug(f"Batch verification complete: {len(streams_verified_on_network)} streams confirmed to exist on the network.")
+
+        except Exception as e:
+            # If batch verification fails, log a warning and assume none of the streams_to_verify exist on the network
+            # This ensures we attempt to deploy them rather than incorrectly skipping them.
+            logger.warning(
+                f"Batch verification of stream existence failed: {e!s}. "
+                f"Proceeding assuming streams marked deployed might not exist.",
+                exc_info=True,
+            )
+            streams_verified_on_network = set()
+
+    # Keep streams that need deployment
+    # (Not marked as deployed or not verified on network)
+    streams_to_deploy = [stream_id for stream_id in all_stream_ids if stream_id not in streams_verified_on_network]
+
+    # Filter the DataFrame to keep only streams that need deployment
+    filtered_df = descriptor_df[descriptor_df["stream_id"].isin(streams_to_deploy)]
+
+    # Log summary
+    filtered_count = len(all_stream_ids) - len(filtered_df)
+    logger.info(
+        f"Filtered {filtered_count} streams that are already deployed. "
+        f"{len(filtered_df)} streams remain for processing."
+    )
+
+    # Return filtered DataFrame with proper type
+    return cast(DataFrame[PrimitiveSourceDataModel], filtered_df)
+
+
+@task(name="Mark Batch as Deployed", retries=DEFAULT_RETRY_ATTEMPTS, retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS)
+def mark_batch_deployed_task(
+    stream_ids: List[str], deployment_state: DeploymentStateBlock, timestamp: datetime
+) -> None:
+    """
+    Mark a batch of streams as deployed in the deployment state.
+
+    Args:
+        stream_ids: List of stream IDs that were successfully deployed
+        deployment_state: Block for tracking deployment state
+        timestamp: UTC timestamp to use for all streams in this batch
+    """
+    logger = get_run_logger()
+
+    # Skip if no streams to mark
+    if not stream_ids:
+        logger.debug("No streams to mark as deployed.")
+        return
+
+    # Ensure timestamp is UTC
+    if timestamp.tzinfo is None or timestamp.tzinfo.utcoffset(timestamp) is None:
+        logger.warning("Received timestamp without timezone for marking deployment. Assuming UTC.")
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    elif timestamp.tzinfo != timezone.utc:
+        timestamp = timestamp.astimezone(timezone.utc)
+
+    # Mark streams as deployed with the provided timestamp
+    try:
+        deployment_state.mark_multiple_as_deployed(stream_ids, timestamp)
+        logger.debug(f"Marked {len(stream_ids)} streams as deployed at {timestamp.isoformat()}.")
+    except Exception as e:
+        logger.warning(f"Failed to mark streams as deployed: {e!s}. Continuing with flow execution.", exc_info=True)
+
+
+def _create_stream_batches(stream_ids: List[str], batch_size: int, start_from_batch: int) -> List[List[str]]:
+    """
+    Split a list of stream IDs into batches of specified size.
+
+    Args:
+        stream_ids: List of stream IDs to batch
+        batch_size: Maximum number of streams per batch
+        start_from_batch: Index of the first batch to process
+
+    Returns:
+        List of batches, where each batch is a list of stream IDs
+    """
+    # Create batches of specified size
+    all_batches = [stream_ids[i : i + batch_size] for i in range(0, len(stream_ids), batch_size)]
+
+    # Return only batches starting from the specified index
+    return all_batches[start_from_batch:]
+
+
+def _process_deployment_results(
+    deployment_results: List[DeployStreamResult],
+    deployment_state: Optional[DeploymentStateBlock] = None,
+    batch_timestamp: Optional[datetime] = None,
+) -> None:
+    """
+    Process deployment results and update deployment state if provided.
+
+    Args:
+        deployment_results: List of individual stream deployment results
+        deployment_state: Optional block for tracking deployment state
+        batch_timestamp: Timestamp to use for this batch (required if deployment_state is provided)
+    """
+    logger = get_run_logger()
+
+    # Skip if no deployment state provided
+    if deployment_state is None:
+        return
+
+    # We need a timestamp to mark streams as deployed
+    if batch_timestamp is None:
+        batch_timestamp = datetime.now(timezone.utc)
+
+    # Collect successfully deployed stream IDs
+    deployed_stream_ids = [result["stream_id"] for result in deployment_results if result["status"] == "deployed"]
+
+    # Skip if no streams were deployed
+    if not deployed_stream_ids:
+        return
+
+    # Mark batch as deployed in deployment state
+    try:
+        mark_batch_deployed_task.submit(
+            stream_ids=deployed_stream_ids, deployment_state=deployment_state, timestamp=batch_timestamp
+        )
+    except Exception as e:
+        logger.warning(f"Failed to submit marking task: {e!s}. Continuing with next batch.")
 
 
 @flow(name="Stream Deployment Flow")
@@ -74,60 +294,143 @@ def deploy_streams_flow(
     psd_block: PrimitiveSourcesDescriptorBlock,
     tna_block: TNAccessBlock,
     is_unix: bool = False,
-    batch_size: int = 500,
+    batch_size: int = DEFAULT_BATCH_SIZE,
     start_from_batch: int = 0,
+    deployment_state: Optional[DeploymentStateBlock] = None,
 ) -> DeployStreamResults:
     """
-    Deploys primitive streams defined in the provided primitive source descriptor.
+    Deploy primitive streams from a descriptor, with optional deployment state tracking.
 
-    For each stream descriptor:
-      - Verifies if the stream exists.
-      - If not, creates deployment and initialization transactions (without waiting)
-        and then waits for confirmation using tn-read concurrency.
+    This flow handles the entire stream deployment process:
+    1. Retrieves stream descriptors from the provided block
+    2. Filters out already deployed streams (if deployment_state is provided)
+    3. Deploys streams in batches with concurrency control
+    4. Updates deployment state for successfully deployed streams
+    5. Returns summary statistics of deployed and skipped streams
 
     Args:
-        psd_block: A PrimitiveSourcesDescriptorBlock providing the stream descriptors.
-        tn_client: A TNClient instance for deployment interactions.
-        tna_block: A TNAccessBlock instance used to wait for transaction confirmation.
-        batch_size: The number of streams to deploy in each batch. Defaults to 500.
-        start_from_batch: The batch number to start from. Defaults to 0.
+        psd_block: Block providing the stream descriptors
+        tna_block: Block for TN interactions
+        is_unix: Whether to use Unix timestamps (default: False)
+        batch_size: Number of streams to deploy in each batch (default: 500)
+        start_from_batch: Batch number to start from (default: 0)
+        deployment_state: Optional block for tracking deployment state
 
     Returns:
-        A list of messages indicating whether each stream was deployed or skipped.
+        Statistics on deployed and skipped streams
     """
     logger = get_run_logger()
-    logger.info("Starting stream deployment flow.")
+    logger.info(f"Starting stream deployment flow. Batch size: {batch_size}, Start batch: {start_from_batch}.")
 
-    # Retrieve the descriptor DataFrame.
-    descriptor_df: DataFrame[PrimitiveSourceDataModel] = psd_block.get_descriptor()
+    # SECTION 1: Retrieve and validate descriptor DataFrame
+    try:
+        descriptor_df: DataFrame[PrimitiveSourceDataModel] = psd_block.get_descriptor()
+    except Exception as e:
+        logger.error(f"Failed to retrieve stream descriptors: {e!s}", exc_info=True)
+        raise  # Cannot proceed without descriptors
+
     if descriptor_df.empty:
         logger.info("No stream descriptors found. Exiting flow.")
         return DeployStreamResults(deployed_count=0, skipped_count=0)
 
-    # Extract stream_ids from the descriptor.
-    stream_ids = descriptor_df["stream_id"].tolist()
-    logger.info(f"Found {len(stream_ids)} stream descriptors.")
+    # Track original stream count for calculating filtered count
+    original_stream_count = len(descriptor_df)
+    logger.info(f"Retrieved {original_stream_count} stream descriptors.")
+    filtered_by_state_count = 0
 
-    # we will deploy in batches of 500 to avoid infinite threads creation
-    batches = [stream_ids[i:i+batch_size] for i in range(0, len(stream_ids), batch_size)]
+    # SECTION 2: Filter already deployed streams if deployment state is provided
+    if deployment_state is not None:
+        logger.info("Deployment state block provided. Filtering already deployed streams...")
+        try:
+            filter_future = filter_deployed_streams_task.submit(
+                descriptor_df=descriptor_df, deployment_state=deployment_state, tna_block=tna_block
+            )
+            descriptor_df = filter_future.result()  # Wait for filtering to complete
+            # Calculate how many streams were filtered out
+            filtered_by_state_count = original_stream_count - len(descriptor_df)
+        except Exception as e:
+            logger.error(f"Failed during stream filtering: {e!s}. Aborting flow.", exc_info=True)
+            raise  # Stop flow if filtering fails
 
-    aggregated_results: list[DeployStreamResult] = []
-    for batch in batches[start_from_batch:]:
-        # for each batch, we will completely deploy -> iniialize and wait for each confirmation
-        futures = []
-        # Map over the stream IDs using the check/deploy task.
+        # Exit early if all streams are already deployed
+        if descriptor_df.empty:
+            logger.info("All streams are already deployed. Exiting flow.")
+            return DeployStreamResults(deployed_count=0, skipped_count=original_stream_count)
+    else:
+        logger.info("No deployment state block provided. Processing all streams from descriptor.")
+
+    # SECTION 3: Prepare for batch processing
+    # Extract stream IDs from filtered descriptor and ensure proper typing
+    stream_ids: List[str] = [str(sid) for sid in descriptor_df["stream_id"]]
+
+    logger.info(f"Found {len(stream_ids)} stream descriptors to process.")
+
+    # Create batches for processing
+    batches = _create_stream_batches(stream_ids, batch_size, start_from_batch)
+    total_batches = len(batches)
+
+    # Check if start_from_batch is out of range
+    if start_from_batch >= total_batches and total_batches > 0:
+        logger.warning(
+            f"Start batch {start_from_batch} is out of range (total batches: {total_batches}). "
+            f"No batches will be processed."
+        )
+        return DeployStreamResults(deployed_count=0, skipped_count=filtered_by_state_count)
+    elif start_from_batch > 0:
+        logger.info(f"Starting processing from batch {start_from_batch+1}/{total_batches}.")
+
+    # SECTION 4: Process batches
+    all_deployment_results: List[DeployStreamResult] = []
+
+    for batch_index, batch in enumerate(batches, start=start_from_batch):
+        # Log batch progress
+        logger.info(f"Processing batch {batch_index + 1}/{total_batches} with {len(batch)} streams.")
+
+        # Process each stream in the batch
+        batch_futures: Dict[str, PrefectFuture[DeployStreamResult]] = {}
         for stream_id in batch:
-            futures.append(check_and_deploy_stream.submit(stream_id=stream_id, tna_block=tna_block, is_unix=is_unix))
+            # Submit the task with the new name
+            future = check_deploy_and_init_stream.submit(stream_id=stream_id, tna_block=tna_block, is_unix=is_unix)
+            batch_futures[stream_id] = future
 
-        # Wait for all futures to complete
-        results: list[DeployStreamResult] = []
-        for future in futures:
-            results.append(future.result())
-        aggregated_results.extend(results)
+        # Collect batch results
+        batch_results: List[DeployStreamResult] = []
+        for stream_id, future in batch_futures.items():
+            try:
+                result = future.result()
+                batch_results.append(result)
+            except Exception as e:
+                logger.error(f"Task failed for stream {stream_id} even after retries: {e!s}", exc_info=True)
+                # Continue with other streams even if one fails
 
-    # aggregate results to print
-    deployed = [result for result in aggregated_results if result["status"] == "deployed"]
-    skipped = [result for result in aggregated_results if result["status"] == "skipped"]
-    summary_results = DeployStreamResults(deployed_count=len(deployed), skipped_count=len(skipped))
-    logger.info(summary_results)
+        # Add to overall results
+        all_deployment_results.extend(batch_results)
+
+        # Update deployment state if provided
+        if deployment_state is not None:
+            batch_timestamp = datetime.now(timezone.utc)
+            _process_deployment_results(batch_results, deployment_state, batch_timestamp)
+
+        logger.info(f"Finished processing batch {batch_index + 1}/{total_batches}.")
+
+    # SECTION 5: Aggregate and summarize results
+    deployed_results = [result for result in all_deployment_results if result["status"] == "deployed"]
+    skipped_during_deploy = [result for result in all_deployment_results if result["status"] == "skipped"]
+
+    # Calculate summary statistics
+    deployed_count = len(deployed_results)
+    skipped_during_processing = len(skipped_during_deploy)
+    total_skipped_count = skipped_during_processing + filtered_by_state_count
+
+    # Prepare final results
+    summary_results = DeployStreamResults(deployed_count=deployed_count, skipped_count=total_skipped_count)
+
+    # Log summary
+    logger.info(
+        f"Deployment summary: {summary_results['deployed_count']} deployed, "
+        f"{summary_results['skipped_count']} skipped "
+        f"({filtered_by_state_count} filtered by deployment state, "
+        f"{skipped_during_processing} skipped during processing)."
+    )
+
     return summary_results

--- a/tests/fixtures/test_trufnetwork.py
+++ b/tests/fixtures/test_trufnetwork.py
@@ -440,7 +440,7 @@ def disable_prefect_retries():
         'tsn_adapters.flows.fmp.historical_flow.fetch_historical_data',
         'tsn_adapters.flows.fmp.historical_flow.get_earliest_data_date',
         # Stream Deploy Flow
-        'tsn_adapters.flows.stream_deploy_flow.check_and_deploy_stream',
+        'tsn_adapters.flows.stream_deploy_flow.check_deploy_and_init_stream',
         # Primitive Source Descriptor
         'tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_url',
         'tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_github',

--- a/tests/flows/test_stream_deploy_flow.py
+++ b/tests/flows/test_stream_deploy_flow.py
@@ -1,23 +1,33 @@
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Any, Optional
+from unittest.mock import MagicMock
 
 import pandas as pd
 from pandera.typing import DataFrame
+from prefect.futures import PrefectFuture
 from pydantic import ConfigDict, SecretStr
 import pytest
-from pytest import FixtureRequest
-import trufnetwork_sdk_c_bindings.exports as truf_sdk
-import trufnetwork_sdk_py.client as tn_client
+from pytest import FixtureRequest, MonkeyPatch
+import trufnetwork_sdk_c_bindings.exports as truf_sdk  # type: ignore
+import trufnetwork_sdk_py.client as tn_client  # type: ignore
 
+from tsn_adapters.blocks.deployment_state import DeploymentStateBlock, DeploymentStateModel
 from tsn_adapters.blocks.primitive_source_descriptor import (
     PrimitiveSourceDataModel,
     PrimitiveSourcesDescriptorBlock,
 )
+from tsn_adapters.blocks.shared_types import StreamLocatorModel
 from tsn_adapters.blocks.tn_access import TNAccessBlock
-from tsn_adapters.flows.stream_deploy_flow import deploy_streams_flow
+from tsn_adapters.flows.stream_deploy_flow import (
+    deploy_streams_flow,
+    filter_deployed_streams_task,
+    mark_batch_deployed_task,
+)
 
 
 class TestPrimitiveSourcesDescriptor(PrimitiveSourcesDescriptorBlock):
     """Test implementation of PrimitiveSourcesDescriptorBlock that can generate a configurable number of streams."""
+
     model_config = ConfigDict(ignored_types=(object,))
     num_streams: int = 3
 
@@ -32,6 +42,7 @@ class TestPrimitiveSourcesDescriptor(PrimitiveSourcesDescriptorBlock):
 
 class TestTNClient(tn_client.TNClient):
     """Test implementation of TNClient that tracks deployed streams and can be initialized with existing streams."""
+
     def __init__(self, existing_streams: set[str] | None = None):
         # We don't call super().__init__ to avoid real client initialization
         if existing_streams is None:
@@ -65,18 +76,78 @@ class TestTNClient(tn_client.TNClient):
 
 
 class TestTNAccessBlock(TNAccessBlock):
-    """Test implementation of TNAccessBlock that uses our TestTNClient."""
-    _test_client: TestTNClient
-    model_config = ConfigDict(ignored_types=(object,))
+    """Test implementation of TNAccessBlock for testing."""
 
     def __init__(self, existing_streams: set[str] | None = None):
-        super().__init__(tn_provider="", tn_private_key=SecretStr(""))
+        super().__init__(
+            tn_provider="", tn_private_key=SecretStr(""), helper_contract_name="", helper_contract_deployer=None
+        )
+        self._test_client = TestTNClient(existing_streams=existing_streams)
+
+    def set_existing_streams(self, existing_streams: set[str]) -> None:
+        """Set the streams that exist in TN for testing."""
         self._test_client = TestTNClient(existing_streams=existing_streams)
 
     @property
     def client(self) -> tn_client.TNClient:
         """Override client property to return our test client instead of creating a real one."""
         return self._test_client
+
+
+class TestDeploymentStateBlock(DeploymentStateBlock):
+    """Test implementation of DeploymentStateBlock for testing."""
+
+    model_config = ConfigDict(ignored_types=(object,), extra="allow")
+
+    def __init__(self, predeployed_streams: set[str] | None = None):
+        super().__init__()
+        # Store which streams have been marked as deployed
+        self._deployed_streams: dict[str, bool] = (
+            {} if predeployed_streams is None else {s: True for s in predeployed_streams}
+        )
+        self._marked_streams: list[tuple[list[str], datetime]] = []
+
+    def has_been_deployed(self, stream_id: str) -> bool:
+        """Check if a stream has been marked as deployed."""
+        return self._deployed_streams.get(stream_id, False)
+
+    def check_multiple_streams(self, stream_ids: list[str]) -> dict[str, bool]:
+        """Check deployment status for multiple streams."""
+        return {stream_id: self._deployed_streams.get(stream_id, False) for stream_id in stream_ids}
+
+    def mark_as_deployed(self, stream_id: str, timestamp: datetime) -> None:
+        """Mark a stream as deployed."""
+        self._deployed_streams[stream_id] = True
+        self._marked_streams.append(([stream_id], timestamp))
+
+    def mark_multiple_as_deployed(self, stream_ids: list[str], timestamp: datetime) -> None:
+        """Mark multiple streams as deployed with a single timestamp."""
+        for stream_id in stream_ids:
+            self._deployed_streams[stream_id] = True
+        self._marked_streams.append((stream_ids, timestamp))
+
+    def get_deployment_states(self) -> DataFrame[DeploymentStateModel]:
+        """Not implemented for testing."""
+        raise NotImplementedError("This method is not implemented for testing")
+
+    def update_deployment_states(self, states: DataFrame[DeploymentStateModel]) -> None:
+        """Not implemented for testing."""
+        raise NotImplementedError("This method is not implemented for testing")
+
+    @property
+    def deployed_streams(self) -> dict[str, bool]:
+        """Get the dictionary of deployed streams."""
+        return self._deployed_streams
+
+    @deployed_streams.setter
+    def deployed_streams(self, value: dict[str, bool]) -> None:
+        """Set the dictionary of deployed streams."""
+        self._deployed_streams = value
+
+    @property
+    def marked_streams(self) -> list[tuple[list[str], datetime]]:
+        """Get the list of marked streams."""
+        return self._marked_streams
 
 
 @pytest.fixture
@@ -92,16 +163,19 @@ def primitive_descriptor(request: FixtureRequest) -> TestPrimitiveSourcesDescrip
     return TestPrimitiveSourcesDescriptor(num_streams=num_streams)
 
 
+@pytest.fixture
+def deployment_state_block(request: FixtureRequest) -> TestDeploymentStateBlock:
+    """Fixture that provides a TestDeploymentStateBlock with configurable predeployed streams."""
+    predeployed_streams: set[str] = getattr(request, "param", set[str]())  # Default to no predeployed streams
+    return TestDeploymentStateBlock(predeployed_streams=predeployed_streams)
+
+
 @pytest.mark.usefixtures("prefect_test_fixture")
 def test_deploy_streams_flow_all_new(
-    tn_access_block: TestTNAccessBlock,
-    primitive_descriptor: TestPrimitiveSourcesDescriptor
+    tn_access_block: TestTNAccessBlock, primitive_descriptor: TestPrimitiveSourcesDescriptor
 ) -> None:
     """Test that all streams are deployed when none exist."""
-    results = deploy_streams_flow(
-        psd_block=primitive_descriptor,
-        tna_block=tn_access_block
-    )
+    results = deploy_streams_flow(psd_block=primitive_descriptor, tna_block=tn_access_block)
 
     # All three streams should be deployed
     assert results["deployed_count"] == 3
@@ -119,14 +193,11 @@ def test_deploy_streams_flow_with_existing() -> None:
     # Create TNAccessBlock with some existing streams
     existing_streams = {"stream_0", "stream_2"}  # First and last streams exist
     tn_access_block = TestTNAccessBlock(existing_streams=existing_streams)
-    
+
     # Create descriptor with 3 streams
     primitive_descriptor = TestPrimitiveSourcesDescriptor(num_streams=3)
 
-    results = deploy_streams_flow(
-        psd_block=primitive_descriptor,
-        tna_block=tn_access_block
-    )
+    results = deploy_streams_flow(psd_block=primitive_descriptor, tna_block=tn_access_block)
 
     # Only stream_1 should be deployed, others should be skipped
     assert results["deployed_count"] == 1
@@ -136,6 +207,272 @@ def test_deploy_streams_flow_with_existing() -> None:
     client = tn_access_block.client
     assert isinstance(client, TestTNClient)  # Type check for mypy
     assert client.deployed_streams == ["stream_1"]  # Changed from len check to exact match
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_deploy_streams_flow_with_deployment_state(
+    tn_access_block: TestTNAccessBlock,
+    primitive_descriptor: TestPrimitiveSourcesDescriptor,
+    deployment_state_block: TestDeploymentStateBlock,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Test that the flow uses deployment state to filter and mark streams."""
+    # Pre-mark stream_0 as deployed
+    deployment_state_block.deployed_streams = {"stream_0": True}
+
+    # Configure TN to have stream_0 exist (so it will be filtered out)
+    tn_access_block.set_existing_streams({"stream_0"})
+
+    # --- Mock the batch filter task ---
+    mock_filter_submit = MagicMock(return_value=create_mock_filter_future(existing_stream_ids=["stream_0"]))
+    monkeypatch.setattr(
+        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_filter_submit
+    )
+    # --- End Mock ---
+
+    # --- Mock the batch mark task submission to run synchronously ---
+    def mock_mark_submit(*args: Any, **kwargs: Any) -> PrefectFuture[None]:
+        # Directly call the marking logic on the provided state block
+        stream_ids = kwargs.get("stream_ids", [])
+        state_block = kwargs.get("deployment_state")
+        timestamp = kwargs.get("timestamp")
+        if state_block and stream_ids and timestamp:
+            # Simulate the task's core logic
+            if timestamp.tzinfo is None or timestamp.tzinfo.utcoffset(timestamp) is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
+            elif timestamp.tzinfo != timezone.utc:
+                timestamp = timestamp.astimezone(timezone.utc)
+            state_block.mark_multiple_as_deployed(stream_ids, timestamp)
+        # Return a dummy future-like object if needed, though not strictly necessary here
+        mock_future = MagicMock(spec=PrefectFuture)
+        mock_future.result.return_value = None
+        return mock_future
+
+    monkeypatch.setattr("tsn_adapters.flows.stream_deploy_flow.mark_batch_deployed_task.submit", mock_mark_submit)
+    # --- End Mock ---
+
+    # Run flow with deployment state
+    results = deploy_streams_flow(
+        psd_block=primitive_descriptor, tna_block=tn_access_block, deployment_state=deployment_state_block
+    )
+
+    # Only streams 1 and 2 should be deployed, stream_0 should be skipped due to deployment state
+    assert results["deployed_count"] == 2
+    assert results["skipped_count"] == 1
+
+    # Verify that only streams 1 and 2 were deployed
+    client = tn_access_block.client
+    assert isinstance(client, TestTNClient)  # Type check for mypy
+    assert set(client.deployed_streams) == {"stream_1", "stream_2"}
+
+    # Verify that streams 1 and 2 were marked as deployed in the deployment state
+    for stream_id in ["stream_1", "stream_2"]:
+        assert deployment_state_block.deployed_streams.get(
+            stream_id, False
+        ), f"Stream {stream_id} was not marked deployed"
+
+    # Verify that the mark_multiple_as_deployed method was called
+    assert len(deployment_state_block.marked_streams) > 0
+    # The first element is the list of stream IDs, check that it contains the expected streams
+    stream_ids_list = deployment_state_block.marked_streams[0][0]
+    assert set(stream_ids_list) == {"stream_1", "stream_2"}
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_deploy_streams_flow_all_deployed_in_state(
+    tn_access_block: TestTNAccessBlock, primitive_descriptor: TestPrimitiveSourcesDescriptor, monkeypatch: MonkeyPatch
+) -> None:
+    """Test that if all streams are already deployed in the state, none are deployed."""
+    # Create a deployment state with all streams already deployed
+    deployment_state_block = TestDeploymentStateBlock(predeployed_streams={"stream_0", "stream_1", "stream_2"})
+
+    # Configure TN to have all streams exist (so they will all be filtered out)
+    tn_access_block.set_existing_streams({"stream_0", "stream_1", "stream_2"})
+
+    # --- Mock the batch filter task ---
+    mock_filter_submit = MagicMock(
+        return_value=create_mock_filter_future(existing_stream_ids=["stream_0", "stream_1", "stream_2"])
+    )
+    monkeypatch.setattr(
+        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_filter_submit
+    )
+    # --- End Mock ---
+
+    # --- Mock the batch mark task submission (shouldn't be called, but good practice) ---
+    mock_mark_submit = MagicMock()
+    monkeypatch.setattr("tsn_adapters.flows.stream_deploy_flow.mark_batch_deployed_task.submit", mock_mark_submit)
+    # --- End Mock ---
+
+    # Run flow with deployment state
+    results = deploy_streams_flow(
+        psd_block=primitive_descriptor, tna_block=tn_access_block, deployment_state=deployment_state_block
+    )
+
+    # All streams should be skipped due to deployment state
+    assert results["deployed_count"] == 0
+    assert results["skipped_count"] == 3
+
+    # Verify that no streams were deployed
+    client = tn_access_block.client
+    assert isinstance(client, TestTNClient)  # Type check for mypy
+    assert len(client.deployed_streams) == 0
+
+    # Verify that no streams were marked as deployed in the deployment state
+    assert len(deployment_state_block.marked_streams) == 0
+    mock_mark_submit.assert_not_called()  # Verify the mock submit wasn't called
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_deploy_streams_flow_backward_compatibility(
+    tn_access_block: TestTNAccessBlock, primitive_descriptor: TestPrimitiveSourcesDescriptor
+) -> None:
+    """Test that the flow still works without a deployment state (backward compatibility)."""
+    # Run flow without deployment state
+    results = deploy_streams_flow(psd_block=primitive_descriptor, tna_block=tn_access_block)
+
+    # All three streams should be deployed
+    assert results["deployed_count"] == 3
+    assert results["skipped_count"] == 0
+
+    # Verify the actual streams that were deployed
+    client = tn_access_block.client
+    assert isinstance(client, TestTNClient)  # Type check for mypy
+    assert set(client.deployed_streams) == {"stream_0", "stream_1", "stream_2"}
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_filter_deployed_streams_task(
+    primitive_descriptor: TestPrimitiveSourcesDescriptor, tn_access_block: TestTNAccessBlock, monkeypatch: MonkeyPatch
+) -> None:
+    """Test that filter_deployed_streams_task correctly filters streams."""
+    # Create a deployment state with stream_0 already deployed
+    deployment_state = TestDeploymentStateBlock(predeployed_streams={"stream_0"})
+
+    # Verify deployment state has stream_0 marked as deployed
+    assert deployment_state.has_been_deployed("stream_0")
+    assert deployment_state.check_multiple_streams(["stream_0"])["stream_0"]
+
+    # Get descriptor DataFrame
+    descriptor_df = primitive_descriptor.get_descriptor()
+
+    # Configure TN to have stream_0 exist (important for verification)
+    tn_access_block.set_existing_streams({"stream_0"})
+
+    # --- Mock the batch filter task ---
+    # It will be called with stream_0, and since it exists, it should return stream_0
+    mock_submit = MagicMock(return_value=create_mock_filter_future(existing_stream_ids=["stream_0"]))
+    monkeypatch.setattr(
+        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_submit
+    )
+    # --- End Mock ---
+
+    # Apply filter
+    filtered_df = filter_deployed_streams_task(
+        descriptor_df=descriptor_df, deployment_state=deployment_state, tna_block=tn_access_block
+    )
+
+    # Check that stream_0 is filtered out
+    filtered_stream_ids: list[str] = filtered_df["stream_id"].tolist()
+    assert "stream_0" not in filtered_stream_ids
+    assert "stream_1" in filtered_stream_ids
+    assert "stream_2" in filtered_stream_ids
+    assert len(filtered_df) == 2
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_filter_deployed_streams_task_with_tn_verification(
+    primitive_descriptor: TestPrimitiveSourcesDescriptor, monkeypatch: MonkeyPatch
+) -> None:
+    """Test that filter_deployed_streams_task verifies deployment with TN."""
+    # Create a deployment state with all streams already deployed
+    deployment_state = TestDeploymentStateBlock(predeployed_streams={"stream_0", "stream_1", "stream_2"})
+
+    # Verify all streams are marked as deployed in the deployment state
+    for stream_id in ["stream_0", "stream_1", "stream_2"]:
+        assert deployment_state.has_been_deployed(stream_id)
+
+    # Create TN access block with only stream_0 existing in TN
+    tn_access_block = TestTNAccessBlock(existing_streams={"stream_0"})
+
+    # Get descriptor DataFrame
+    descriptor_df = primitive_descriptor.get_descriptor()
+
+    # --- Mock the batch filter task ---
+    # It will be called with stream_0, stream_1, stream_2.
+    # Since only stream_0 exists in TN, it should return only stream_0.
+    mock_submit = MagicMock(return_value=create_mock_filter_future(existing_stream_ids=["stream_0"]))
+    monkeypatch.setattr(
+        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_submit
+    )
+    # --- End Mock ---
+
+    # Apply filter
+    filtered_df = filter_deployed_streams_task(
+        descriptor_df=descriptor_df, deployment_state=deployment_state, tna_block=tn_access_block
+    )
+
+    # Check that only stream_0 is filtered out (marked as deployed AND exists in TN)
+    # stream_1 and stream_2 should still be in the filtered_df because they're marked as
+    # deployed but don't exist in TN (as simulated by the mock)
+    filtered_stream_ids: list[str] = filtered_df["stream_id"].tolist()
+    assert "stream_0" not in filtered_stream_ids
+    assert "stream_1" in filtered_stream_ids
+    assert "stream_2" in filtered_stream_ids
+    assert len(filtered_df) == 2
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_mark_batch_deployed_task() -> None:
+    """Test that mark_batch_deployed_task correctly marks streams as deployed."""
+    # Create a deployment state
+    deployment_state = TestDeploymentStateBlock()
+
+    # Create a timestamp (ensure it's UTC)
+    timestamp = datetime.now(timezone.utc)
+
+    # Mark streams as deployed
+    mark_batch_deployed_task(
+        stream_ids=["stream_1", "stream_2"], deployment_state=deployment_state, timestamp=timestamp
+    )
+
+    # Verify that the streams were marked as deployed
+    assert deployment_state.deployed_streams.get("stream_1", False)
+    assert deployment_state.deployed_streams.get("stream_2", False)
+
+    # Verify that mark_multiple_as_deployed was called with the correct arguments
+    assert len(deployment_state.marked_streams) == 1
+    marked_stream_ids, marked_timestamp = deployment_state.marked_streams[0]
+    assert set(marked_stream_ids) == {"stream_1", "stream_2"}
+    assert marked_timestamp == timestamp
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_mark_batch_deployed_task_empty_list() -> None:
+    """Test that mark_batch_deployed_task handles empty stream list correctly."""
+    # Create a deployment state
+    deployment_state = TestDeploymentStateBlock()
+
+    # Create a timestamp
+    timestamp = datetime.now()
+
+    # Mark empty list of streams as deployed
+    mark_batch_deployed_task(stream_ids=[], deployment_state=deployment_state, timestamp=timestamp)
+
+    # Verify that no streams were marked as deployed
+    assert len(deployment_state.marked_streams) == 0
+
+
+# Helper to create a mock future for the batch filter task
+def create_mock_filter_future(
+    existing_stream_ids: list[str], account: str = "dummy_account"
+) -> PrefectFuture[DataFrame[StreamLocatorModel]]:
+    """Creates a mock PrefectFuture that resolves to a StreamLocatorModel DataFrame."""
+    mock_future = MagicMock(spec=PrefectFuture)
+    result_df = DataFrame[StreamLocatorModel](
+        pd.DataFrame({"stream_id": existing_stream_ids, "data_provider": account})
+    )
+    mock_future.result.return_value = result_df
+    return mock_future
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail; use bullet points. -->
This PR enhances the `deploy_streams_flow` to optionally integrate with a `DeploymentStateBlock`.

- **Optional Deployment State:** Added an optional `deployment_state: DeploymentStateBlock` parameter to `deploy_streams_flow`.
- **Stream Filtering:** When `deployment_state` is provided, the flow now filters out streams already marked as deployed (and verified to exist in TN) before processing batches, using the new `filter_deployed_streams_task`.
- **State Tracking:** Successfully deployed streams are now marked in the `DeploymentStateBlock` after each batch completes, using the new `mark_batch_deployed_task`. A single timestamp is used per batch.
- **Backward Compatibility:** The flow maintains its original behavior if the `deployment_state` parameter is not provided.
- **Dependency Updates:** Updated `prefect-client` to `3.2.14` and added `prefect==3.2.14` to dev dependencies for testing consistency.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example:

resolves: #112330

-->

- fix https://github.com/trufnetwork/truf-data-provider/issues/484

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- New unit tests have been added in `tests/flows/test_stream_deploy_flow.py` to cover the new functionality:
    - Testing the flow with the `DeploymentStateBlock` provided (happy path).
    - Testing the filtering logic.
    - Testing the state marking logic.
    - Testing edge cases, such as when marking the deployment state fails (the flow should continue).
- Existing tests were maintained to ensure backward compatibility. 