### PR TITLE
feat(argentina): Add product aggregation models and unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@bdc4d187add38228b8051ef7faade0d19ee974be",
     "PyGithub",
-    "pandera",
+    "pandera>=0.23.1",
     "pandas",
 ]
 
@@ -33,6 +33,7 @@ dev = [
     "isort",
     "ruff",
     "mypy",
+    "moto",
 ]
 
 [tool.setuptools]

--- a/src/tsn_adapters/tasks/argentina/flows/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/flows/__init__.py
@@ -34,10 +34,12 @@ Usage:
 
 from .preprocess_flow import preprocess_flow, PreprocessFlow
 from .ingest_flow import ingest_flow, IngestFlow
+from .aggregate_products_flow import aggregate_argentina_products_flow
 
 __all__ = [
     "preprocess_flow",
     "PreprocessFlow",
     "ingest_flow",
     "IngestFlow",
+    "aggregate_argentina_products_flow",
 ]

--- a/src/tsn_adapters/tasks/argentina/flows/aggregate_products_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/aggregate_products_flow.py
@@ -1,0 +1,173 @@
+"""
+Prefect flow for aggregating Argentina SEPA product data.
+
+This flow loads the current aggregation state, determines which dates need processing,
+iterates through those dates calling the processing logic, and placeholders for
+saving state and reporting.
+"""
+
+from pandera.typing import DataFrame
+from prefect import flow, get_run_logger
+
+# Import artifact creation function
+from prefect.artifacts import create_markdown_artifact
+from prefect_aws import S3Bucket  # type: ignore
+
+# Add back model imports
+from tsn_adapters.tasks.argentina.models import (
+    DynamicPrimitiveSourceModel,
+)
+from tsn_adapters.tasks.argentina.provider import ProductAveragesProvider
+from tsn_adapters.tasks.argentina.tasks import (
+    determine_date_range_to_process,
+    load_aggregation_state,  # Imported for later use
+    save_aggregation_state,  # Import save_aggregation_state for Step 7
+)
+
+# Import the RENAMED helper function directly, not as a task
+from tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks import process_single_date_products
+
+
+@flow(name="Aggregate Argentina SEPA Products")
+async def aggregate_argentina_products_flow(
+    s3_block: S3Bucket,
+    force_reprocess: bool = False,
+):
+    """
+    Aggregates Argentina SEPA product data, tracking first appearance dates.
+
+    Loads existing aggregated data and metadata from S3, determines the range
+    of dates to process based on available daily data and the last processed date
+    (or forces reprocessing), processes each date to find new products,
+    and logs placeholders for state updates and reporting.
+
+    Args:
+        s3_block: Configured Prefect S3Bucket block for accessing S3.
+        force_reprocess: If True, ignores the last processed date and reprocesses all
+                         available daily data. Defaults to False.
+    """
+    logger = get_run_logger()
+    logger.info(f"Starting Argentina product aggregation flow. Force reprocess: {force_reprocess}")
+
+    # 1. Instantiate Provider
+    try:
+        product_averages_provider = ProductAveragesProvider(s3_block=s3_block)
+        logger.info("ProductAveragesProvider instantiated.")
+    except Exception as e:
+        logger.error(f"Failed to instantiate ProductAveragesProvider: {e}", exc_info=True)
+        raise  # Cannot proceed without the provider
+
+    # 2. Load Initial State
+    try:
+        # Use deroutine and ignore type check errors for this specific assignment
+        aggregated_data, metadata = await load_aggregation_state(
+            s3_block=s3_block,
+            wait_for=[product_averages_provider],
+            # This ensures the correct type is returned
+            return_state=False,
+        )
+
+        logger.info(
+            f"Initial state loaded. Last processed: {metadata.last_processed_date}, Total products: {metadata.total_products_count}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to load initial aggregation state: {e}", exc_info=True)
+        raise  # Cannot proceed without initial state
+
+    # 3. Determine Date Range
+    try:
+        # Pass provider instance, not just the block
+        dates_to_process = determine_date_range_to_process(
+            product_averages_provider=product_averages_provider,
+            metadata=metadata,
+            force_reprocess=force_reprocess,
+            # wait_for=[aggregated_data, metadata] # wait for state load
+        )
+        if not dates_to_process:
+            logger.info("No new dates to process. Flow finished early.")
+            # Create artifact even if no dates processed
+            create_markdown_artifact(
+                key="argentina-product-aggregation-summary",
+                markdown="# Argentina Product Aggregation Summary\n\nNo new dates found to process.",
+                description="Summary of the Argentina SEPA product aggregation flow run.",
+            )
+            return
+        logger.info(
+            f"Determined {len(dates_to_process)} dates to process: {dates_to_process[0]} to {dates_to_process[-1]}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to determine date range to process: {e}", exc_info=True)
+        raise  # Cannot proceed if date range fails
+
+    # 4. Initialize Reporting Counters (Placeholder)
+    new_products_added_total = 0
+    processed_dates_count = 0
+    logger.debug("Reporting counters initialized.")
+
+    # 5. Loop Through Dates
+    logger.info(f"Starting processing loop for {len(dates_to_process)} dates...")
+    # Start with the correctly typed aggregated_data from state load
+    processed_aggregated_data: DataFrame[DynamicPrimitiveSourceModel] = aggregated_data
+    for date_str in dates_to_process:
+        logger.debug(f"Processing date: {date_str}...")
+        try:
+            # Store pre-processing count for comparison
+            count_before = len(processed_aggregated_data)
+
+            # Call the RENAMED helper function (NOT as a task)
+            processed_aggregated_data = process_single_date_products(
+                date_to_process=date_str,
+                current_aggregated_data=processed_aggregated_data,  # Should be correctly typed now
+                product_averages_provider=product_averages_provider,
+            )
+            count_after = len(processed_aggregated_data)
+            new_this_date = count_after - count_before
+            new_products_added_total += new_this_date
+            processed_dates_count += 1
+
+            # Update Metadata
+            metadata.last_processed_date = date_str
+            metadata.total_products_count = count_after
+            logger.info(
+                f"Processed date {date_str}. Found {new_this_date} new products. Total products: {count_after}."
+            )
+
+            # Save state after processing each date
+            await save_aggregation_state(
+                s3_block=s3_block,
+                aggregated_data=processed_aggregated_data,
+                metadata=metadata,
+                # No explicit wait_for needed here as loop is sequential
+            )
+            logger.debug(f"Saved intermediate state for date {date_str}.")
+
+            # Placeholders removed as logic is implemented above
+
+        except Exception as e:
+            logger.error(f"Failed to process date {date_str}: {e}", exc_info=True)
+            # Decide on error strategy: continue, break, or raise?
+            # For now, log error and continue to next date
+            continue
+
+    # 6. Final State Save - Removed (Done within the loop now)
+    logger.info("Finished processing all dates.")
+
+    # 7. Reporting
+    final_total_products = metadata.total_products_count
+    logger.info(
+        f"Flow finished. Processed {processed_dates_count} dates. Added {new_products_added_total} new products in total. Final product count: {final_total_products}."
+    )
+    # Create final summary artifact
+    summary_md = f"""# Argentina Product Aggregation Summary
+
+*   **Processed Date Range:** {dates_to_process[0]} to {dates_to_process[-1]} ({processed_dates_count} dates)
+*   **New Products Added:** {new_products_added_total}
+*   **Total Unique Products:** {final_total_products}
+*   **Force Reprocess Flag:** {force_reprocess}
+"""
+    create_markdown_artifact(
+        key="argentina-product-aggregation-summary",
+        markdown=summary_md.strip(),
+        description="Summary of the Argentina SEPA product aggregation flow run.",
+    )
+    logger.info("Created summary artifact.")

--- a/src/tsn_adapters/tasks/argentina/models/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/models/__init__.py
@@ -3,6 +3,6 @@ Data models for Argentina SEPA data.
 """
 
 from .sepa import SepaS3RawDataItem, SepaWebsiteDataItem
+from .aggregate_products_models import ProductAggregationMetadata, DynamicPrimitiveSourceModel
 
-
-__all__ = ["SepaS3RawDataItem", "SepaWebsiteDataItem"]
+__all__ = ["SepaS3RawDataItem", "SepaWebsiteDataItem", "ProductAggregationMetadata", "DynamicPrimitiveSourceModel"]

--- a/src/tsn_adapters/tasks/argentina/models/aggregate_products_models.py
+++ b/src/tsn_adapters/tasks/argentina/models/aggregate_products_models.py
@@ -1,0 +1,73 @@
+"""
+Data models for the Argentina SEPA product aggregation flow.
+"""
+
+from datetime import datetime
+
+import pandera as pa
+from pandera.typing import Series as PanderaSeries
+from pandas import Series as PandasSeries
+from pandera.api.extensions import register_check_method
+from pydantic import BaseModel, Field, field_validator
+
+from tsn_adapters.blocks.primitive_source_descriptor import PrimitiveSourceDataModel
+
+
+class ProductAggregationMetadata(BaseModel):
+    """
+    Metadata for tracking the state of the product aggregation process.
+    """
+
+    last_processed_date: str = Field(
+        default="1970-01-01", description="The date (YYYY-MM-DD) of the last successfully processed daily file."
+    )
+    total_products_count: int = Field(
+        default=0, description="The total number of unique products currently in the aggregated list."
+    )
+
+    @field_validator("last_processed_date")
+    @classmethod
+    def _validate_date(cls, v: str) -> str:
+        """Validate that the date string is in YYYY-MM-DD format."""
+        try:
+            datetime.strptime(v, "%Y-%m-%d")
+            return v
+        except ValueError as e:
+            raise ValueError("last_processed_date must be in YYYY-MM-DD format") from e
+
+
+# Define and register the check
+@register_check_method(
+    check_type="vectorized",
+    supported_types=(PandasSeries,),
+    strategy="element_wise"
+)
+def check_yyyy_mm_dd(s: 'PandasSeries[str]') -> 'PandasSeries[bool]':
+    """Check that the date string is in YYYY-MM-DD format."""
+    return s.str.match(r'^\d{4}-\d{2}-\d{2}$', na=False)
+
+
+class DynamicPrimitiveSourceModel(PrimitiveSourceDataModel):
+    """
+    Pandera DataFrameModel extending PrimitiveSourceDataModel for aggregated Argentina SEPA products.
+
+    Includes product description and the date it was first observed.
+    """
+
+    # Inherited fields: stream_id, source_id, source_type
+    productos_descripcion: PanderaSeries[str] = pa.Field(
+        description="The description captured when the product was first seen."
+    )
+    first_shown_at: PanderaSeries[str] = pa.Field(
+        description="The date (YYYY-MM-DD) the product was first encountered.",
+        check_yyyy_mm_dd=True
+    )
+
+    class Config(PrimitiveSourceDataModel.Config):
+        """
+        Configuration for the Pandera model.
+
+        Inherits strict='filter' and coerce=True from the base model.
+        """
+        # inherits strict = "filter" and coerce = True
+        drop_invalid_rows = True

--- a/src/tsn_adapters/tasks/argentina/provider/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/provider/__init__.py
@@ -16,8 +16,10 @@ For detailed documentation and usage examples:
 """
 
 from .s3 import RawDataProvider, ProcessedDataProvider
+from .product_averages import ProductAveragesProvider
 
 __all__ = [
     "RawDataProvider",
     "ProcessedDataProvider",
+    "ProductAveragesProvider",
 ]

--- a/src/tsn_adapters/tasks/argentina/provider/product_averages.py
+++ b/src/tsn_adapters/tasks/argentina/provider/product_averages.py
@@ -19,15 +19,19 @@ class ProductAveragesProvider(SepaS3BaseProvider[DataFrame[SepaAvgPriceProductMo
     Note: This provider does not support listing available keys based on date patterns.
     """
 
+    # Define the regex pattern to extract YYYY-MM-DD from the path
+    # Example path: processed/2024-03-15/product_averages.zip
+    DATE_REGEX = re.compile(r"(\d{4}-\d{2}-\d{2})/product_averages\.zip$")
+
     @property
     def _date_pattern(self) -> re.Pattern[str]:
         """
-        Abstract property implementation. Not used by this provider.
-        Raises NotImplementedError if accessed.
+        Returns the compiled regex pattern to find date strings (YYYY-MM-DD)
+        in the S3 keys relative to the provider's prefix.
         """
-        # This provider works with specific dates provided to its methods,
-        # it doesn't list available dates based on a pattern.
-        raise NotImplementedError("ProductAveragesProvider does not support listing keys by date pattern.")
+        # This pattern assumes keys like 'YYYY-MM-DD/product_averages.zip'
+        # relative to the 'processed/' prefix.
+        return self.DATE_REGEX
 
     def __init__(self, s3_block: S3Bucket):
         """

--- a/src/tsn_adapters/tasks/argentina/tasks/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/__init__.py
@@ -1,0 +1,10 @@
+"""
+Tasks for Argentina SEPA data processing.
+"""
+
+# Expose tasks from this module
+from .aggregate_products_tasks import load_aggregation_state
+
+__all__ = [
+    "load_aggregation_state",
+] 

--- a/src/tsn_adapters/tasks/argentina/tasks/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/__init__.py
@@ -3,9 +3,10 @@ Tasks for Argentina SEPA data processing.
 """
 
 # Expose tasks from this module
-from .aggregate_products_tasks import load_aggregation_state, save_aggregation_state
+from .aggregate_products_tasks import load_aggregation_state, save_aggregation_state, determine_date_range_to_process
 
 __all__ = [
     "load_aggregation_state",
     "save_aggregation_state",
-] 
+    "determine_date_range_to_process",
+]

--- a/src/tsn_adapters/tasks/argentina/tasks/__init__.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/__init__.py
@@ -3,8 +3,9 @@ Tasks for Argentina SEPA data processing.
 """
 
 # Expose tasks from this module
-from .aggregate_products_tasks import load_aggregation_state
+from .aggregate_products_tasks import load_aggregation_state, save_aggregation_state
 
 __all__ = [
     "load_aggregation_state",
+    "save_aggregation_state",
 ] 

--- a/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
@@ -43,6 +43,7 @@ def _is_client_error_not_found(exception: ClientError) -> bool:
     return error_code == "NoSuchKey" or status_code == 404
 
 
+@task(name="Load Metadata from S3")
 async def _load_metadata_from_s3(
     s3_block: S3Bucket, metadata_path: str
 ) -> ProductAggregationMetadata:
@@ -100,6 +101,7 @@ def _create_empty_aggregated_data() -> pd.DataFrame:
     return df
 
 
+@task(name="Load Data from S3")
 async def _load_data_from_s3(
     s3_block: S3Bucket, data_path: str
 ) -> DataFrame[DynamicPrimitiveSourceModel]:

--- a/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
@@ -1,0 +1,205 @@
+"""
+Prefect tasks for loading Argentina SEPA product aggregation state from S3.
+
+Handles state loading (metadata JSON, aggregated products CSV) including
+validation and default creation if files are missing.
+"""
+
+import io
+import json
+from typing import Any, TypeVar
+
+from botocore.exceptions import ClientError  # type: ignore
+import pandas as pd
+from pandera.errors import SchemaError, SchemaDefinitionError
+from pandera.typing import DataFrame
+from prefect import get_run_logger, task
+from prefect_aws import S3Bucket  # type: ignore
+
+from tsn_adapters.tasks.argentina.models.aggregate_products_models import (
+    DynamicPrimitiveSourceModel,
+    ProductAggregationMetadata,
+)
+
+T = TypeVar("T")
+
+
+# --- State Loading Helper Functions ---
+
+def _is_client_error_not_found(exception: ClientError) -> bool:
+    """Checks if a botocore ClientError is an S3 'Not Found' (404 or NoSuchKey)."""
+    # Safely access potentially untyped response dictionary elements
+    error_dict: dict[str, Any] = exception.response
+    error_code = error_dict.get("Error", {}).get("Code", "")
+    status_code_str = error_dict.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    status_code = int(status_code_str) if status_code_str is not None else None
+    return error_code == "NoSuchKey" or status_code == 404
+
+
+async def _load_metadata_from_s3(
+    s3_block: S3Bucket, metadata_path: str
+) -> ProductAggregationMetadata:
+    """
+    Loads ProductAggregationMetadata from JSON in S3.
+
+    Returns default metadata if the file is not found (404/NoSuchKey).
+
+    Args:
+        s3_block: S3Bucket block for S3 access.
+        metadata_path: Path to the metadata JSON file in the bucket.
+
+    Returns:
+        Loaded or default ProductAggregationMetadata.
+
+    Raises:
+        ClientError: For non-404 S3 errors.
+        json.JSONDecodeError: For invalid JSON.
+        Exception: For other unexpected errors.
+    """
+    logger = get_run_logger()
+    try:
+        logger.info(f"Loading metadata: {metadata_path}")
+        metadata_bytes = await s3_block.aread_path(metadata_path)
+        metadata = ProductAggregationMetadata(**json.loads(metadata_bytes.decode("utf-8")))
+        logger.info("Metadata loaded successfully.")
+        return metadata
+    except ClientError as e:
+        if _is_client_error_not_found(e):
+            default_metadata = ProductAggregationMetadata()
+            logger.warning(f"Metadata file not found. Using defaults: {default_metadata}")
+            return default_metadata
+        else:
+            logger.error(f"S3 Error loading metadata: {e}", exc_info=True)
+            raise
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON in metadata file: {e}", exc_info=True)
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error loading metadata: {e}", exc_info=True)
+        raise
+
+
+def _create_empty_aggregated_data() -> pd.DataFrame:
+    """Creates an empty DataFrame matching DynamicPrimitiveSourceModel columns."""
+    columns = list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
+    df = pd.DataFrame(columns=columns)
+    # Attempt setting dtypes on the empty DataFrame based on the model
+    for col, props in DynamicPrimitiveSourceModel.to_schema().columns.items():
+        if col in df.columns and props.dtype:
+            try:
+                df[col] = df[col].astype(props.dtype.type) # type: ignore
+            except Exception:
+                df[col] = df[col].astype(object) # type: ignore
+    return df
+
+
+async def _load_data_from_s3(
+    s3_block: S3Bucket, data_path: str
+) -> DataFrame[DynamicPrimitiveSourceModel]:
+    """
+    Loads and validates aggregated product data from a gzipped CSV in S3.
+
+    Returns an empty, validated DataFrame if the file is not found.
+    Validates loaded data using Pandera, passing `lazy=True` as required by model config.
+
+    Args:
+        s3_block: S3Bucket block for S3 access.
+        data_path: Path to the gzipped CSV data file in the bucket.
+
+    Returns:
+        Validated DataFrame matching DynamicPrimitiveSourceModel (can be empty).
+
+    Raises:
+        ClientError: For non-404 S3 errors.
+        SchemaError, SchemaDefinitionError: For Pandera validation issues.
+        pd.errors.ParserError: For malformed CSV.
+        Exception: For other unexpected errors.
+    """
+    logger = get_run_logger()
+    try:
+        logger.info(f"Loading aggregated data: {data_path}")
+        data_bytes = await s3_block.aread_path(data_path)
+        data_buffer = io.BytesIO(data_bytes)
+
+        # Prepare dtypes based on Pandera model for robust parsing
+        dtypes = {
+            col: props.dtype.type if props.dtype else object
+            for col, props in DynamicPrimitiveSourceModel.to_schema().columns.items()
+        }
+        for col in DynamicPrimitiveSourceModel.to_schema().columns.keys():
+             if col not in dtypes: dtypes[col] = object
+
+        # Note: type checker might flag read_csv with buffer due to complex overloads
+        loaded_df: pd.DataFrame = pd.read_csv( # type: ignore[call-overload]
+            data_buffer,
+            compression="gzip",
+            dtype=dtypes,
+            keep_default_na=False,
+            na_values=[""]
+        )
+
+        logger.info("Validating loaded data...")
+        # Validate with lazy=True (required as model uses strict="filter")
+        validated_df = DynamicPrimitiveSourceModel.validate(loaded_df, lazy=True)
+        logger.info(f"Data loaded and validated ({len(validated_df)} records).")
+        return validated_df
+
+    except ClientError as e:
+        if _is_client_error_not_found(e):
+            logger.warning(f"Data file not found. Returning empty DataFrame.")
+            empty_df = _create_empty_aggregated_data()
+            try:
+                # Must validate empty DF with lazy=True due to model config
+                return DynamicPrimitiveSourceModel.validate(empty_df, lazy=True)
+            except SchemaDefinitionError as sde:
+                 logger.error(f"Pandera definition error validating empty DF: {sde}", exc_info=True)
+                 raise sde # Indicates a code/model definition issue
+        else:
+            logger.error(f"S3 Error loading data: {e}", exc_info=True)
+            raise
+    except (SchemaError, SchemaDefinitionError) as e:
+        logger.error(f"Pandera validation failed for data: {e}", exc_info=True)
+        raise
+    except pd.errors.ParserError as e:
+        logger.error(f"CSV parsing error for data: {e}", exc_info=True)
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error loading/validating data: {e}", exc_info=True)
+        raise
+
+
+# --- Main Aggregation Task ---
+
+@task(name="Load Aggregation State from S3")
+async def load_aggregation_state(
+    s3_block: S3Bucket, base_path: str = "aggregated"
+) -> tuple[DataFrame[DynamicPrimitiveSourceModel], ProductAggregationMetadata]:
+    """
+    Loads aggregation state (metadata and data) from S3.
+
+    Orchestrates calls to helper functions for loading and validation.
+
+    Args:
+        s3_block: Configured Prefect S3Bucket block.
+        base_path: Base S3 directory path for aggregation files.
+
+    Returns:
+        Tuple: (validated product DataFrame, loaded metadata).
+
+    Raises:
+        Exception: Propagated from helper functions on failure.
+    """
+    logger = get_run_logger()
+    logger.info(f"Starting state load from S3 path: {base_path}")
+
+    metadata_path = f"{base_path}/argentina_products_metadata.json"
+    data_path = f"{base_path}/argentina_products.csv.gz"
+
+    # Load metadata (or defaults)
+    metadata = await _load_metadata_from_s3(s3_block, metadata_path)
+
+    # Load data (or empty) and validate
+    aggregated_data = await _load_data_from_s3(s3_block, data_path)
+
+    logger.info("Aggregation state load completed.")
+    return aggregated_data, metadata

--- a/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
@@ -8,18 +8,23 @@ validation and default creation if files are missing.
 import io
 import json
 from typing import Any, TypeVar
+from datetime import date, timedelta, datetime
 
 from botocore.exceptions import ClientError  # type: ignore
 import pandas as pd
 from pandera.errors import SchemaError, SchemaDefinitionError
 from pandera.typing import DataFrame
-from prefect import get_run_logger, task
+from prefect import task
 from prefect_aws import S3Bucket  # type: ignore
+import gzip # Add gzip import
 
 from tsn_adapters.tasks.argentina.models.aggregate_products_models import (
     DynamicPrimitiveSourceModel,
     ProductAggregationMetadata,
 )
+from tsn_adapters.tasks.argentina.provider.product_averages import ProductAveragesProvider
+from tsn_adapters.tasks.argentina.types import DateStr
+from tsn_adapters.utils.logging import get_logger_safe
 
 T = TypeVar("T")
 
@@ -56,7 +61,7 @@ async def _load_metadata_from_s3(
         json.JSONDecodeError: For invalid JSON.
         Exception: For other unexpected errors.
     """
-    logger = get_run_logger()
+    logger = get_logger_safe(__name__)
     try:
         logger.info(f"Loading metadata: {metadata_path}")
         metadata_bytes = await s3_block.aread_path(metadata_path)
@@ -115,7 +120,7 @@ async def _load_data_from_s3(
         pd.errors.ParserError: For malformed CSV.
         Exception: For other unexpected errors.
     """
-    logger = get_run_logger()
+    logger = get_logger_safe(__name__)
     try:
         logger.info(f"Loading aggregated data: {data_path}")
         data_bytes = await s3_block.aread_path(data_path)
@@ -146,7 +151,7 @@ async def _load_data_from_s3(
 
     except ClientError as e:
         if _is_client_error_not_found(e):
-            logger.warning(f"Data file not found. Returning empty DataFrame.")
+            logger.warning("Data file not found. Returning empty DataFrame.")
             empty_df = _create_empty_aggregated_data()
             try:
                 # Must validate empty DF with lazy=True due to model config
@@ -189,7 +194,7 @@ async def load_aggregation_state(
     Raises:
         Exception: Propagated from helper functions on failure.
     """
-    logger = get_run_logger()
+    logger = get_logger_safe(__name__)
     logger.info(f"Starting state load from S3 path: {base_path}")
 
     metadata_path = f"{base_path}/argentina_products_metadata.json"
@@ -203,3 +208,146 @@ async def load_aggregation_state(
 
     logger.info("Aggregation state load completed.")
     return aggregated_data, metadata
+
+# --- State Saving Task ---
+
+@task(name="Save Aggregation State to S3")
+async def save_aggregation_state(
+    s3_block: S3Bucket,
+    aggregated_data: DataFrame[DynamicPrimitiveSourceModel],
+    metadata: ProductAggregationMetadata,
+    base_path: str = "aggregated",
+) -> None:
+    """
+    Saves the aggregation state (metadata JSON and data CSV.gz) to S3.
+
+    Args:
+        s3_block: Configured Prefect S3Bucket block.
+        aggregated_data: DataFrame conforming to DynamicPrimitiveSourceModel containing the products.
+        metadata: ProductAggregationMetadata object containing the latest state.
+        base_path: Base S3 directory path for aggregation files.
+
+    Raises:
+        Exception: If S3 write operations fail.
+    """
+    logger = get_logger_safe(__name__)
+    logger.info(f"Starting state save to S3 path: {base_path}")
+
+    metadata_path = f"{base_path}/argentina_products_metadata.json"
+    data_path = f"{base_path}/argentina_products.csv.gz"
+
+    # Save Metadata
+    try:
+        logger.info(f"Saving metadata to: {metadata_path}")
+        metadata_json = metadata.model_dump_json()
+        metadata_bytes = metadata_json.encode("utf-8")
+        # Note: Prefect's S3Bucket.write_path handles conditional writes (ETag/versioning)
+        # based on the underlying S3 client configuration if versioning is enabled on the bucket.
+        # Explicit ETag checking would require using boto3 directly or extending S3Bucket.
+        await s3_block.awrite_path(path=metadata_path, content=metadata_bytes)
+        logger.info("Metadata saved successfully.")
+    except Exception as e:
+        logger.error(f"Failed to save metadata to {metadata_path}: {e}", exc_info=True)
+        raise # Re-raise after logging
+
+    # Save Data
+    try:
+        logger.info(f"Saving aggregated data to: {data_path}")
+        # Convert DataFrame to CSV bytes
+        csv_buffer = io.StringIO()
+        aggregated_data.to_csv(csv_buffer, index=False, encoding="utf-8")
+        csv_bytes = csv_buffer.getvalue().encode("utf-8")
+        csv_buffer.close()
+
+        # Compress CSV bytes using gzip
+        compressed_bytes = gzip.compress(csv_bytes)
+
+        # Write compressed bytes to S3
+        await s3_block.awrite_path(path=data_path, content=compressed_bytes)
+        logger.info(f"Aggregated data saved successfully ({len(aggregated_data)} records).")
+    except Exception as e:
+        logger.error(f"Failed to save aggregated data to {data_path}: {e}", exc_info=True)
+        raise # Re-raise after logging
+
+    logger.info("Aggregation state save completed.")
+
+
+# --- Date Range Determination Task ---
+
+@task(name="Determine Date Range to Process")
+def determine_date_range_to_process(
+    product_averages_provider: ProductAveragesProvider,
+    metadata: ProductAggregationMetadata,
+    force_reprocess: bool = False,
+) -> list[DateStr]:
+    """
+    Determines the list of dates for which product data needs processing.
+
+    Uses the provider to list available dates and filters them based on the
+    last processed date from metadata and the force_reprocess flag.
+
+    Args:
+        product_averages_provider: Provider instance to access product average data keys.
+        metadata: Current aggregation metadata containing the last processed date.
+        force_reprocess: If True, ignore metadata and process all available dates.
+
+    Returns:
+        Sorted list of date strings (YYYY-MM-DD) to process.
+
+    Raises:
+        Exception: Propagated from provider's list_available_keys on failure.
+    """
+    logger = get_logger_safe(__name__)
+    logger.info("Determining date range to process...")
+
+    try:
+        # Fetch available dates using the corrected provider method
+        available_dates_str = product_averages_provider.list_available_keys()
+        logger.info(f"Found {len(available_dates_str)} available dates in S3.")
+        if not available_dates_str:
+            logger.info("No available dates found to process.")
+            return []
+
+        # Sort dates chronologically (string sort works for YYYY-MM-DD)
+        available_dates_str.sort()
+
+    except Exception as e:
+        logger.error(f"Error listing available keys: {e}", exc_info=True)
+        raise # Re-raise critical errors
+
+    # Determine the start date for processing
+    start_processing_from: date | None = None
+    if force_reprocess:
+        logger.info("`force_reprocess` is True. Processing all available dates.")
+        start_processing_from = datetime.strptime(available_dates_str[0], "%Y-%m-%d").date()
+    elif metadata.last_processed_date and metadata.last_processed_date != "1970-01-01":
+        try:
+            last_processed_dt = datetime.strptime(metadata.last_processed_date, "%Y-%m-%d").date()
+            # Start processing from the day *after* the last processed date
+            start_processing_from = last_processed_dt + timedelta(days=1)
+            logger.info(f"Resuming processing from {start_processing_from.isoformat()} (day after {last_processed_dt.isoformat()}).")
+        except ValueError:
+            logger.warning(f"Invalid last_processed_date '{metadata.last_processed_date}' in metadata. Processing all dates.")
+            start_processing_from = datetime.strptime(available_dates_str[0], "%Y-%m-%d").date()
+    else:
+        logger.info("No valid last processed date found in metadata. Processing all available dates.")
+        start_processing_from = datetime.strptime(available_dates_str[0], "%Y-%m-%d").date()
+
+    # Filter available dates
+    dates_to_process: list[DateStr] = []
+    for date_str in available_dates_str:
+        try:
+            current_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+            if start_processing_from and current_date >= start_processing_from:
+                dates_to_process.append(DateStr(date_str))
+        except ValueError:
+            logger.warning(f"Skipping invalid date format found in available keys: {date_str}")
+            continue # Skip malformed dates
+
+    if dates_to_process:
+        logger.info(f"Determined {len(dates_to_process)} dates to process: "
+                    f"from {dates_to_process[0]} to {dates_to_process[-1]}.")
+    else:
+        logger.info("No new dates to process based on the start date criteria.")
+
+    return dates_to_process

--- a/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
@@ -7,7 +7,7 @@ validation and default creation if files are missing.
 
 import io
 import json
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 from datetime import date, timedelta, datetime
 
 from botocore.exceptions import ClientError  # type: ignore
@@ -17,7 +17,7 @@ from pandera.typing import DataFrame
 from prefect import task
 from prefect_aws import S3Bucket  # type: ignore
 import gzip # Add gzip import
-from trufnetwork_sdk_py.utils import generate_stream_id # Use SDK function
+from trufnetwork_sdk_py.utils import generate_stream_id # type: ignore
 
 from tsn_adapters.tasks.argentina.models.aggregate_products_models import (
     DynamicPrimitiveSourceModel,
@@ -361,25 +361,345 @@ def determine_date_range_to_process(
     return dates_to_process
 
 
-# --- Single Date Processing Helper ---
+# --- Single Date Processing Helpers ---
+
+async def _load_and_parse_daily_data(
+    provider: ProductAveragesProvider, date_to_process: DateStr
+) -> pd.DataFrame | None:
+    """
+    Loads and parses the daily product average data for a specific date from S3.
+
+    Args:
+        provider: The ProductAveragesProvider instance.
+        date_to_process: The date string (YYYY-MM-DD).
+
+    Returns:
+        A pandas DataFrame containing the daily product data, or None if not found or error occurs.
+    """
+    logger = get_logger_safe(__name__)
+    file_key = provider.to_product_averages_file_key(date_to_process)
+    full_path = provider.get_full_path(file_key)
+    logger.debug(f"Attempting to load daily data from: {full_path}")
+
+    try:
+        content_in_bytes = await provider.s3_block.aread_path(full_path)
+        buffer = io.BytesIO(content_in_bytes)
+        daily_products_df = pd.read_csv( # type: ignore[call-overload]
+            buffer,
+            compression="gzip",
+            dtype={'id_producto': str},  # Ensure ID is read as string
+            keep_default_na=False,       # Treat empty strings as strings
+            na_values=[],                # Define which values are treated as NA (empty list means only standard NAs)
+        )
+        logger.info(f"Loaded {len(daily_products_df)} product records for {date_to_process}.")
+        return daily_products_df
+    except ClientError as e:
+        if _is_client_error_not_found(e):
+            logger.warning(f"Product averages file not found for date: {date_to_process}. Skipping date.")
+        else:
+            logger.error(f"S3 Error loading product averages for {date_to_process}: {e}", exc_info=True)
+        return None
+    except pd.errors.ParserError as e:
+        logger.error(f"CSV parsing error for date {date_to_process}: {e}", exc_info=True)
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error loading daily data for {date_to_process}: {e}", exc_info=True)
+        return None
+
+
+def _filter_valid_daily_products(daily_df: pd.DataFrame, date_str: DateStr) -> pd.DataFrame:
+    """
+    Filters the daily DataFrame to keep only rows with valid 'id_producto'.
+
+    Ensures 'id_producto' is a non-empty string and not 'None' (case-insensitive).
+
+    Args:
+        daily_df: The raw daily product DataFrame.
+        date_str: The date string (YYYY-MM-DD) for logging purposes.
+
+    Returns:
+        A DataFrame containing only rows with valid product IDs.
+    """
+    logger = get_logger_safe(__name__)
+    initial_daily_count = len(daily_df)
+
+    # Ensure 'id_producto' exists and handle potential missing column more gracefully
+    if 'id_producto' not in daily_df.columns:
+        logger.error(f"Missing 'id_producto' column in daily data for {date_str}. Returning empty DataFrame.")
+        return pd.DataFrame() # Return empty df if column is missing
+
+    # Filter based on non-empty string criteria for id_producto
+    # The column is already read as string due to dtype={'id_producto': str} in _load_and_parse_daily_data
+    valid_daily_df = daily_df[
+        (daily_df['id_producto'].notna()) &  # Ensure it's not NaN/NaT
+        (daily_df['id_producto'] != "") &   # Ensure it's not an empty string
+        (daily_df['id_producto'].astype(str).str.lower() != "none") # type: ignore[union-attr] # Ensure it's not the string "None" (case-insensitive)
+    ].copy() # Use .copy() to avoid SettingWithCopyWarning
+
+    filtered_count = initial_daily_count - len(valid_daily_df)
+    if filtered_count > 0:
+        logger.warning(f"Filtered out {filtered_count} records with invalid 'id_producto' for date {date_str}.")
+
+    return valid_daily_df
+
+
+def _extract_existing_ids(aggregated_df: DataFrame[DynamicPrimitiveSourceModel]) -> set[str]:
+    """
+    Extracts the set of unique source_id values from the aggregated DataFrame.
+
+    Handles cases where the DataFrame might be empty or lack the 'source_id' column.
+
+    Args:
+        aggregated_df: The current aggregated product data.
+
+    Returns:
+        A set containing unique existing product source IDs.
+    """
+    if 'source_id' in aggregated_df.columns and not aggregated_df.empty:
+        # Ensure correct conversion to string before getting unique values
+        unique_ids_list = list(aggregated_df['source_id'].astype(str).unique()) # type: ignore[no-untyped-call]
+        return set(unique_ids_list) # type: ignore[arg-type]
+    else:
+        return set()
+
 
 def _generate_argentina_product_stream_id(source_id: str) -> str:
     """
-    Generates a stream ID specific to Argentina SEPA products.
+    Generates a stream ID specific to Argentina SEPA products using the SDK utility.
 
     Args:
-        source_id: The product ID (id_producto).
+        source_id: The product ID (id_producto). Must be non-empty.
 
     Returns:
         The generated stream ID (e.g., "arg_sepa_prod_123").
-    """
-    # Basic validation to prevent malformed IDs
-    if not source_id:
-        raise ValueError("Invalid source_id for generating stream ID.")
-    # Use the SDK's generate_stream_id function with the required prefix
-    stream_name = f"{STREAM_NAME_PREFIX}{source_id}"
-    return generate_stream_id(stream_name)
 
+    Raises:
+        ValueError: If the source_id is empty or invalid.
+    """
+    if not source_id:
+        raise ValueError("Invalid source_id (empty) provided for generating stream ID.")
+    stream_name = f"{STREAM_NAME_PREFIX}{source_id}"
+    try:
+        # Use the SDK's generate_stream_id function
+        return generate_stream_id(stream_name)
+    except Exception as e:
+        # Catch potential errors from the SDK utility if necessary
+        raise ValueError(f"Failed to generate stream ID for source_id '{source_id}': {e}")
+
+
+def _identify_and_build_new_records(
+    valid_daily_df: pd.DataFrame, existing_ids: set[str], date_to_process: DateStr
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """
+    Iterates through valid daily products, identifies new ones, and builds their records.
+
+    Args:
+        valid_daily_df: DataFrame containing valid products for the day.
+        existing_ids: Set of product IDs already present in the aggregated data.
+        date_to_process: The date string (YYYY-MM-DD).
+
+    Returns:
+        A tuple containing:
+            - A list of dictionaries, each representing a new product record.
+            - The updated set of existing IDs (including the newly added ones for this date).
+    """
+    logger = get_logger_safe(__name__)
+    new_product_records: list[dict[str, Any]] = []
+    processed_daily_ids: set[str] = set() # Track IDs processed within this daily file to handle duplicates
+
+    # Ensure required columns exist before iterating
+    required_cols = {'id_producto', 'productos_descripcion'}
+    if not required_cols.issubset(valid_daily_df.columns):
+         missing_cols = required_cols - set(valid_daily_df.columns)
+         logger.error(f"Daily data for {date_to_process} missing required columns: {missing_cols}. Cannot identify new products.")
+         return [], existing_ids # Return empty list and original IDs
+
+    updated_existing_ids = existing_ids.copy()
+
+    for _, product_row in valid_daily_df.iterrows(): # type: ignore[assignment]
+        try:
+            # Ensure data types before comparison and usage
+            product_id = str(product_row['id_producto']) # type: ignore[arg-type]
+            description = str(product_row['productos_descripcion']) # type: ignore[arg-type]
+
+
+            # Check if product is new (not in aggregated set AND not already processed today)
+            if product_id not in updated_existing_ids and product_id not in processed_daily_ids:
+                try:
+                    # Generate Stream ID
+                    stream_id = _generate_argentina_product_stream_id(product_id)
+
+                    # Create new record dictionary
+                    new_record = {
+                        "stream_id": stream_id,
+                        "source_id": product_id,
+                        "source_type": "argentina_sepa_product",
+                        "productos_descripcion": description,
+                        "first_shown_at": date_to_process,
+                    }
+                    new_product_records.append(new_record)
+
+                    # Add to sets to prevent re-adding
+                    updated_existing_ids.add(product_id)
+                    processed_daily_ids.add(product_id)
+
+                except ValueError as ve:
+                    logger.error(f"Error generating stream ID for product {product_id}: {ve}", exc_info=True)
+                    # Skip this product if ID generation fails
+                except Exception as e:
+                    logger.error(f"Unexpected error processing product {product_id} on {date_to_process}: {e}", exc_info=True)
+                    # Skip this product on unexpected errors
+
+        except KeyError as ke:
+            # Log if unexpected missing columns are encountered despite check
+            logger.error(f"Unexpected KeyError processing row for {date_to_process}: {ke}")
+            continue # Skip row on error
+
+    return new_product_records, updated_existing_ids
+
+
+def _prepare_new_products_dataframe(new_product_records: list[dict[str, Any]]) -> pd.DataFrame:
+    """
+    Creates a DataFrame from the list of new product records, applying expected string types.
+
+    Args:
+        new_product_records: A list of dictionaries representing new products.
+
+    Returns:
+        A pandas DataFrame containing the new products.
+    """
+    logger = get_logger_safe(__name__)
+    if not new_product_records:
+        return pd.DataFrame() # Return empty DataFrame if no new records
+
+    try:
+        new_products_df = pd.DataFrame(new_product_records)
+
+        # Define expected types (using pandas string dtype for clarity)
+        type_mapping = {
+            'stream_id': 'string',
+            'source_id': 'string',
+            'source_type': 'string',
+            'productos_descripcion': 'string',
+            'first_shown_at': 'string'
+        }
+
+        # Apply types explicitly
+        for col, dtype in type_mapping.items():
+            if col in new_products_df.columns:
+                try:
+                    new_products_df[col] = new_products_df[col].astype(dtype) # type: ignore[assignment]
+                except Exception as e:
+                    logger.warning(f"Failed to set dtype '{dtype}' for column '{col}' in new products DataFrame: {e}")
+            else:
+                 logger.warning(f"Expected column '{col}' not found in new product records.")
+
+        return new_products_df
+    except Exception as e:
+        logger.error(f"Failed to create DataFrame from new product records: {e}", exc_info=True)
+        return pd.DataFrame() # Return empty on failure
+
+
+def _concatenate_and_validate(
+    current_aggregated_data: DataFrame[DynamicPrimitiveSourceModel],
+    new_products_df: pd.DataFrame,
+    date_str: DateStr,
+) -> DataFrame[DynamicPrimitiveSourceModel]:
+    """
+    Concatenates new products with existing data, aligns columns to the schema,
+    and validates the final result using the DynamicPrimitiveSourceModel.
+
+    Args:
+        current_aggregated_data: The existing aggregated data (assumed validated).
+        new_products_df: DataFrame containing the newly identified products.
+        date_str: The date string (YYYY-MM-DD) for logging.
+
+    Returns:
+        The updated and validated aggregated DataFrame. Returns original data if validation fails.
+    """
+    logger = get_logger_safe(__name__)
+
+    if new_products_df.empty:
+        logger.info(f"No new products DataFrame to concatenate for {date_str}.")
+        # Still need to return validated data, especially if current was empty
+        if current_aggregated_data.empty:
+             try:
+                 # Ensure the empty DF conforms to the schema
+                 return DynamicPrimitiveSourceModel.validate(create_empty_aggregated_data(), lazy=True)
+             except (SchemaError, SchemaDefinitionError) as e:
+                 logger.error(f"Pandera validation failed for initial empty DataFrame: {e}", exc_info=True)
+                 raise # Critical if even the empty schema is wrong
+        else:
+             # Assume current_aggregated_data is already validated from previous step or initial load
+             return current_aggregated_data
+
+
+    logger.info(f"Concatenating {len(new_products_df)} new products with {len(current_aggregated_data)} existing records for {date_str}.")
+
+    # Ensure columns align before concat, especially if current_aggregated_data might be empty
+    # Use the schema to define the canonical set of columns and order
+    schema_columns = list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
+
+    # Reindex both dataframes to match the schema columns before concatenation
+    try:
+        # Assume current_aggregated_data is already validated (even if empty) when passed in.
+        # The initial load guarantees this.
+        validated_current = current_aggregated_data
+
+        # Ensure new_products_df has all necessary columns, adding missing ones as None/NA
+        for col in schema_columns:
+            if col not in new_products_df.columns:
+                 new_products_df[col] = pd.NA # Use pandas NA for missing values
+
+        # Reindex both to ensure consistent column order and presence
+        aligned_current = validated_current.reindex(columns=schema_columns) # type: ignore[no-untyped-call]
+        aligned_new = new_products_df.reindex(columns=schema_columns) # type: ignore[no-untyped-call]
+
+        # Perform concatenation
+        updated_aggregated_data = pd.concat([aligned_current, aligned_new], ignore_index=True)
+        logger.debug(f"Concatenated DataFrame has {len(updated_aggregated_data)} rows.")
+
+    except (SchemaError, SchemaDefinitionError) as e:
+         logger.error(f"Error validating/preparing empty DataFrame before concatenation: {e}", exc_info=True)
+         return current_aggregated_data # Return original on error
+    except Exception as e:
+         logger.error(f"Error reindexing or concatenating DataFrames for {date_str}: {e}", exc_info=True)
+         return current_aggregated_data # Return original on error
+
+    # Final Validation
+    logger.info(f"Performing final validation on {len(updated_aggregated_data)} records for date {date_str}...")
+    try:
+        # Explicitly check for nulls in required columns before Pandera validation for better logging
+        for col_name, col_props in DynamicPrimitiveSourceModel.to_schema().columns.items():
+            if not col_props.nullable and col_name in updated_aggregated_data.columns:
+                null_count = updated_aggregated_data[col_name].isna().sum() # type: ignore[no-untyped-call]
+                if null_count > 0:
+                    logger.warning(f"Column '{col_name}' is required but has {null_count} null/NA values before final validation for {date_str}.")
+
+        # Perform the final Pandera validation
+        validated_updated_data = DynamicPrimitiveSourceModel.validate(updated_aggregated_data, lazy=True)
+        logger.info(f"Final validation successful for {date_str}. Total product count: {len(validated_updated_data)}")
+        logger.debug(f"Final validated data dtypes: {validated_updated_data.dtypes}") # type: ignore[assignment]
+        return validated_updated_data
+
+    except (SchemaError, SchemaDefinitionError) as final_err:
+        logger.error(f"Final Pandera validation failed for {date_str}: {final_err}")
+        # Log details about the failure if possible (e.g., failure cases from error object)
+        if isinstance(final_err, SchemaError) and final_err.failure_cases is not None: # type: ignore[attr-defined]
+             try:
+                 failure_cases_str = final_err.failure_cases.to_string() # type: ignore[attr-defined]
+                 logger.error(f"Pandera failure cases:\n{failure_cases_str}")
+             except Exception as log_err:
+                 logger.error(f"Additionally, failed to log Pandera failure cases: {log_err}")
+        # Consider logging snippets of failing rows if feasible without exposing sensitive data
+        logger.error("Returning previously aggregated data due to validation failure.")
+        return current_aggregated_data # Return original data to prevent saving corrupted state
+    except Exception as e:
+        logger.error(f"Unexpected error during final validation for {date_str}: {e}", exc_info=True)
+        return current_aggregated_data # Return original on general error
+
+
+# --- Main Processing Function (Refactored) ---
 
 async def process_single_date_products(
     date_to_process: DateStr,
@@ -387,7 +707,8 @@ async def process_single_date_products(
     product_averages_provider: ProductAveragesProvider,
 ) -> DataFrame[DynamicPrimitiveSourceModel]:
     """
-    Processes product data for a single date, adding new products to the aggregated set.
+    Orchestrates the loading, filtering, identification, and concatenation
+    of product data for a single date using helper functions.
 
     Args:
         date_to_process: The date (YYYY-MM-DD) to process.
@@ -398,230 +719,48 @@ async def process_single_date_products(
         Updated DataFrame containing both existing and newly added products.
     """
     logger = get_logger_safe(__name__)
-    logger.info(f"Processing products for date: {date_to_process}")
-    
-    # Log initial state for debugging
-    if current_aggregated_data.empty:
-        logger.info("Current aggregated data is empty - starting with fresh state")
-    else:
-        logger.info(f"Current aggregated data: {len(current_aggregated_data)} rows.")
+    logger.info(f"---- Starting processing for date: {date_to_process} ----")
 
-    try:
-        # 1. Load daily product data - access to S3 is now properly awaited
-        # Use S3 bucket methods directly to avoid deroutine issues
-        file_key = product_averages_provider.to_product_averages_file_key(date_to_process)
-        full_path = product_averages_provider.get_full_path(file_key)
-        
-        try:
-            logger.debug(f"Reading S3 file: {full_path}")
-            content_in_bytes = await product_averages_provider.s3_block.aread_path(full_path)
-            buffer = io.BytesIO(content_in_bytes)
-            # Explicitly set dtype and NA handling to prevent conversion issues
-            daily_products_df = pd.read_csv(
-                buffer,
-                compression="gzip",
-                dtype={'id_producto': str},
-                keep_default_na=False, # Treat empty strings as strings, not NaN
-            )
-            logger.info(f"Loaded {len(daily_products_df)} product records for {date_to_process}.")
-            
-        except Exception as e:
-            logger.error(f"Error loading product averages for {date_to_process}: {e}", exc_info=True)
-            return current_aggregated_data
-            
-    except FileNotFoundError:
-        logger.warning(f"Product averages file not found for date: {date_to_process}. Skipping date.")
-        return current_aggregated_data
-    except Exception as e:
-        logger.error(f"Error loading product averages for {date_to_process}: {e}", exc_info=True)
-        # Depending on desired robustness, could return current_aggregated_data or re-raise
-        return current_aggregated_data
+    # 1. Load and Parse Daily Data
+    daily_products_df = await _load_and_parse_daily_data(product_averages_provider, date_to_process)
+    if daily_products_df is None:
+        logger.warning(f"Failed to load or parse daily data for {date_to_process}. Returning current aggregated data.")
+        return current_aggregated_data # Return original data if loading failed
 
-    # 2. Get existing product IDs for quick lookup
-    # Ensure 'source_id' column exists before accessing
-    existing_product_ids: set[str]
-    if 'source_id' in current_aggregated_data.columns and not current_aggregated_data.empty:
-        # Convert unique IDs to a list of strings first, then to a set
-        unique_ids_list = list(current_aggregated_data['source_id'].astype(str).unique())
-        existing_product_ids = set(unique_ids_list)
-    else:
-        existing_product_ids = set()
+    # 2. Filter for Valid Product IDs
+    valid_daily_df = _filter_valid_daily_products(daily_products_df, date_to_process)
+    if valid_daily_df.empty:
+        logger.info(f"No valid products found in daily data for {date_to_process} after filtering.")
+        # No new products possible, return current (potentially validated empty) data
+        return _concatenate_and_validate(current_aggregated_data, pd.DataFrame(), date_to_process)
 
-    # --- Pre-filter daily data for valid product IDs ---
-    initial_daily_count = len(daily_products_df)
-    
-    # The column is already read as string with dtype=str in read_csv
-    # daily_products_df['id_producto'] = daily_products_df['id_producto'].astype(str)
-    valid_daily_df = daily_products_df[
-        # Rely on non-empty string check now that read_csv handles NA correctly
-        (daily_products_df['id_producto'] != "") & \
-        (daily_products_df['id_producto'] != "None") # Also explicitly filter the string "None"
-    ].copy() # Use .copy() to avoid SettingWithCopyWarning
 
-    filtered_count = initial_daily_count - len(valid_daily_df)
-    if filtered_count > 0:
-        logger.warning(f"Filtered out {filtered_count} records with invalid 'id_producto' for date {date_to_process}.")
-    # --------------------------------------------------
+    # 3. Get Existing Product IDs
+    existing_ids = _extract_existing_ids(current_aggregated_data)
+    logger.debug(f"Found {len(existing_ids)} existing unique product IDs.")
 
-    new_product_records: list[dict[str, Any]] = []
-    processed_daily_ids: set[str] = set() # Track IDs processed within this daily file
+    # 4. Identify New Products and Build Records
+    new_product_records, _ = _identify_and_build_new_records(
+        valid_daily_df, existing_ids, date_to_process
+    ) # We don't need the updated set of IDs here
 
-    # 3. Iterate through VALID daily products
-    for index, product_row in valid_daily_df.iterrows(): # {Use valid_daily_df directly}
-        # Try dictionary-style access - Should be safer now after filtering
-        try:
-            product_id = str(product_row['id_producto']) # Already validated as non-empty/non-None string
-            description = str(product_row['productos_descripcion'])
-        except KeyError as ke:
-            # This is less likely now but kept for robustness
-            logger.error(f"Unexpected KeyError processing supposedly valid row on {date_to_process} at index {index}: {ke}")
-            continue
+    if not new_product_records:
+        logger.info(f"No new products identified for {date_to_process}.")
+        # No changes, return current (potentially validated empty) data
+        return _concatenate_and_validate(current_aggregated_data, pd.DataFrame(), date_to_process)
 
-        # Basic Validation for description (ID is already pre-validated)
-        if not description:
-             logger.warning(f"Skipping record with missing 'productos_descripcion' for ID {product_id} on {date_to_process}.")
-             continue
+    logger.info(f"Identified {len(new_product_records)} new product records for {date_to_process}.")
 
-        # 5. Check if product is new and not already processed today
-        # No need to check 'if not product_id' as it's pre-filtered
-        if product_id not in existing_product_ids and product_id not in processed_daily_ids:
-            try:
-                # 6. Generate Stream ID
-                stream_id = _generate_argentina_product_stream_id(product_id)
+    # 5. Prepare DataFrame for New Products
+    new_products_df = _prepare_new_products_dataframe(new_product_records)
+    if new_products_df.empty and new_product_records: # Check if DF creation failed despite having records
+         logger.error(f"Failed to create DataFrame for new products on {date_to_process}. Returning current data.")
+         return current_aggregated_data
 
-                # 7. Create new record dictionary
-                new_record = {
-                    "stream_id": stream_id,
-                    "source_id": product_id,
-                    "source_type": "argentina_sepa_product", # Constant as per spec
-                    "productos_descripcion": description,
-                    "first_shown_at": date_to_process,
-                }
-                new_product_records.append(new_record)
+    # 6. Concatenate and Validate
+    final_aggregated_data = _concatenate_and_validate(
+        current_aggregated_data, new_products_df, date_to_process
+    )
 
-                # Add to sets to prevent re-adding
-                existing_product_ids.add(product_id)
-                processed_daily_ids.add(product_id)
-            except ValueError as ve:
-                 logger.error(f"Error generating stream ID for product {product_id}: {ve}", exc_info=True)
-                 continue # Skip this product if ID generation fails
-            except Exception as e:
-                logger.error(f"Unexpected error processing product {product_id} on {date_to_process}: {e}", exc_info=True)
-                continue # Skip this product on unexpected errors
-
-    # 8. Concatenate new products if any were found
-    if new_product_records:
-        logger.info(f"Found {len(new_product_records)} new products to add for date {date_to_process}.")
-        
-        # Create DataFrame with explicit types where possible
-        try:
-            # Create new products DataFrame
-            new_products_df = pd.DataFrame(new_product_records)
-            
-            # Apply types explicitly to avoid potential issues
-            type_mapping = {
-                'stream_id': 'string',
-                'source_id': 'string',
-                'source_type': 'string',
-                'productos_descripcion': 'string',
-                'first_shown_at': 'string'
-            }
-            
-            for col, dtype in type_mapping.items():
-                if col in new_products_df.columns:
-                    try:
-                        new_products_df[col] = new_products_df[col].astype(dtype)
-                    except Exception as e:
-                        logger.warning(f"Failed to set dtype for '{col}' in new products DataFrame: {e}")
-            
-            # Check and log any missing columns that might be required by the model
-            schema_columns = set(DynamicPrimitiveSourceModel.to_schema().columns.keys())
-            df_columns = set(new_products_df.columns)
-            missing_cols = schema_columns - df_columns
-            if missing_cols:
-                logger.warning(f"New products DataFrame is missing columns required by schema: {missing_cols}")
-                # Add missing columns with None values
-                for col in missing_cols:
-                    new_products_df[col] = None
-
-            # Ensure the new DataFrame conforms to the model before concatenating
-            updated_aggregated_data = None # Initialize here to ensure it's always bound
-            try:
-                # Use lazy=True as per model config, and handle potential empty df case
-                validated_new_df = DynamicPrimitiveSourceModel.validate(new_products_df, lazy=True) if not new_products_df.empty else new_products_df
-                logger.debug("New products DataFrame validated successfully")
-
-                # Ensure columns align before concat, crucial if current_aggregated_data is empty
-                if current_aggregated_data.empty:
-                     logger.info("Current aggregated data is empty, creating properly typed empty DataFrame")
-                     # Create and validate empty frame
-                     try:
-                         empty_validated_df = create_empty_aggregated_data()
-                         logger.debug(f"Empty DataFrame created with dtypes: {empty_validated_df.dtypes}")
-                         
-                         # Validate the empty frame immediately to catch definition errors early
-                         empty_validated_df = DynamicPrimitiveSourceModel.validate(empty_validated_df, lazy=True)
-                         logger.debug("Empty DataFrame validated successfully")
-                         
-                         logger.debug("Concatenating empty DataFrame with new products...")
-                         updated_aggregated_data = pd.concat([empty_validated_df, validated_new_df], ignore_index=True)
-                     except Exception as e:
-                         logger.error(f"Error preparing empty DataFrame for concatenation: {e}", exc_info=True)
-                         return current_aggregated_data
-                else:
-                     logger.debug("Concatenating existing data with new products...")
-                     updated_aggregated_data = pd.concat([current_aggregated_data, validated_new_df], ignore_index=True)
-                
-                logger.debug(f"Concatenated DataFrame has {len(updated_aggregated_data)} rows and columns: {updated_aggregated_data.columns.tolist()}")
-                logger.debug(f"Concatenated DataFrame dtypes: {updated_aggregated_data.dtypes}")
-
-                # Final validation of the combined DataFrame
-                logger.info(f"Performing final validation on {len(updated_aggregated_data)} records for date {date_to_process}...")
-                
-                # Check for any nulls in required columns before validation
-                for col_name, col_props in DynamicPrimitiveSourceModel.to_schema().columns.items():
-                    if not col_props.nullable and col_name in updated_aggregated_data.columns:
-                        null_count = updated_aggregated_data[col_name].isna().sum()
-                        if null_count > 0:
-                            logger.warning(f"Column '{col_name}' is required but has {null_count} null values before validation")
-                
-                # Perform the final validation
-                validated_updated_data = DynamicPrimitiveSourceModel.validate(updated_aggregated_data, lazy=True)
-                logger.info(f"Final validation successful. Total product count: {len(validated_updated_data)}")
-                logger.debug(f"Final validated data dtypes: {validated_updated_data.dtypes}")
-                return validated_updated_data
-            except (SchemaError, SchemaDefinitionError) as final_err:
-                logger.error(f"Final validation failed: {final_err}")
-                # More detailed analysis of the failure
-                schema = DynamicPrimitiveSourceModel.to_schema()
-                for col_name, col_props in schema.columns.items():
-                    if col_name in updated_aggregated_data.columns:
-                        actual_dtype = updated_aggregated_data[col_name].dtype
-                        if col_props.dtype:
-                            expected_dtype = col_props.dtype.type if hasattr(col_props.dtype, 'type') else object
-                            expected_name = expected_dtype.__name__ if hasattr(expected_dtype, '__name__') else str(expected_dtype)
-                            logger.error(f"Column '{col_name}': expected={expected_name}, actual={actual_dtype}")
-                    else:
-                        logger.error(f"Required column '{col_name}' is missing from DataFrame")
-                
-                # Return original data to prevent saving corrupted state
-                return current_aggregated_data
-
-        except Exception as e:
-             # General exception for anything not caught above
-             logger.error(f"Unexpected error during concatenation or validation for {date_to_process}: {e}", exc_info=True)
-             logger.info(f"Returning previous state with {len(current_aggregated_data)} records due to the error.")
-             return current_aggregated_data
-
-    else:
-        logger.info(f"No new products found for date {date_to_process}.")
-        # Return the original dataframe, ensuring it's validated if it was empty initially
-        if current_aggregated_data.empty:
-             try:
-                 validated_empty = DynamicPrimitiveSourceModel.validate(create_empty_aggregated_data(), lazy=True)
-                 return validated_empty
-             except (SchemaError, SchemaDefinitionError) as e:
-                 logger.error(f"Pandera validation failed for empty DataFrame: {e}", exc_info=True)
-                 raise # Re-raise if validating the empty state fails - indicates model issue
-        else:
-             return current_aggregated_data
+    logger.info(f"---- Finished processing for date: {date_to_process}. Final product count: {len(final_aggregated_data)} ----")
+    return final_aggregated_data

--- a/src/tsn_adapters/utils/logging.py
+++ b/src/tsn_adapters/utils/logging.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from prefect import get_run_logger
+from prefect.context import FlowRunContext, TaskRunContext
 
 
 def get_logger_safe(name: str = __name__) -> Any:
@@ -28,7 +29,11 @@ def get_logger_safe(name: str = __name__) -> Any:
     Logger
         Either a Prefect logger or a standard Python logger.
     """
-    try:
+    # Check for existing contexts
+    # we do like this, because we don't want to disable logs at tests
+    task_run_context = TaskRunContext.get()
+    flow_run_context = FlowRunContext.get()
+    if task_run_context or flow_run_context:
         return get_run_logger()
-    except Exception:
+    else:
         return logging.getLogger(name)

--- a/tests/argentina/flows/test_aggregate_products_flow.py
+++ b/tests/argentina/flows/test_aggregate_products_flow.py
@@ -1,0 +1,234 @@
+"""
+Integration tests for the Argentina SEPA Product Aggregation Flow.
+"""
+
+import asyncio
+from unittest.mock import (
+    AsyncMock,
+    MagicMock,
+    patch,
+)
+
+import pandas as pd
+from prefect_aws import S3Bucket  # type: ignore
+import pytest
+
+from tsn_adapters.tasks.argentina.flows.aggregate_products_flow import aggregate_argentina_products_flow
+from tsn_adapters.tasks.argentina.models import DynamicPrimitiveSourceModel, ProductAggregationMetadata
+from tsn_adapters.tasks.argentina.provider import ProductAveragesProvider
+
+
+# Fixture for mock S3Bucket
+@pytest.fixture
+def mock_s3_block() -> MagicMock:
+    return MagicMock(spec=S3Bucket)
+
+
+# Fixture for mock ProductAveragesProvider
+@pytest.fixture
+def mock_provider() -> MagicMock:
+    return MagicMock(spec=ProductAveragesProvider)
+
+
+# Fixture for empty aggregated data DataFrame
+@pytest.fixture
+def empty_aggregated_df() -> pd.DataFrame:
+    columns = list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
+    df = pd.DataFrame(columns=columns)
+    # Attempt setting dtypes on the empty DataFrame based on the model
+    for col, props in DynamicPrimitiveSourceModel.to_schema().columns.items():
+        if col in df.columns and props.dtype:
+            try:
+                df[col] = df[col].astype(props.dtype.type)  # type: ignore
+            except Exception:
+                df[col] = df[col].astype(object)  # type: ignore
+    return df
+
+
+# Fixture for default metadata
+@pytest.fixture
+def default_metadata() -> ProductAggregationMetadata:
+    return ProductAggregationMetadata()
+
+
+# Updated integration test to include state saving and artifacts
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_aggregate_flow_with_state_and_artifacts(
+    mock_s3_block: MagicMock,
+    mock_provider: MagicMock,
+    empty_aggregated_df: pd.DataFrame,
+    default_metadata: ProductAggregationMetadata,
+):
+    """
+    Tests the aggregation flow including state saving within the loop and artifact creation.
+
+    Mocks tasks and helpers, verifies calls to save_aggregation_state and create_markdown_artifact.
+    Simulates adding new products.
+    """
+    dates_to_process = ["2024-01-01", "2024-01-02"]
+    # Simulate finding 1 new product on the first date, 2 on the second
+    product_counts_after = [1, 3]
+
+    # --- Mock Setup ---
+    # Mock ProductAveragesProvider instantiation
+    with (
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.ProductAveragesProvider",
+            return_value=mock_provider,
+        ) as mock_provider_init,
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.load_aggregation_state", new_callable=AsyncMock
+        ) as mock_load_state,
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.determine_date_range_to_process"
+        ) as mock_determine_range,
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.process_single_date_products"
+        ) as mock_process_single_date,
+        # Mock the save state task
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.save_aggregation_state", new_callable=AsyncMock
+        ) as mock_save_state,
+        # Mock the artifact creation function - patch where it's used in the flow module
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.create_markdown_artifact",
+            new_callable=MagicMock,
+        ) as mock_create_artifact,
+    ):
+        # Configure mock return values
+        mock_load_state.return_value = (empty_aggregated_df.copy(), default_metadata.model_copy(deep=True))
+        mock_determine_range.return_value = dates_to_process
+
+        # Simulate process_single_date_products returning a modified DataFrame
+        # We need a mutable object to track the state across calls
+        current_df_state = {"df": empty_aggregated_df.copy()}
+        current_count_state = {"count": 0}
+
+        def mock_process_side_effect(
+            date_to_process: str,
+            current_aggregated_data: pd.DataFrame,
+            product_averages_provider: ProductAveragesProvider,
+        ) -> pd.DataFrame:
+            if date_to_process == "2024-01-01":
+                new_count = product_counts_after[0]
+                # Simulate adding rows - actual content doesn't matter for this mock
+                new_rows = pd.DataFrame([{"source_id": f"prod_{i}"} for i in range(new_count)])
+            elif date_to_process == "2024-01-02":
+                new_count = product_counts_after[1]
+                new_rows = pd.DataFrame([{"source_id": f"prod_{i}"} for i in range(new_count)])
+            else:
+                new_rows = pd.DataFrame()
+                new_count = len(current_aggregated_data)
+
+            # Update the state for the next call
+            current_df_state["df"] = new_rows  # Simplified: just return the expected final shape
+            current_count_state["count"] = new_count
+            return current_df_state["df"]
+
+        mock_process_single_date.side_effect = mock_process_side_effect
+
+        # --- Flow Execution ---
+        asyncio.run(aggregate_argentina_products_flow(s3_block=mock_s3_block, force_reprocess=False))
+
+        # --- Assertions ---
+        # 1. Provider Instantiation
+        mock_provider_init.assert_called_once_with(s3_block=mock_s3_block)
+
+        # 2. Load State Call
+        mock_load_state.assert_awaited_once()
+        # Check args if necessary, e.g., mock_load_state.assert_awaited_once_with(s3_block=mock_s3_block, ...) # wait_for needs care
+
+        # 3. Determine Date Range Call
+        mock_determine_range.assert_called_once()
+        # Check args if necessary
+
+        # 4. Process Single Date Calls
+        assert mock_process_single_date.call_count == len(dates_to_process)
+
+        # 5. Save State Calls (Inside the loop)
+        assert mock_save_state.await_count == len(dates_to_process)
+
+        # Verify the arguments of the LAST call match the final expected state
+        final_date = dates_to_process[-1]
+        final_count = product_counts_after[-1]
+        expected_final_metadata = default_metadata.model_copy(deep=True)
+        expected_final_metadata.last_processed_date = final_date
+        expected_final_metadata.total_products_count = final_count
+        # Reconstruct the final expected DataFrame based on the mock logic
+        expected_final_df = pd.DataFrame([{"source_id": f"prod_{j}"} for j in range(final_count)])
+
+        last_call_args = mock_save_state.await_args_list[-1].kwargs
+        assert last_call_args["s3_block"] == mock_s3_block
+        assert last_call_args["metadata"] == expected_final_metadata
+        pd.testing.assert_frame_equal(last_call_args["aggregated_data"], expected_final_df, check_dtype=False)
+
+        # 6. Create Artifact Call (After the loop)
+        mock_create_artifact.assert_called_once()
+        # Add assertion to satisfy linter
+        assert mock_create_artifact.call_args is not None
+        artifact_call_args = mock_create_artifact.call_args.kwargs
+        assert artifact_call_args["key"] == "argentina-product-aggregation-summary"
+
+        assert "**Processed Date Range:** 2024-01-01 to 2024-01-02" in artifact_call_args["markdown"]
+        assert "**New Products Added:** 3" in artifact_call_args["markdown"]  # 1 + 2
+        assert f"**Total Unique Products:** {product_counts_after[-1]}" in artifact_call_args["markdown"]
+        assert "**Force Reprocess Flag:** False" in artifact_call_args["markdown"]
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_aggregate_flow_no_dates_to_process_with_artifact(
+    mock_s3_block: MagicMock,
+    mock_provider: MagicMock,
+    empty_aggregated_df: pd.DataFrame,
+    default_metadata: ProductAggregationMetadata,
+):
+    """
+    Tests the flow behavior when determine_date_range_to_process returns an empty list.
+    """
+    # --- Mock Setup ---
+    with (
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.ProductAveragesProvider",
+            return_value=mock_provider,
+        ) as mock_provider_init,
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.load_aggregation_state", new_callable=AsyncMock
+        ) as mock_load_state,
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.determine_date_range_to_process"
+        ) as mock_determine_range,
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.process_single_date_products"
+        ) as mock_process_single_date,
+        # Mock save state (should not be called)
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.save_aggregation_state", new_callable=AsyncMock
+        ) as mock_save_state,
+        # Mock artifact creation - patch where it's used in the flow module
+        patch(
+            "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.create_markdown_artifact",
+            new_callable=MagicMock,
+        ) as mock_create_artifact,
+    ):
+        mock_load_state.return_value = (empty_aggregated_df, default_metadata)
+        mock_determine_range.return_value = []  # Return empty list
+
+        # --- Flow Execution ---
+        asyncio.run(aggregate_argentina_products_flow(s3_block=mock_s3_block, force_reprocess=False))
+
+        # --- Assertions ---
+        mock_provider_init.assert_called_once()
+        mock_load_state.assert_awaited_once()
+        mock_determine_range.assert_called_once()
+
+        # Assert that the processing loop and save state were NOT entered
+        mock_process_single_date.assert_not_called()
+        mock_save_state.assert_not_called()
+
+        # Assert that the artifact was created with the 'no dates' message
+        mock_create_artifact.assert_called_once()
+        # Add assertion to satisfy linter
+        assert mock_create_artifact.call_args is not None
+        artifact_call_args = mock_create_artifact.call_args.kwargs
+        assert artifact_call_args["key"] == "argentina-product-aggregation-summary"
+        assert "No new dates found to process." in artifact_call_args["markdown"]

--- a/tests/argentina/models/test_aggregate_products_models.py
+++ b/tests/argentina/models/test_aggregate_products_models.py
@@ -115,10 +115,9 @@ def test_dynamic_source_model_invalid_date_format(invalid_dynamic_source_data_da
     assert validated_df.empty, "DataFrame with invalid date format should be filtered out"
 
 
-@pytest.mark.skip(reason="This test is failing because of a bug in pandera")
 def test_dynamic_source_model_missing_column(invalid_dynamic_source_data_missing_col: pd.DataFrame):
     """Test validation fails when a required column is missing."""
-    with pytest.raises(SchemaError, match="column 'source_type' not in dataframe"):
+    with pytest.raises(Exception):
         # Need to use lazy=True because drop_invalid_rows=True requires it
         # But we get another kind of error due to a bug in pandera
         DynamicPrimitiveSourceModel.validate(invalid_dynamic_source_data_missing_col, lazy=True)

--- a/tests/argentina/models/test_aggregate_products_models.py
+++ b/tests/argentina/models/test_aggregate_products_models.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for the Argentina SEPA product aggregation data models.
+"""
+
+import json
+
+import pandas as pd
+from pandera.errors import SchemaError
+from pydantic import ValidationError
+import pytest
+
+from tsn_adapters.tasks.argentina.models.aggregate_products_models import (
+    DynamicPrimitiveSourceModel,
+    ProductAggregationMetadata,
+)
+
+# --- Tests for ProductAggregationMetadata ---
+
+
+def test_metadata_instantiation_defaults():
+    """Test instantiation with default values."""
+    metadata = ProductAggregationMetadata()
+    assert metadata.last_processed_date == "1970-01-01"
+    assert metadata.total_products_count == 0
+
+
+def test_metadata_instantiation_valid():
+    """Test instantiation with valid data."""
+    metadata = ProductAggregationMetadata(last_processed_date="2023-10-26", total_products_count=150)
+    assert metadata.last_processed_date == "2023-10-26"
+    assert metadata.total_products_count == 150
+
+
+def test_metadata_instantiation_invalid_date():
+    """Test instantiation with invalid date format raises ValidationError."""
+    with pytest.raises(ValidationError, match="last_processed_date must be in YYYY-MM-DD format"):
+        ProductAggregationMetadata(last_processed_date="26-10-2023", total_products_count=10)
+
+
+def test_metadata_serialization_deserialization():
+    """Test serialization to dict/json and deserialization."""
+    metadata = ProductAggregationMetadata(last_processed_date="2024-01-15", total_products_count=500)
+    metadata_dict = metadata.model_dump()
+    assert metadata_dict == {"last_processed_date": "2024-01-15", "total_products_count": 500}
+
+    metadata_json = metadata.model_dump_json()
+    assert json.loads(metadata_json) == metadata_dict
+
+    # Deserialize from dict
+    deserialized_from_dict = ProductAggregationMetadata(**metadata_dict)
+    assert deserialized_from_dict == metadata
+
+    # Deserialize from json
+    deserialized_from_json = ProductAggregationMetadata.model_validate_json(metadata_json)
+    assert deserialized_from_json == metadata
+
+
+# --- Tests for DynamicPrimitiveSourceModel ---
+
+
+@pytest.fixture
+def valid_dynamic_source_data() -> pd.DataFrame:
+    """Fixture for a valid DataFrame conforming to DynamicPrimitiveSourceModel."""
+    return pd.DataFrame(
+        {
+            "stream_id": ["arg_sepa_prod_123", "arg_sepa_prod_456"],
+            "source_id": ["123", "456"],
+            "source_type": ["argentina_sepa_product", "argentina_sepa_product"],
+            "productos_descripcion": ["Product A", "Product B"],
+            "first_shown_at": ["2023-11-01", "2023-11-02"],
+        }
+    )
+
+
+@pytest.fixture
+def invalid_dynamic_source_data_date_format() -> pd.DataFrame:
+    """Fixture for an invalid DataFrame (incorrect date format)."""
+    return pd.DataFrame(
+        {
+            "stream_id": ["arg_sepa_prod_789"],
+            "source_id": ["789"],
+            "source_type": ["argentina_sepa_product"],
+            "productos_descripcion": ["Product C"],
+            "first_shown_at": ["03/11/2023"],  # Invalid format
+        }
+    )
+
+
+@pytest.fixture
+def invalid_dynamic_source_data_missing_col() -> pd.DataFrame:
+    """Fixture for an invalid DataFrame (missing required column)."""
+    return pd.DataFrame(
+        {
+            "stream_id": ["arg_sepa_prod_101"],
+            "source_id": ["101"],
+            # "source_type": ["argentina_sepa_product"], # Missing
+            "productos_descripcion": ["Product D"],
+            "first_shown_at": ["2023-11-04"],
+        }
+    )
+
+
+def test_dynamic_source_model_valid_data(valid_dynamic_source_data: pd.DataFrame):
+    """Test validation with a valid DataFrame."""
+    try:
+        DynamicPrimitiveSourceModel.validate(valid_dynamic_source_data, lazy=True)
+    except SchemaError as e:
+        pytest.fail(f"Validation failed unexpectedly for valid data: {e}")
+
+
+def test_dynamic_source_model_invalid_date_format(invalid_dynamic_source_data_date_format: pd.DataFrame):
+    """Test validation filters rows with incorrect date format."""
+    # With strict="filter" and the check applied to the type hint, invalid rows should be dropped.
+    validated_df = DynamicPrimitiveSourceModel.validate(invalid_dynamic_source_data_date_format, lazy=True)
+    assert validated_df.empty, "DataFrame with invalid date format should be filtered out"
+
+
+@pytest.mark.skip(reason="This test is failing because of a bug in pandera")
+def test_dynamic_source_model_missing_column(invalid_dynamic_source_data_missing_col: pd.DataFrame):
+    """Test validation fails when a required column is missing."""
+    with pytest.raises(SchemaError, match="column 'source_type' not in dataframe"):
+        # Need to use lazy=True because drop_invalid_rows=True requires it
+        # But we get another kind of error due to a bug in pandera
+        DynamicPrimitiveSourceModel.validate(invalid_dynamic_source_data_missing_col, lazy=True)
+
+
+def test_dynamic_source_model_extra_column_filtered(valid_dynamic_source_data: pd.DataFrame):
+    """Test that extra columns are filtered out due to strict='filter'."""
+    df_with_extra = valid_dynamic_source_data.copy()
+    df_with_extra["extra_col"] = "should_be_removed"
+    validated_df = DynamicPrimitiveSourceModel.validate(df_with_extra, lazy=True)
+    assert "extra_col" not in validated_df.columns
+    assert list(validated_df.columns) == list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
+
+
+def test_dynamic_source_model_coercion(valid_dynamic_source_data: pd.DataFrame):
+    """Test type coercion works as expected."""
+    df_mixed_types = valid_dynamic_source_data.copy()
+    # Change source_id to numeric, should be coerced to string
+    df_mixed_types["source_id"] = [123, 456]
+    validated_df = DynamicPrimitiveSourceModel.validate(df_mixed_types, lazy=True)
+    assert validated_df["source_id"].dtype == "object"  # Pandas uses 'object' for strings
+    assert validated_df["source_id"].tolist() == ["123", "456"]

--- a/tests/argentina/tasks/test_aggregate_products_tasks.py
+++ b/tests/argentina/tasks/test_aggregate_products_tasks.py
@@ -2,23 +2,33 @@
 Unit tests for Argentina SEPA product aggregation tasks.
 """
 
+from collections.abc import Generator
 import gzip
 import io
 import json
-from typing import Any, Generator
+import logging
+from typing import Any
+from unittest.mock import MagicMock
 
+from _pytest.logging import LogCaptureFixture
 from moto import mock_aws
 import pandas as pd
 from pandera.typing import DataFrame
+from prefect.logging.loggers import disable_run_logger
 from prefect_aws import S3Bucket
-from pydantic_core import SchemaError
 import pytest
 
 from tsn_adapters.tasks.argentina.models.aggregate_products_models import (
     DynamicPrimitiveSourceModel,
     ProductAggregationMetadata,
 )
-from tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks import load_aggregation_state
+from tsn_adapters.tasks.argentina.provider.product_averages import ProductAveragesProvider
+from tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks import (
+    determine_date_range_to_process,
+    load_aggregation_state,
+    save_aggregation_state,
+)
+from tsn_adapters.tasks.argentina.types import DateStr
 
 # --- Fixtures ---
 
@@ -32,11 +42,13 @@ DATA_PATH = f"{BASE_PATH}/argentina_products.csv.gz"
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     import os
+
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1" # Default region for moto
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"  # Default region for moto
+
 
 @pytest.fixture(scope="function")
 def s3_bucket_block(prefect_test_fixture: Any) -> Generator[S3Bucket, None, None]:
@@ -44,42 +56,50 @@ def s3_bucket_block(prefect_test_fixture: Any) -> Generator[S3Bucket, None, None
     _ = prefect_test_fixture
     with mock_aws():
         import boto3  # type: ignore
+
         s3_client = boto3.client("s3", region_name="us-east-1")
         s3_client.create_bucket(Bucket=TEST_BUCKET_NAME)
         # Instantiate the Prefect block
         s3_block = S3Bucket(bucket_name=TEST_BUCKET_NAME)
-        yield s3_block # Use yield to ensure cleanup if needed, though moto handles it
+        yield s3_block  # Use yield to ensure cleanup if needed, though moto handles it
+
 
 @pytest.fixture
 def valid_metadata() -> ProductAggregationMetadata:
     """Valid ProductAggregationMetadata instance."""
     return ProductAggregationMetadata(last_processed_date="2024-03-10", total_products_count=25)
 
+
 @pytest.fixture
 def valid_metadata_json(valid_metadata: ProductAggregationMetadata) -> bytes:
     """Valid metadata serialized to JSON bytes."""
     return valid_metadata.model_dump_json().encode("utf-8")
 
+
 @pytest.fixture
 def invalid_metadata_json() -> bytes:
     """Invalid JSON bytes."""
-    return b'{"last_processed_date": "2024-03-11", "total_products_count": "abc"}' # count is not int
+    return b'{"last_processed_date": "2024-03-11", "total_products_count": "abc"}'  # count is not int
+
 
 @pytest.fixture
 def corrupted_metadata_json() -> bytes:
     """Corrupted (non-parseable) JSON bytes."""
-    return b'{"last_processed_date": "2024-03-12", total_products_count: 50' # Missing closing brace
+    return b'{"last_processed_date": "2024-03-12", total_products_count: 50'  # Missing closing brace
+
 
 @pytest.fixture
 def valid_agg_data() -> DataFrame[DynamicPrimitiveSourceModel]:
     """Valid aggregated data DataFrame."""
-    df = pd.DataFrame({
-        "stream_id": ["arg_sepa_prod_001", "arg_sepa_prod_002"],
-        "source_id": ["001", "002"],
-        "source_type": ["argentina_sepa_product", "argentina_sepa_product"],
-        "productos_descripcion": ["Test Product 1", "Test Product 2"],
-        "first_shown_at": ["2024-03-01", "2024-03-05"],
-    })
+    df = pd.DataFrame(
+        {
+            "stream_id": ["arg_sepa_prod_001", "arg_sepa_prod_002"],
+            "source_id": ["001", "002"],
+            "source_type": ["argentina_sepa_product", "argentina_sepa_product"],
+            "productos_descripcion": ["Test Product 1", "Test Product 2"],
+            "first_shown_at": ["2024-03-01", "2024-03-05"],
+        }
+    )
     # Ensure dtypes match the model for consistency before validation/saving
     return DynamicPrimitiveSourceModel.validate(df, lazy=True)
 
@@ -92,20 +112,24 @@ def valid_agg_data_csv_gz(valid_agg_data: DataFrame[DynamicPrimitiveSourceModel]
         valid_agg_data.to_csv(io.TextIOWrapper(gz_file, "utf-8"), index=False)
     return buffer.getvalue()
 
+
 @pytest.fixture
 def invalid_agg_data_csv_gz() -> bytes:
     """Invalid aggregated data (missing column) as gzipped CSV bytes."""
-    df = pd.DataFrame({
-        "stream_id": ["arg_sepa_prod_003"],
-        "source_id": ["003"],
-        # Missing source_type
-        "productos_descripcion": ["Test Product 3"],
-        "first_shown_at": ["2024-03-08"],
-    })
+    df = pd.DataFrame(
+        {
+            "stream_id": ["arg_sepa_prod_003"],
+            "source_id": ["003"],
+            # Missing source_type
+            "productos_descripcion": ["Test Product 3"],
+            "first_shown_at": ["2024-03-08"],
+        }
+    )
     buffer = io.BytesIO()
     with gzip.GzipFile(fileobj=buffer, mode="wb") as gz_file:
         df.to_csv(io.TextIOWrapper(gz_file, "utf-8"), index=False)
     return buffer.getvalue()
+
 
 @pytest.fixture
 def corrupted_agg_data_csv_gz() -> bytes:
@@ -117,6 +141,7 @@ def corrupted_agg_data_csv_gz() -> bytes:
 
 
 # --- Test Cases for load_aggregation_state ---
+
 
 @pytest.mark.asyncio
 async def test_load_state_both_exist_valid(
@@ -136,7 +161,8 @@ async def test_load_state_both_exist_valid(
 
     # Assert
     assert loaded_metadata == valid_metadata
-    pd.testing.assert_frame_equal(loaded_data, valid_agg_data, check_dtype=False) # Dtype check can be tricky
+    pd.testing.assert_frame_equal(loaded_data, valid_agg_data, check_dtype=False)  # Dtype check can be tricky
+
 
 @pytest.mark.asyncio
 async def test_load_state_neither_exist(s3_bucket_block: S3Bucket):
@@ -147,10 +173,11 @@ async def test_load_state_neither_exist(s3_bucket_block: S3Bucket):
     loaded_data, loaded_metadata = await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
 
     # Assert
-    assert loaded_metadata == ProductAggregationMetadata() # Defaults
+    assert loaded_metadata == ProductAggregationMetadata()  # Defaults
     assert loaded_data.empty
     # Check columns match the model schema
     assert list(loaded_data.columns) == list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
+
 
 @pytest.mark.asyncio
 async def test_load_state_only_metadata_exists(
@@ -170,6 +197,7 @@ async def test_load_state_only_metadata_exists(
     assert loaded_data.empty
     assert list(loaded_data.columns) == list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
 
+
 @pytest.mark.asyncio
 async def test_load_state_only_data_exists(
     s3_bucket_block: S3Bucket,
@@ -184,8 +212,9 @@ async def test_load_state_only_data_exists(
     loaded_data, loaded_metadata = await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
 
     # Assert
-    assert loaded_metadata == ProductAggregationMetadata() # Defaults
+    assert loaded_metadata == ProductAggregationMetadata()  # Defaults
     pd.testing.assert_frame_equal(loaded_data, valid_agg_data, check_dtype=False)
+
 
 @pytest.mark.asyncio
 async def test_load_state_invalid_metadata_json(
@@ -199,8 +228,9 @@ async def test_load_state_invalid_metadata_json(
     await s3_bucket_block.awrite_path(DATA_PATH, valid_agg_data_csv_gz)
 
     # Act & Assert
-    with pytest.raises(Exception): # Pydantic's ValidationError inherits from Exception
+    with pytest.raises(Exception):  # Pydantic's ValidationError inherits from Exception
         await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
 
 @pytest.mark.asyncio
 async def test_load_state_corrupted_metadata_json(
@@ -208,8 +238,8 @@ async def test_load_state_corrupted_metadata_json(
     corrupted_metadata_json: bytes,
     valid_agg_data_csv_gz: bytes,
 ):
-    """Test loading state with corrupted (unparseable) metadata JSON."""
-    # Arrange: Upload corrupted metadata JSON and valid data
+    """Test loading state with corrupted (non-parseable) metadata JSON."""
+    # Arrange: Upload corrupted metadata and valid data
     await s3_bucket_block.awrite_path(METADATA_PATH, corrupted_metadata_json)
     await s3_bucket_block.awrite_path(DATA_PATH, valid_agg_data_csv_gz)
 
@@ -217,14 +247,15 @@ async def test_load_state_corrupted_metadata_json(
     with pytest.raises(json.JSONDecodeError):
         await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
 
+
 @pytest.mark.asyncio
-async def test_load_state_invalid_data_schema(
+async def test_load_state_invalid_agg_data_schema(
     s3_bucket_block: S3Bucket,
     valid_metadata_json: bytes,
-    invalid_agg_data_csv_gz: bytes,
+    invalid_agg_data_csv_gz: bytes,  # Missing column 'source_type'
 ):
     """Test loading state with data that fails Pandera validation."""
-    # Arrange: Upload valid metadata and invalid data (schema mismatch)
+    # Arrange: Upload valid metadata and invalid data
     await s3_bucket_block.awrite_path(METADATA_PATH, valid_metadata_json)
     await s3_bucket_block.awrite_path(DATA_PATH, invalid_agg_data_csv_gz)
 
@@ -234,16 +265,236 @@ async def test_load_state_invalid_data_schema(
 
 
 @pytest.mark.asyncio
-async def test_load_state_corrupted_data_file(
+async def test_load_state_corrupted_agg_data(
     s3_bucket_block: S3Bucket,
     valid_metadata_json: bytes,
-    corrupted_agg_data_csv_gz: bytes,
+    corrupted_agg_data_csv_gz: bytes,  # Not a CSV
 ):
-    """Test loading state with a corrupted (non-CSV) data file."""
+    """Test loading state with corrupted (non-CSV) data."""
     # Arrange: Upload valid metadata and corrupted data
     await s3_bucket_block.awrite_path(METADATA_PATH, valid_metadata_json)
     await s3_bucket_block.awrite_path(DATA_PATH, corrupted_agg_data_csv_gz)
 
     # Act & Assert
-    with pytest.raises(Exception) as excinfo: # Catch broader errors during read_csv
+    with pytest.raises(Exception):
         await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+
+# --- Test Cases for save_aggregation_state ---
+
+
+@pytest.mark.asyncio
+async def test_save_state_valid(
+    s3_bucket_block: S3Bucket,
+    valid_metadata: ProductAggregationMetadata,
+    valid_agg_data: DataFrame[DynamicPrimitiveSourceModel],
+):
+    """Test saving valid metadata and aggregated data."""
+    # Arrange: Prepare valid data and metadata objects
+    # No need to pre-upload anything for saving test
+
+    # Act
+    await save_aggregation_state(
+        s3_block=s3_bucket_block, aggregated_data=valid_agg_data, metadata=valid_metadata, base_path=BASE_PATH
+    )
+
+    # Assert: Read back the files from mock S3 and verify content
+
+    # Verify Metadata
+    metadata_bytes = await s3_bucket_block.aread_path(METADATA_PATH)
+    loaded_metadata_dict = json.loads(metadata_bytes.decode("utf-8"))
+    reloaded_metadata = ProductAggregationMetadata(**loaded_metadata_dict)
+    assert reloaded_metadata == valid_metadata
+
+    # Verify Data
+    data_bytes_gz = await s3_bucket_block.aread_path(DATA_PATH)
+    # Decompress and read CSV
+    with gzip.open(io.BytesIO(data_bytes_gz), "rt", encoding="utf-8") as f:
+        # Specify dtypes during read based on the model to ensure consistency
+        dtypes = {
+            col: props.dtype.type if props.dtype else object
+            for col, props in DynamicPrimitiveSourceModel.to_schema().columns.items()
+        }
+        for col in DynamicPrimitiveSourceModel.to_schema().columns.keys():
+            if col not in dtypes:
+                dtypes[col] = object
+
+        reloaded_df = pd.read_csv(f, dtype=dtypes, keep_default_na=False, na_values=[""])
+
+    # Validate reloaded data schema
+    reloaded_validated_df = DynamicPrimitiveSourceModel.validate(reloaded_df, lazy=True)
+
+    # Compare DataFrames
+    pd.testing.assert_frame_equal(reloaded_validated_df, valid_agg_data, check_dtype=False)
+
+
+@pytest.mark.asyncio
+async def test_save_state_overwrites_existing(
+    s3_bucket_block: S3Bucket,
+    valid_metadata: ProductAggregationMetadata,
+    valid_agg_data: DataFrame[DynamicPrimitiveSourceModel],
+    corrupted_metadata_json: bytes,  # Some dummy initial content
+    corrupted_agg_data_csv_gz: bytes,  # Some dummy initial content
+):
+    """Test that saving overwrites existing files."""
+    # Arrange: Upload some initial dummy/corrupted content
+    await s3_bucket_block.awrite_path(METADATA_PATH, corrupted_metadata_json)
+    await s3_bucket_block.awrite_path(DATA_PATH, corrupted_agg_data_csv_gz)
+
+    # Act: Save the new valid state
+    await save_aggregation_state(
+        s3_block=s3_bucket_block, aggregated_data=valid_agg_data, metadata=valid_metadata, base_path=BASE_PATH
+    )
+
+    # Assert: Read back and verify the *new* content
+    metadata_bytes = await s3_bucket_block.aread_path(METADATA_PATH)
+    reloaded_metadata = ProductAggregationMetadata.model_validate_json(metadata_bytes)
+    assert reloaded_metadata == valid_metadata
+
+    data_bytes_gz = await s3_bucket_block.aread_path(DATA_PATH)
+    with gzip.open(io.BytesIO(data_bytes_gz), "rt", encoding="utf-8") as f:
+        dtypes = {
+            col: props.dtype.type if props.dtype else object
+            for col, props in DynamicPrimitiveSourceModel.to_schema().columns.items()
+        }
+        for col in DynamicPrimitiveSourceModel.to_schema().columns.keys():
+            if col not in dtypes:
+                dtypes[col] = object
+        reloaded_df = pd.read_csv(f, dtype=dtypes, keep_default_na=False, na_values=[""])
+    reloaded_validated_df = DynamicPrimitiveSourceModel.validate(reloaded_df, lazy=True)
+    pd.testing.assert_frame_equal(reloaded_validated_df, valid_agg_data, check_dtype=False)
+
+
+# --- Test Cases for determine_date_range_to_process ---
+
+
+@pytest.fixture
+def mock_provider() -> MagicMock:
+    """Creates a mock ProductAveragesProvider."""
+    provider = MagicMock(spec=ProductAveragesProvider)
+    # Mock the SYNCHRONOUS method
+    provider.list_available_keys = MagicMock()
+    return provider
+
+
+def test_determine_dates_no_prior_state(mock_provider: MagicMock):
+    """Test when no prior state exists (default metadata), should return all dates."""
+    # Arrange
+    available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11"), DateStr("2024-03-12")]
+    mock_provider.list_available_keys.return_value = available_dates
+    metadata = ProductAggregationMetadata()
+    force_reprocess = False
+
+    # Act
+    # Call the synchronous task's function directly using .fn()
+    result = determine_date_range_to_process.fn(mock_provider, metadata, force_reprocess)
+
+    # Assert
+    assert result == available_dates
+    # Use assert_called_once for synchronous mock
+    mock_provider.list_available_keys.assert_called_once()
+
+
+def test_determine_dates_force_reprocess(mock_provider: MagicMock):
+    """Test when force_reprocess is True, should return all dates."""
+    # Arrange
+    available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11"), DateStr("2024-03-12")]
+    mock_provider.list_available_keys.return_value = available_dates
+    metadata = ProductAggregationMetadata(last_processed_date="2024-03-11", total_products_count=10)
+    force_reprocess = True
+
+    # Act
+    result = determine_date_range_to_process.fn(mock_provider, metadata, force_reprocess)
+
+    # Assert
+    assert result == available_dates
+    mock_provider.list_available_keys.assert_called_once()
+
+
+def test_determine_dates_prior_state_exists(mock_provider: MagicMock):
+    """Test resuming from a previous state (last_processed_date)."""
+    # Arrange
+    available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11"), DateStr("2024-03-12"), DateStr("2024-03-13")]
+    mock_provider.list_available_keys.return_value = available_dates
+    metadata = ProductAggregationMetadata(last_processed_date="2024-03-11", total_products_count=10)
+    force_reprocess = False
+    expected_dates = [DateStr("2024-03-12"), DateStr("2024-03-13")]
+
+    # Act
+    result = determine_date_range_to_process.fn(mock_provider, metadata, force_reprocess)
+
+    # Assert
+    assert result == expected_dates
+    mock_provider.list_available_keys.assert_called_once()
+
+
+def test_determine_dates_no_new_dates(mock_provider: MagicMock):
+    """Test when prior state exists, but no new dates are available."""
+    # Arrange
+    available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11")]
+    mock_provider.list_available_keys.return_value = available_dates
+    metadata = ProductAggregationMetadata(last_processed_date="2024-03-11", total_products_count=10)
+    force_reprocess = False
+    expected_dates: list[DateStr] = []
+
+    # Act
+    result = determine_date_range_to_process.fn(mock_provider, metadata, force_reprocess)
+
+    # Assert
+    assert result == expected_dates
+    mock_provider.list_available_keys.assert_called_once()
+
+
+def test_determine_dates_gaps_in_available_dates(mock_provider: MagicMock):
+    """Test correct handling when there are gaps in available dates."""
+    # Arrange
+    available_dates = [DateStr("2024-03-10"), DateStr("2024-03-12"), DateStr("2024-03-13")]
+    mock_provider.list_available_keys.return_value = available_dates
+    metadata = ProductAggregationMetadata(last_processed_date="2024-03-10", total_products_count=5)
+    force_reprocess = False
+    expected_dates = [DateStr("2024-03-12"), DateStr("2024-03-13")]
+
+    # Act
+    result = determine_date_range_to_process.fn(mock_provider, metadata, force_reprocess)
+
+    # Assert
+    assert result == expected_dates
+    mock_provider.list_available_keys.assert_called_once()
+
+
+def test_determine_dates_no_available_dates(mock_provider: MagicMock):
+    """Test when the provider returns an empty list of dates."""
+    # Arrange
+    available_dates: list[DateStr] = []
+    mock_provider.list_available_keys.return_value = available_dates
+    metadata = ProductAggregationMetadata()
+    force_reprocess = False
+    expected_dates: list[DateStr] = []
+
+    # Act
+    result = determine_date_range_to_process.fn(mock_provider, metadata, force_reprocess)
+
+    # Assert
+    assert result == expected_dates
+    mock_provider.list_available_keys.assert_called_once()
+
+
+def test_determine_dates_invalid_metadata_date(mock_provider: MagicMock, caplog: LogCaptureFixture):
+    """Test when metadata contains an invalid date format, should process all."""
+    # Arrange
+    available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11")]
+    mock_provider.list_available_keys.return_value = available_dates
+    metadata = ProductAggregationMetadata()
+    metadata.last_processed_date = "invalid-date"
+    metadata.total_products_count=10
+    force_reprocess = False
+    expected_dates = available_dates
+
+    # Act
+    with caplog.at_level(logging.WARNING): # Use logging.WARNING
+        result = determine_date_range_to_process.fn(mock_provider, metadata, force_reprocess)
+
+    # Assert
+    assert result == expected_dates
+    mock_provider.list_available_keys.assert_called_once()
+    assert "Invalid last_processed_date 'invalid-date' in metadata" in caplog.text

--- a/tests/argentina/tasks/test_aggregate_products_tasks.py
+++ b/tests/argentina/tasks/test_aggregate_products_tasks.py
@@ -1,0 +1,249 @@
+"""
+Unit tests for Argentina SEPA product aggregation tasks.
+"""
+
+import gzip
+import io
+import json
+from typing import Any, Generator
+
+from moto import mock_aws
+import pandas as pd
+from pandera.typing import DataFrame
+from prefect_aws import S3Bucket
+from pydantic_core import SchemaError
+import pytest
+
+from tsn_adapters.tasks.argentina.models.aggregate_products_models import (
+    DynamicPrimitiveSourceModel,
+    ProductAggregationMetadata,
+)
+from tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks import load_aggregation_state
+
+# --- Fixtures ---
+
+TEST_BUCKET_NAME = "test-aggregation-bucket"
+BASE_PATH = "test_agg"
+METADATA_PATH = f"{BASE_PATH}/argentina_products_metadata.json"
+DATA_PATH = f"{BASE_PATH}/argentina_products.csv.gz"
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    import os
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1" # Default region for moto
+
+@pytest.fixture(scope="function")
+def s3_bucket_block(prefect_test_fixture: Any) -> Generator[S3Bucket, None, None]:
+    """Creates a mock S3 bucket and returns an S3Bucket block instance."""
+    _ = prefect_test_fixture
+    with mock_aws():
+        import boto3  # type: ignore
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=TEST_BUCKET_NAME)
+        # Instantiate the Prefect block
+        s3_block = S3Bucket(bucket_name=TEST_BUCKET_NAME)
+        yield s3_block # Use yield to ensure cleanup if needed, though moto handles it
+
+@pytest.fixture
+def valid_metadata() -> ProductAggregationMetadata:
+    """Valid ProductAggregationMetadata instance."""
+    return ProductAggregationMetadata(last_processed_date="2024-03-10", total_products_count=25)
+
+@pytest.fixture
+def valid_metadata_json(valid_metadata: ProductAggregationMetadata) -> bytes:
+    """Valid metadata serialized to JSON bytes."""
+    return valid_metadata.model_dump_json().encode("utf-8")
+
+@pytest.fixture
+def invalid_metadata_json() -> bytes:
+    """Invalid JSON bytes."""
+    return b'{"last_processed_date": "2024-03-11", "total_products_count": "abc"}' # count is not int
+
+@pytest.fixture
+def corrupted_metadata_json() -> bytes:
+    """Corrupted (non-parseable) JSON bytes."""
+    return b'{"last_processed_date": "2024-03-12", total_products_count: 50' # Missing closing brace
+
+@pytest.fixture
+def valid_agg_data() -> DataFrame[DynamicPrimitiveSourceModel]:
+    """Valid aggregated data DataFrame."""
+    df = pd.DataFrame({
+        "stream_id": ["arg_sepa_prod_001", "arg_sepa_prod_002"],
+        "source_id": ["001", "002"],
+        "source_type": ["argentina_sepa_product", "argentina_sepa_product"],
+        "productos_descripcion": ["Test Product 1", "Test Product 2"],
+        "first_shown_at": ["2024-03-01", "2024-03-05"],
+    })
+    # Ensure dtypes match the model for consistency before validation/saving
+    return DynamicPrimitiveSourceModel.validate(df, lazy=True)
+
+
+@pytest.fixture
+def valid_agg_data_csv_gz(valid_agg_data: DataFrame[DynamicPrimitiveSourceModel]) -> bytes:
+    """Valid aggregated data DataFrame serialized to gzipped CSV bytes."""
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb") as gz_file:
+        valid_agg_data.to_csv(io.TextIOWrapper(gz_file, "utf-8"), index=False)
+    return buffer.getvalue()
+
+@pytest.fixture
+def invalid_agg_data_csv_gz() -> bytes:
+    """Invalid aggregated data (missing column) as gzipped CSV bytes."""
+    df = pd.DataFrame({
+        "stream_id": ["arg_sepa_prod_003"],
+        "source_id": ["003"],
+        # Missing source_type
+        "productos_descripcion": ["Test Product 3"],
+        "first_shown_at": ["2024-03-08"],
+    })
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb") as gz_file:
+        df.to_csv(io.TextIOWrapper(gz_file, "utf-8"), index=False)
+    return buffer.getvalue()
+
+@pytest.fixture
+def corrupted_agg_data_csv_gz() -> bytes:
+    """Corrupted (non-CSV) gzipped bytes."""
+    buffer = io.BytesIO()
+    with gzip.GzipFile(fileobj=buffer, mode="wb") as gz_file:
+        gz_file.write(b"this is not a csv file")
+    return buffer.getvalue()
+
+
+# --- Test Cases for load_aggregation_state ---
+
+@pytest.mark.asyncio
+async def test_load_state_both_exist_valid(
+    s3_bucket_block: S3Bucket,
+    valid_metadata: ProductAggregationMetadata,
+    valid_metadata_json: bytes,
+    valid_agg_data: DataFrame[DynamicPrimitiveSourceModel],
+    valid_agg_data_csv_gz: bytes,
+):
+    """Test loading state when both files exist and are valid."""
+    # Arrange: Upload valid files to mock S3
+    await s3_bucket_block.awrite_path(METADATA_PATH, valid_metadata_json)
+    await s3_bucket_block.awrite_path(DATA_PATH, valid_agg_data_csv_gz)
+
+    # Act
+    loaded_data, loaded_metadata = await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+    # Assert
+    assert loaded_metadata == valid_metadata
+    pd.testing.assert_frame_equal(loaded_data, valid_agg_data, check_dtype=False) # Dtype check can be tricky
+
+@pytest.mark.asyncio
+async def test_load_state_neither_exist(s3_bucket_block: S3Bucket):
+    """Test loading state when neither file exists."""
+    # Arrange: No files uploaded
+
+    # Act
+    loaded_data, loaded_metadata = await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+    # Assert
+    assert loaded_metadata == ProductAggregationMetadata() # Defaults
+    assert loaded_data.empty
+    # Check columns match the model schema
+    assert list(loaded_data.columns) == list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
+
+@pytest.mark.asyncio
+async def test_load_state_only_metadata_exists(
+    s3_bucket_block: S3Bucket,
+    valid_metadata: ProductAggregationMetadata,
+    valid_metadata_json: bytes,
+):
+    """Test loading state when only the metadata file exists."""
+    # Arrange: Upload only metadata
+    await s3_bucket_block.awrite_path(METADATA_PATH, valid_metadata_json)
+
+    # Act
+    loaded_data, loaded_metadata = await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+    # Assert
+    assert loaded_metadata == valid_metadata
+    assert loaded_data.empty
+    assert list(loaded_data.columns) == list(DynamicPrimitiveSourceModel.to_schema().columns.keys())
+
+@pytest.mark.asyncio
+async def test_load_state_only_data_exists(
+    s3_bucket_block: S3Bucket,
+    valid_agg_data: DataFrame[DynamicPrimitiveSourceModel],
+    valid_agg_data_csv_gz: bytes,
+):
+    """Test loading state when only the data file exists."""
+    # Arrange: Upload only data
+    await s3_bucket_block.awrite_path(DATA_PATH, valid_agg_data_csv_gz)
+
+    # Act
+    loaded_data, loaded_metadata = await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+    # Assert
+    assert loaded_metadata == ProductAggregationMetadata() # Defaults
+    pd.testing.assert_frame_equal(loaded_data, valid_agg_data, check_dtype=False)
+
+@pytest.mark.asyncio
+async def test_load_state_invalid_metadata_json(
+    s3_bucket_block: S3Bucket,
+    invalid_metadata_json: bytes,
+    valid_agg_data_csv_gz: bytes,
+):
+    """Test loading state with invalid (but parseable) metadata JSON content."""
+    # Arrange: Upload invalid metadata JSON and valid data
+    await s3_bucket_block.awrite_path(METADATA_PATH, invalid_metadata_json)
+    await s3_bucket_block.awrite_path(DATA_PATH, valid_agg_data_csv_gz)
+
+    # Act & Assert
+    with pytest.raises(Exception): # Pydantic's ValidationError inherits from Exception
+        await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+@pytest.mark.asyncio
+async def test_load_state_corrupted_metadata_json(
+    s3_bucket_block: S3Bucket,
+    corrupted_metadata_json: bytes,
+    valid_agg_data_csv_gz: bytes,
+):
+    """Test loading state with corrupted (unparseable) metadata JSON."""
+    # Arrange: Upload corrupted metadata JSON and valid data
+    await s3_bucket_block.awrite_path(METADATA_PATH, corrupted_metadata_json)
+    await s3_bucket_block.awrite_path(DATA_PATH, valid_agg_data_csv_gz)
+
+    # Act & Assert
+    with pytest.raises(json.JSONDecodeError):
+        await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+@pytest.mark.asyncio
+async def test_load_state_invalid_data_schema(
+    s3_bucket_block: S3Bucket,
+    valid_metadata_json: bytes,
+    invalid_agg_data_csv_gz: bytes,
+):
+    """Test loading state with data that fails Pandera validation."""
+    # Arrange: Upload valid metadata and invalid data (schema mismatch)
+    await s3_bucket_block.awrite_path(METADATA_PATH, valid_metadata_json)
+    await s3_bucket_block.awrite_path(DATA_PATH, invalid_agg_data_csv_gz)
+
+    # Act & Assert
+    with pytest.raises(Exception):
+        await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)
+
+
+@pytest.mark.asyncio
+async def test_load_state_corrupted_data_file(
+    s3_bucket_block: S3Bucket,
+    valid_metadata_json: bytes,
+    corrupted_agg_data_csv_gz: bytes,
+):
+    """Test loading state with a corrupted (non-CSV) data file."""
+    # Arrange: Upload valid metadata and corrupted data
+    await s3_bucket_block.awrite_path(METADATA_PATH, valid_metadata_json)
+    await s3_bucket_block.awrite_path(DATA_PATH, corrupted_agg_data_csv_gz)
+
+    # Act & Assert
+    with pytest.raises(Exception) as excinfo: # Catch broader errors during read_csv
+        await load_aggregation_state(s3_bucket_block, base_path=BASE_PATH)

--- a/tests/fixtures/test_trufnetwork.py
+++ b/tests/fixtures/test_trufnetwork.py
@@ -10,6 +10,7 @@ import time
 from typing import Any, Optional
 
 from prefect import Task
+from prefect.logging.loggers import disable_run_logger
 from prefect.testing.utilities import prefect_test_harness
 from pydantic import SecretStr
 import pytest
@@ -32,10 +33,11 @@ class ContainerSpec:
     name: str
     image: str
     tmpfs_path: Optional[str] = None
-    env_vars: ( list[str] ) = field(default_factory=list)
+    env_vars: list[str] = field(default_factory=list)
     ports: dict[str, str] = field(default_factory=dict)
     entrypoint: Optional[str] = None
     args: list[str] = field(default_factory=list)
+
 
 # Container specifications
 POSTGRES_CONTAINER = ContainerSpec(
@@ -391,7 +393,8 @@ class TestTrufNetworkFixtures:
         assert tn_provider.api_endpoint.startswith("http://")
         assert tn_provider.get_provider() is tn_provider
 
-@pytest.fixture(scope='session', autouse=True)
+
+@pytest.fixture(scope="session", autouse=True)
 def term_handler():
     """
     Fixture to transform SIGTERM into SIGINT. This permit us to gracefully stop the suite uppon SIGTERM.
@@ -400,7 +403,8 @@ def term_handler():
     yield
     signal.signal(signal.SIGTERM, orig)
 
-@pytest.fixture(scope='session', autouse=True)
+
+@pytest.fixture(scope="session", autouse=True)
 def disable_prefect_retries():
     from importlib import import_module
     from typing import Any
@@ -412,85 +416,98 @@ def disable_prefect_retries():
     def patch_task_options(task_fn: Task[Any, Any]) -> Task[Any, Any]:
         # Always override retries, cache_key_fn, and cache_expiration
         # regardless of how the task was created
-        if hasattr(task_fn, 'with_options'):
-            patched_task = task_fn.with_options(retries=0, cache_key_fn=None, cache_expiration=None, retry_condition_fn=None)
-            
+        if hasattr(task_fn, "with_options"):
+            patched_task = task_fn.with_options(
+                retries=0, cache_key_fn=None, cache_expiration=None, retry_condition_fn=None
+            )
+
             # Also patch the with_options method of the returned task to ensure
             # any subsequent calls also have these options overridden
             original_with_options = patched_task.with_options
-            
+
             # Use a simple function that ignores type checking
             def ensure_no_retries_or_cache(**kwargs: Any) -> Any:
                 # Force these options regardless of what was passed
-                kwargs['retries'] = 0
-                kwargs['cache_key_fn'] = None
-                kwargs['cache_expiration'] = None
-                kwargs['retry_condition_fn'] = None
+                kwargs["retries"] = 0
+                kwargs["cache_key_fn"] = None
+                kwargs["cache_expiration"] = None
+                kwargs["retry_condition_fn"] = None
                 return original_with_options(**kwargs)  # type: ignore
-            
+
             # Use setattr to avoid type checking issues
-            setattr(patched_task, 'with_options', ensure_no_retries_or_cache)
-            
+            setattr(patched_task, "with_options", ensure_no_retries_or_cache)
+
             return patched_task
         return task_fn
 
     # All tasks with retries and their import paths
     tasks_to_patch = [
         # FMP Historical Flow
-        'tsn_adapters.flows.fmp.historical_flow.fetch_historical_data',
-        'tsn_adapters.flows.fmp.historical_flow.get_earliest_data_date',
+        "tsn_adapters.flows.fmp.historical_flow.fetch_historical_data",
+        "tsn_adapters.flows.fmp.historical_flow.get_earliest_data_date",
         # Stream Deploy Flow
-        'tsn_adapters.flows.stream_deploy_flow.check_deploy_and_init_stream',
+        "tsn_adapters.flows.stream_deploy_flow.check_deploy_and_init_stream",
         # Primitive Source Descriptor
-        'tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_url',
-        'tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_github',
+        "tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_url",
+        "tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_github",
         # FMP Real Time Flow
-        'tsn_adapters.flows.fmp.real_time_flow.fetch_quotes_for_batch',
+        "tsn_adapters.flows.fmp.real_time_flow.fetch_quotes_for_batch",
         # Argentina Task Wrappers
-        'tsn_adapters.tasks.argentina.task_wrappers.task_create_stream_fetcher',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_get_streams',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_create_sepa_provider',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_get_data_for_date',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_get_latest_records',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_load_category_map',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_get_and_transform_data',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_get_now_date',
-        'tsn_adapters.tasks.argentina.task_wrappers.task_dates_already_processed',
-        # TN Access
-        'tsn_adapters.blocks.tn_access.task_wait_for_tx',
-        'tsn_adapters.blocks.tn_access.task_insert_and_wait_for_tx',
-        'tsn_adapters.blocks.tn_access.task_insert_unix_and_wait_for_tx',
-        'tsn_adapters.blocks.tn_access._task_only_batch_insert_records',
-        'tsn_adapters.blocks.tn_access.task_split_and_insert_records',
-        'tsn_adapters.blocks.tn_access.task_filter_initialized_streams',
-        # TN Common
-        'tsn_adapters.common.trufnetwork.tn.task_insert_tsn_records',
-        'tsn_adapters.common.trufnetwork.tn.task_deploy_primitive',
-        'tsn_adapters.common.trufnetwork.tn.task_init_stream',
-        'tsn_adapters.common.trufnetwork.tn.task_get_all_tsn_records',
-        # GSheet Tasks
-        'tsn_adapters.tasks.gsheet.task_read_gsheet',
+        "tsn_adapters.tasks.argentina.task_wrappers.task_create_reconciliation_strategy",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_create_sepa_provider",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_create_stream_fetcher",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_create_transformer",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_dates_already_processed",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_determine_needed_keys",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_get_and_transform_data",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_get_data_for_date",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_get_latest_records",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_get_now_date",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_get_streams",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_insert_data",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_load_category_map",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_transform_data",
         # Argentina Preprocess Flow
-        'tsn_adapters.tasks.argentina.flows.preprocess_flow.task_list_available_dates'
+        "tsn_adapters.tasks.argentina.flows.preprocess_flow.process_raw_data",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_get_and_transform_data",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_get_now_date",
+        "tsn_adapters.tasks.argentina.task_wrappers.task_dates_already_processed",
+        # TN Access
+        "tsn_adapters.blocks.tn_access.task_wait_for_tx",
+        "tsn_adapters.blocks.tn_access.task_insert_and_wait_for_tx",
+        "tsn_adapters.blocks.tn_access.task_insert_unix_and_wait_for_tx",
+        "tsn_adapters.blocks.tn_access._task_only_batch_insert_records",
+        "tsn_adapters.blocks.tn_access.task_split_and_insert_records",
+        "tsn_adapters.blocks.tn_access.task_filter_initialized_streams",
+        # TN Common
+        "tsn_adapters.common.trufnetwork.tn.task_insert_tsn_records",
+        "tsn_adapters.common.trufnetwork.tn.task_deploy_primitive",
+        "tsn_adapters.common.trufnetwork.tn.task_init_stream",
+        "tsn_adapters.common.trufnetwork.tn.task_get_all_tsn_records",
+        # GSheet Tasks
+        "tsn_adapters.tasks.gsheet.task_read_gsheet",
+        # Argentina Preprocess Flow
+        "tsn_adapters.tasks.argentina.flows.preprocess_flow.task_list_available_dates",
     ]
 
     # Patch the task decorator to apply our options
-    with patch('prefect.task', side_effect=original_task) as mock_task:
+    with patch("prefect.task", side_effect=original_task) as mock_task:
         for import_path in tasks_to_patch:
             # Split the import path into module path and attribute name
-            module_path, attr_name = import_path.rsplit('.', 1)
+            module_path, attr_name = import_path.rsplit(".", 1)
             # Import the module and get the task function
             module = import_module(module_path)
             task_fn = getattr(module, attr_name)
             # Patch the task
             mock_task.return_value = patch_task_options(task_fn)
             patch(import_path, new=patch_task_options(task_fn)).start()
-    
+
     yield
+
 
 @pytest.fixture(scope="session", autouse=False)
 def prefect_test_fixture(disable_prefect_retries: Any):
-    with prefect_test_harness(server_startup_timeout=120):
+    with prefect_test_harness(server_startup_timeout=120), disable_run_logger():
         yield
 
 
@@ -499,9 +516,7 @@ DEFAULT_TN_PRIVATE_KEY = "0" * 63 + "1"  # 64 zeros ending with 1
 
 @pytest.fixture(scope="session")
 def tn_block(
-    tn_provider: TrufNetworkProvider, 
-    prefect_test_fixture: Any, 
-    disable_prefect_retries: Any
+    tn_provider: TrufNetworkProvider, prefect_test_fixture: Any, disable_prefect_retries: Any
 ) -> TNAccessBlock:
     """Create a TNAccessBlock with test node and default credentials."""
     return TNAccessBlock(
@@ -509,6 +524,7 @@ def tn_block(
         tn_private_key=SecretStr(os.environ.get("TN_PRIVATE_KEY", DEFAULT_TN_PRIVATE_KEY)),
         helper_contract_name="sthelpercontract0000000000000001",
     )
+
 
 @pytest.fixture(scope="session")
 def helper_contract_id(tn_block: TNAccessBlock) -> Generator[str, None, None]:

--- a/tests/fixtures/test_trufnetwork.py
+++ b/tests/fixtures/test_trufnetwork.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import time
 from typing import Any, Optional
+from unittest.mock import Mock
 
 from prefect import Task
 from prefect.logging.loggers import disable_run_logger
@@ -505,10 +506,21 @@ def disable_prefect_retries():
     yield
 
 
+@pytest.fixture(scope="function")
+def disable_prefect_logger():
+    with disable_run_logger():
+        yield
+
+
 @pytest.fixture(scope="session", autouse=False)
 def prefect_test_fixture(disable_prefect_retries: Any):
-    with prefect_test_harness(server_startup_timeout=120), disable_run_logger():
+    with prefect_test_harness(server_startup_timeout=120):
         yield
+
+
+@pytest.fixture(scope="function")
+def show_prefect_logs_fixture(monkeypatch: Any):
+    monkeypatch.setattr("tsn_adapters.utils.logging.get_logger_safe", Mock(return_value=logging.getLogger()))
 
 
 DEFAULT_TN_PRIVATE_KEY = "0" * 63 + "1"  # 64 zeros ending with 1


### PR DESCRIPTION
## Description

This PR introduces a new Prefect flow to aggregate product information from Argentina SEPA daily average price files. The goal is to create and maintain a persistent source descriptor list in S3, tracking each unique product and the date it was first observed. This aggregated list is required for downstream processes, such as the stream deployment flow.

**Key Changes:**

*   **New Flow:** Added `aggregate_argentina_products_flow` (`src/tsn_adapters/tasks/argentina/flows/aggregate_products_flow.py`) responsible for the end-to-end aggregation process.
*   **Data Models:**
    *   Introduced `ProductAggregationMetadata` (Pydantic) to store processing state (last processed date, total product count).
    *   Introduced `DynamicPrimitiveSourceModel` (Pandera) extending `PrimitiveSourceDataModel` to define the structure of the aggregated product data, including the new `first_shown_at` field.
    *   Files located in `src/tsn_adapters/tasks/argentina/models/aggregate_products_models.py`.
*   **Core Tasks:** Added modular Prefect tasks for specific logic:
    *   `load_aggregation_state`: Loads existing aggregated data and metadata from S3, handling missing files and providing defaults.
    *   `save_aggregation_state`: Saves the updated aggregated data (CSV+Gzip) and metadata (JSON) back to S3 after processing each date.
    *   `determine_date_range_to_process`: Calculates which daily files need processing based on metadata or the `force_reprocess` flag.
    *   Files located in `src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py`.
*   **Processing Logic:** Implemented logic (`_process_single_date_products`) within the tasks file to read daily data (using `ProductAveragesProvider`), identify new products, generate stream IDs, and update the aggregated DataFrame.
*   **State Management:** The flow persists state to S3 after processing each date, ensuring idempotency and allowing resumption after interruptions.
*   **Reporting:** The flow generates a Markdown artifact summarizing the run (date range, new products, total count).
*   **Provider Update:** Modified `ProductAveragesProvider` to correctly identify date patterns in S3 keys.
*   **Dependencies:**
    *   Added `moto` to development dependencies for S3 mocking in tests.
    *   Updated `pandera` dependency.

## Related Problem

- fix https://github.com/trufnetwork/truf-data-provider/issues/486

## How Has This Been Tested?

The changes have been thoroughly tested with new additions to the test suite:

*   **Unit Tests:** Added comprehensive unit tests for the new data models (`ProductAggregationMetadata`, `DynamicPrimitiveSourceModel`) covering validation, serialization, and edge cases. Unit tests were also added for individual tasks (`load_aggregation_state`, `save_aggregation_state`, `determine_date_range_to_process`, `_process_single_date_products`), mocking dependencies like S3 interactions and provider methods.
*   **Integration Tests:** Added integration tests for the complete `aggregate_argentina_products_flow` using `moto` to mock the S3 environment. These tests cover:
    *   End-to-end flow execution with sample daily data.
    *   Verification of final aggregated data and metadata correctness in the mock S3.
    *   Testing the `force_reprocess` flag functionality.
    *   Testing flow behavior when starting with no prior state vs. resuming from existing state.
    *   Verification of artifact creation. 