### PR TITLE
feat(deployment): improve deploy workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ __pycache__/
 # IDEs
 .idea
 .cursorrules
+.cursor
 *.code-workspace
 
 # Python specific

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A collection of prefect tasks and examples ingesting data into TSN"
 readme = "README.md"
 dependencies = [
-    "prefect-client==3.3.1",
+    "prefect-client>=3.3.1",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@bdc4d187add38228b8051ef7faade0d19ee974be",
     "PyGithub",
@@ -29,7 +29,7 @@ argentina = [
 ]
 dev = [
     # we need this for the testing harness
-    "prefect==3.3.1",
+    "prefect>=3.3.1",
     "pytest-timeout",
     "pytest-mock",
     "black",

--- a/src/tsn_adapters/blocks/stream_filtering.py
+++ b/src/tsn_adapters/blocks/stream_filtering.py
@@ -6,7 +6,7 @@ using various strategies, including a divide-and-conquer approach.
 """
 
 import traceback
-from typing import Any, Optional, cast
+from typing import Any, Optional, cast, TypedDict
 
 import pandas as pd
 from prefect import get_run_logger, task
@@ -24,7 +24,19 @@ from tsn_adapters.blocks.tn_access import (
     diff_stream_locator_sets,
     get_stream_locator_set,
     task_filter_batch_initialized_streams,
+    UNUSED_INFINITY_RETRIES,
+    tn_special_retry_condition,
 )
+
+
+class StreamStatesResult(TypedDict):
+    """Result of the stream state checking operation."""
+
+    non_deployed: DataFrame[StreamLocatorModel]
+    deployed_but_not_initialized: DataFrame[StreamLocatorModel]
+    deployed_and_initialized: DataFrame[StreamLocatorModel]
+    depth: int
+    fallback_used: bool
 
 
 def fallback_method_filter_streams(
@@ -283,8 +295,8 @@ def task_filter_streams_divide_conquer(
         # Process each half recursively
         try:
             # Convert DataFrames to proper typed DataFrames for recursive calls
-            left_half_typed = cast(DataFrame[StreamLocatorModel], left_half)
-            right_half_typed = cast(DataFrame[StreamLocatorModel], right_half)
+            left_half_typed = left_half
+            right_half_typed = right_half
 
             left = task_filter_streams_divide_conquer.submit(
                 block=block,
@@ -325,3 +337,271 @@ def task_filter_streams_divide_conquer(
             force_fallback=True,
             max_filter_size=max_filter_size,
         )
+
+
+@task(
+    name="Get Stream States (Divide & Conquer)",
+    retries=UNUSED_INFINITY_RETRIES,
+    retry_delay_seconds=10,
+    retry_condition_fn=tn_special_retry_condition(3),
+)
+def task_get_stream_states_divide_conquer(
+    block: TNAccessBlock,
+    stream_locators: DataFrame[StreamLocatorModel],
+    max_depth: int = 10,
+    current_depth: int = 0,
+    force_fallback: bool = False,
+    max_filter_size: int = 5000,
+) -> StreamStatesResult:
+    """
+    Determine the precise state of streams using a divide-and-conquer approach.
+
+    States:
+    - non_deployed: The stream ID does not exist on the network for the provider.
+    - deployed_but_not_initialized: The stream exists but has not been initialized.
+    - deployed_and_initialized: The stream exists and has been initialized.
+
+    Args:
+        block: TNAccessBlock instance for network interactions.
+        stream_locators: DataFrame containing stream IDs and providers to check.
+        max_depth: Maximum recursion depth to prevent infinite loops.
+        current_depth: Current recursion depth.
+        force_fallback: If True, forces the use of the fallback method (checking one by one).
+        max_filter_size: Threshold above which the batch method is skipped initially.
+
+    Returns:
+        A StreamStatesResult TypedDict containing partitioned DataFrames for each state.
+    """
+    logger = get_run_logger()
+    logger.info(
+        f"Getting stream states for {len(stream_locators)} streams at depth {current_depth}. "
+        f"Max depth: {max_depth}, Force fallback: {force_fallback}, Max filter size: {max_filter_size}"
+    )
+
+    # Base case: empty input
+    if stream_locators.empty:
+        logger.info("Input stream_locators is empty, returning empty result.")
+        empty_df = create_empty_stream_locator_df()
+        return StreamStatesResult(
+            non_deployed=empty_df,
+            deployed_but_not_initialized=empty_df,
+            deployed_and_initialized=empty_df,
+            depth=current_depth,
+            fallback_used=False,
+        )
+
+    # --- Batch Attempt (Step 4) ---
+    if not force_fallback and len(stream_locators) <= max_filter_size:
+        try:
+            logger.debug(
+                f"Attempting batch method (task_filter_batch_initialized_streams) for {len(stream_locators)} streams."
+            )
+            # This task returns only the *initialized* streams from the input
+            initialized_df = task_filter_batch_initialized_streams(block=block, stream_locators=stream_locators)
+
+            logger.debug(f"Batch method returned {len(initialized_df)} initialized streams.")
+
+            # Since the batch call succeeding implies existence, all streams in the input
+            # are either deployed_and_initialized or deployed_but_not_initialized.
+            # Non-deployed streams would cause MetadataProcedureNotFoundError.
+
+            # Identify initialized streams
+            deployed_and_initialized_df = convert_to_typed_df(initialized_df, StreamLocatorModel)
+
+            # Identify uninitialized (but existing) streams
+            all_input_set = get_stream_locator_set(stream_locators)
+            initialized_set = get_stream_locator_set(deployed_and_initialized_df)
+            uninitialized_data = diff_stream_locator_sets(all_input_set, initialized_set)
+
+            deployed_but_not_initialized_df = convert_to_typed_df(
+                pd.DataFrame(uninitialized_data) if uninitialized_data else create_empty_df(["data_provider", "stream_id"]),
+                StreamLocatorModel,
+            )
+
+            logger.info(
+                f"Batch method success: DeployedAndInitialized={len(deployed_and_initialized_df)}, "
+                f"DeployedButNotInitialized={len(deployed_but_not_initialized_df)}"
+            )
+
+            return StreamStatesResult(
+                non_deployed=create_empty_stream_locator_df(), # Batch success implies all exist
+                deployed_but_not_initialized=deployed_but_not_initialized_df,
+                deployed_and_initialized=deployed_and_initialized_df,
+                depth=current_depth,
+                fallback_used=False,
+            )
+
+        except MetadataProcedureNotFoundError:
+            # This is expected if *any* stream in the batch does not exist or the helper contract is wrong.
+            # Fall through to divide/fallback logic which handles non-existence.
+            logger.debug(
+                "Batch method failed with MetadataProcedureNotFoundError. Falling back to divide/individual checks."
+            )
+            # Proceed to divide/fallback logic below
+        except Exception as e:
+            # For other unexpected errors during the batch attempt, log and re-raise
+            # This might indicate a deeper issue with TN or the SDK
+            logger.error(f"Unexpected error during batch state check: {e!s}", exc_info=True)
+            raise e
+
+    # --- Fallback Logic (Step 3) or Divide/Recurse (Step 5) ---
+
+    # Determine if fallback should be used
+    use_fallback = current_depth >= max_depth or force_fallback or len(stream_locators) == 1
+
+    if use_fallback:
+        logger.debug(f"Using fallback method for {len(stream_locators)} streams at depth {current_depth}")
+
+        # Initialize lists/DataFrames
+        non_deployed_list: list[dict[str, str]] = []
+        provisionally_existing_df = create_empty_stream_locator_df()
+        deployed_and_initialized_df = create_empty_stream_locator_df()
+        deployed_but_not_initialized_df = create_empty_stream_locator_df()
+
+        # 1. Check existence for each stream
+        for _, row in stream_locators.iterrows():
+            try:
+                exists = block.stream_exists(data_provider=row["data_provider"], stream_id=row["stream_id"])
+                if exists:
+                    provisionally_existing_df = cast(
+                        DataFrame[StreamLocatorModel], append_to_df(provisionally_existing_df, row)
+                    )
+                else:
+                    non_deployed_list.append(row.to_dict())
+            except Exception as e:
+                # If existence check fails, tentatively mark as non-deployed but log error
+                logger.error(
+                    f"Error checking existence for stream {row['stream_id']} from {row['data_provider']}: {e!s}. Marking as non-deployed.",
+                    exc_info=True,
+                )
+                non_deployed_list.append(row.to_dict())
+
+        # 2. Check initialization for provisionally existing streams
+        if not provisionally_existing_df.empty:
+            try:
+                # Use the batch task to efficiently check initialization
+                logger.debug(
+                    f"Calling task_filter_batch_initialized_streams for {len(provisionally_existing_df)} provisionally existing streams."
+                )
+                initialized_in_batch_df = task_filter_batch_initialized_streams(
+                    block=block, stream_locators=provisionally_existing_df
+                )
+                deployed_and_initialized_df = convert_to_typed_df(initialized_in_batch_df, StreamLocatorModel)
+
+                # Find those that existed but were not returned by the initialization check
+                if not deployed_and_initialized_df.empty:
+                    existing_set = get_stream_locator_set(provisionally_existing_df)
+                    initialized_set = get_stream_locator_set(deployed_and_initialized_df)
+                    uninitialized_data = diff_stream_locator_sets(existing_set, initialized_set)
+                    deployed_but_not_initialized_df = convert_to_typed_df(
+                        pd.DataFrame(uninitialized_data),
+                        StreamLocatorModel,
+                    )
+                else:
+                    # None were initialized
+                    deployed_but_not_initialized_df = provisionally_existing_df
+
+            except MetadataProcedureNotFoundError:
+                # If batch init check itself fails (e.g., helper contract issue?), assume none are initialized
+                logger.warning(
+                    "task_filter_batch_initialized_streams failed with MetadataProcedureNotFoundError during fallback. "
+                    "Assuming all provisionally existing streams are deployed_but_not_initialized."
+                )
+                deployed_but_not_initialized_df = provisionally_existing_df
+                deployed_and_initialized_df = create_empty_stream_locator_df() # Ensure it's empty
+            except Exception as e:
+                # Handle other potential errors during batch initialization check
+                logger.error(
+                    f"Error during task_filter_batch_initialized_streams in fallback: {e!s}. "
+                    "Assuming all provisionally existing streams are deployed_but_not_initialized.",
+                    exc_info=True,
+                )
+                deployed_but_not_initialized_df = provisionally_existing_df
+                deployed_and_initialized_df = create_empty_stream_locator_df() # Ensure it's empty
+
+        # 3. Combine results
+        non_deployed_df = convert_to_typed_df(
+            pd.DataFrame(non_deployed_list) if non_deployed_list else create_empty_df(["data_provider", "stream_id"]),
+            StreamLocatorModel,
+        )
+
+        logger.info(
+            f"Fallback result: NonDeployed={len(non_deployed_df)}, "
+            f"DeployedButNotInitialized={len(deployed_but_not_initialized_df)}, "
+            f"DeployedAndInitialized={len(deployed_and_initialized_df)}"
+        )
+
+        return StreamStatesResult(
+            non_deployed=non_deployed_df,
+            deployed_but_not_initialized=deployed_but_not_initialized_df,
+            deployed_and_initialized=deployed_and_initialized_df,
+            depth=current_depth,
+            fallback_used=True,
+        )
+
+    # --- Divide and Recurse (Step 5) ---
+    else: # Neither batch success nor fallback condition met
+        logger.debug(f"Dividing {len(stream_locators)} streams for recursive state check at depth {current_depth}.")
+        mid = len(stream_locators) // 2
+        left_half = stream_locators.iloc[:mid]
+        right_half = stream_locators.iloc[mid:]
+
+        # Submit recursive calls as subtasks (or directly if not using Prefect tasks yet)
+        # NOTE: Using .submit() requires the function to be a @task, which is Step 6.
+        # For now, we'll call directly for testing, assuming it's not yet a task.
+        # TODO: Convert to .submit() in Step 6
+        # UPDATE: Now that it's a task, we should use .submit()
+        logger.debug(f"Submitting left half ({len(left_half)}) for depth {current_depth + 1}")
+        left_future = task_get_stream_states_divide_conquer.submit(
+            block=block,
+            stream_locators=left_half,
+            max_depth=max_depth,
+            current_depth=current_depth + 1,
+            force_fallback=force_fallback,
+            max_filter_size=max_filter_size,
+        )
+
+        logger.debug(f"Submitting right half ({len(right_half)}) for depth {current_depth + 1}")
+        right_future = task_get_stream_states_divide_conquer.submit(
+            block=block,
+            stream_locators=right_half,
+            max_depth=max_depth,
+            current_depth=current_depth + 1,
+            force_fallback=force_fallback,
+            max_filter_size=max_filter_size,
+        )
+
+        # Wait for results
+        left_result = left_future.result()
+        right_result = right_future.result()
+
+        # Combine results from both halves
+        logger.debug("Combining results from recursive calls.")
+        # Need a helper function to combine StreamStatesResult
+        combined_result = _combine_stream_states_results(left_result, right_result)
+        return combined_result
+
+
+def _combine_stream_states_results(
+    left: StreamStatesResult, right: StreamStatesResult
+) -> StreamStatesResult:
+    """Helper function to combine two StreamStatesResult objects."""
+    combined_non_deployed = pd.concat([left["non_deployed"], right["non_deployed"]])
+    combined_dep_not_init = pd.concat([left["deployed_but_not_initialized"], right["deployed_but_not_initialized"]])
+    combined_dep_and_init = pd.concat([left["deployed_and_initialized"], right["deployed_and_initialized"]])
+
+    # Ensure correct types after concat
+    non_deployed_typed = convert_to_typed_df(combined_non_deployed, StreamLocatorModel)
+    dep_not_init_typed = convert_to_typed_df(combined_dep_not_init, StreamLocatorModel)
+    dep_and_init_typed = convert_to_typed_df(combined_dep_and_init, StreamLocatorModel)
+
+    return StreamStatesResult(
+        non_deployed=non_deployed_typed,
+        deployed_but_not_initialized=dep_not_init_typed,
+        deployed_and_initialized=dep_and_init_typed,
+        depth=max(left["depth"], right["depth"]), # Depth is max of branches
+        fallback_used=left["fallback_used"] or right["fallback_used"], # Fallback if used in either branch
+    )
+
+
+# --- Existing task below ---

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -12,7 +12,6 @@ from typing import (
     cast,
     overload,
 )
-from typing_extensions import ParamSpec
 
 import pandas as pd
 from pandera.typing import DataFrame
@@ -24,6 +23,7 @@ from prefect.states import Completed
 from pydantic import ConfigDict, Field, SecretStr
 import trufnetwork_sdk_c_bindings.exports as truf_sdk
 import trufnetwork_sdk_py.client as tn_client
+from typing_extensions import ParamSpec
 
 from tsn_adapters.blocks.shared_types import DivideAndConquerResult
 from tsn_adapters.common.trufnetwork.models.tn_models import StreamLocatorModel, TnDataRowModel, TnRecord, TnRecordModel
@@ -131,6 +131,10 @@ def handle_tn_errors(func: F) -> F:
                 raise TNDbTimeoutError.from_error(e)
             if MetadataProcedureNotFoundError.is_metadata_procedure_not_found_error(e):
                 raise MetadataProcedureNotFoundError.from_error(e)
+            if StreamAlreadyExistsError.is_stream_already_exists_error(e):
+                raise StreamAlreadyExistsError.from_error(e)
+            if StreamAlreadyInitializedError.is_stream_already_initialized_error(e):
+                raise StreamAlreadyInitializedError.from_error(e)
             raise
 
     return cast(F, wrapper)
@@ -159,7 +163,7 @@ def tn_special_retry_condition(max_other_error_retries: int) -> Any:
         except (TNNodeNetworkError, TNDbTimeoutError):
             # Always retry on network and DB timeout errors.
             return True
-        except (MetadataProcedureNotFoundError,):
+        except (MetadataProcedureNotFoundError, StreamAlreadyExistsError, StreamAlreadyInitializedError):
             # This won't change with retries.
             return False
         except Exception:
@@ -250,6 +254,83 @@ class MetadataProcedureNotFoundError(Exception):
         if isinstance(error, RuntimeError) and "get_metadata" in str(error) and "not found in schema" in str(error):
             return cls(str(error))
         raise error
+
+
+class StreamAlreadyExistsError(Exception):
+    """Custom exception raised when attempting to deploy a stream that already exists."""
+    def __init__(self, stream_id: str):
+        self.stream_id = stream_id
+        super().__init__(f"Stream '{stream_id}' already exists.")
+
+    @classmethod
+    def from_error(cls, error: Exception) -> "StreamAlreadyExistsError":
+        """
+        Convert a generic exception to StreamAlreadyExistsError if the error message matches.
+        """
+        if isinstance(error, StreamAlreadyExistsError):
+            return error
+        msg = str(error).lower()
+        import re
+        # Match "transaction failed: dataset exists: <stream_id>"
+        match = re.search(r"dataset exists: ([a-z0-9]+)", msg)
+        if match:
+            stream_id = match.group(1)
+            return cls(stream_id)
+        if (
+            isinstance(error, RuntimeError) and ("dataset exists" in msg or "already exists" in msg)
+        ):
+            # Try to extract stream_id if possible, else use a placeholder
+            import re
+            match = re.search(r"stream '([^']+)' already exists", str(error))
+            stream_id = match.group(1) if match else "unknown"
+            return cls(stream_id)
+        raise error
+
+    @classmethod
+    def is_stream_already_exists_error(cls, error: Exception) -> bool:
+        """
+        Check if the given exception is a StreamAlreadyExistsError or matches its error pattern.
+        """
+        try:
+            cls.from_error(error)
+            return True
+        except Exception:
+            return False
+
+
+class StreamAlreadyInitializedError(Exception):
+    """Custom exception raised when attempting to initialize a stream that is already initialized."""
+    def __init__(self, stream_id: str):
+        self.stream_id = stream_id
+        super().__init__(f"Stream '{stream_id}' is already initialized.")
+
+    @classmethod
+    def from_error(cls, error: Exception) -> "StreamAlreadyInitializedError":
+        """
+        Convert a generic exception to StreamAlreadyInitializedError if the error message matches.
+        """
+        if isinstance(error, StreamAlreadyInitializedError):
+            return error
+        msg = str(error).lower()
+        if (
+            isinstance(error, RuntimeError) and ("already initialized" in msg)
+        ):
+            import re
+            match = re.search(r"stream '([^']+)' is already initialized", str(error))
+            stream_id = match.group(1) if match else "unknown"
+            return cls(stream_id)
+        raise error
+
+    @classmethod
+    def is_stream_already_initialized_error(cls, error: Exception) -> bool:
+        """
+        Check if the given exception is a StreamAlreadyInitializedError or matches its error pattern.
+        """
+        try:
+            cls.from_error(error)
+            return True
+        except Exception:
+            return False
 
 
 class TNAccessBlock(Block):

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -326,7 +326,7 @@ class TNAccessBlock(Block):
 
     @handle_tn_errors
     def stream_exists(self, data_provider: str, stream_id: str) -> bool:
-        """Check if a stream exists"""
+        """Check if a stream exists. Does not take into account if it's initialized."""
         with concurrency("tn-read", occupy=1):
             try:
                 return self.client.stream_exists(stream_id=stream_id, data_provider=data_provider)

--- a/src/tsn_adapters/flows/stream_deploy_flow.py
+++ b/src/tsn_adapters/flows/stream_deploy_flow.py
@@ -1,22 +1,15 @@
 """
 Stream Deployment Flow
 
-This module contains a Prefect flow to deploy primitive streams from a generic
-primitive source descriptor. For each stream in the descriptor, the flow:
-
-1. Filters out already deployed streams (using DeploymentStateBlock if provided)
-2. Checks if remaining streams exist using the TN SDK
-3. Deploys non-existent streams with proper transaction handling
-4. Tracks deployment results and updates deployment state
-
-The flow uses concurrency control via Prefect tasks and appropriate wait mechanisms
-for transaction confirmations.
+This module defines a Prefect flow for robust, idempotent deployment of primitive streams
+using a batch-oriented, state-aware approach. It supports both detailed state checking
+(for efficiency) and a simple deploy+init mode (for simplicity), and integrates with
+an optional deployment state block to avoid redundant work.
 """
 
 from datetime import datetime, timezone
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
-import pandas as pd
 from pandera.typing import DataFrame
 from prefect import flow, get_run_logger, task
 from prefect.futures import PrefectFuture
@@ -28,19 +21,139 @@ from tsn_adapters.blocks.deployment_state import DeploymentStateBlock
 
 # Import the primitive source descriptor interface and data model
 from tsn_adapters.blocks.primitive_source_descriptor import (
-    PrimitiveSourceDataModel,
     PrimitiveSourcesDescriptorBlock,
 )
 
+# Import state checking task and helpers
+from tsn_adapters.blocks.stream_filtering import (
+    task_get_stream_states_divide_conquer,
+)
+
 # Import TNAccessBlock and task_wait_for_tx so that we can use its waiting functionality.
-from tsn_adapters.blocks.tn_access import TNAccessBlock, task_filter_batch_initialized_streams, task_wait_for_tx
+# Import retry helpers
+from tsn_adapters.blocks.tn_access import (
+    DataFrame,  # Re-import locally if needed
+    StreamLocatorModel,  # Re-import locally if needed
+    TNAccessBlock,
+    create_empty_stream_locator_df,
+    task_wait_for_tx,
+)
 from tsn_adapters.common.trufnetwork.models.tn_models import StreamLocatorModel
-from tsn_adapters.common.trufnetwork.tn import task_deploy_primitive, task_init_stream
+from tsn_adapters.common.trufnetwork.tn import StreamAlreadyExistsError, task_deploy_primitive, task_init_stream
+from tsn_adapters.utils import cast_future
 
 # Configuration constants
 DEFAULT_RETRY_ATTEMPTS = 3
 DEFAULT_RETRY_DELAY_SECONDS = 5
 DEFAULT_BATCH_SIZE = 500
+
+
+# --- Internal Helper Functions for Task Submission ---
+
+@task(
+    name="Check Deployment State",
+    retries=DEFAULT_RETRY_ATTEMPTS,
+    retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS,
+    tags=["deployment-state"],
+)
+def task_check_deployment_state(deployment_state: DeploymentStateBlock, stream_ids: list[str]) -> dict[str, bool]:
+    """
+    Checks which streams are already marked as deployed in the deployment state block.
+
+    Args:
+        deployment_state: Block tracking deployment status.
+        stream_ids: List of stream IDs to check.
+
+    Returns:
+        Dict mapping stream IDs to booleans (True if deployed).
+
+    Why:
+        Used to efficiently skip streams that are already deployed, minimizing unnecessary network calls.
+    """
+    logger = get_run_logger()
+    if not stream_ids:
+        logger.debug("No stream IDs provided to check deployment state.")
+        return {}
+    try:
+        logger.debug(f"Checking deployment state for {len(stream_ids)} streams.")
+        result = deployment_state.check_multiple_streams(stream_ids)
+        logger.debug("Deployment state check complete.")
+        return result
+    except Exception as e:
+        logger.error(f"Failed to check deployment state: {e!s}", exc_info=True)
+        raise e
+
+
+@task(
+    retries=3,
+    retry_delay_seconds=5,
+    name="check_exist_deploy_init",
+    tags=["deploy", "init"],
+)
+def task_check_exist_deploy_init(
+    stream_id: str,
+    tna_block: TNAccessBlock,
+    is_unix: bool = False,
+    force_init_only: bool = False,
+) -> Literal["deployed", "initialized", "failed"]:
+    """
+    Deploys and/or initializes a stream, handling idempotency and state.
+
+    Args:
+        stream_id: Stream identifier.
+        tna_block: TNAccessBlock for network operations.
+        is_unix: Whether the stream uses Unix timestamps.
+        force_init_only: If True, skips deploy and only attempts initialization.
+
+    Returns:
+        "deployed" if deploy+init succeeded,
+        "initialized" if only init was needed (already existed or force_init_only),
+        "failed" if any step failed.
+
+    Why:
+        Ensures streams are always initialized, even if already deployed, and allows
+        callers to skip deploy if prior state checks guarantee it.
+    """
+    logger = get_run_logger()
+    try:
+        if force_init_only:
+            logger.info(f"Stream {stream_id}: force_init_only=True, skipping deploy and attempting initialization.")
+            init_future = task_init_stream.submit(
+                stream_id=stream_id, block=tna_block, return_state=False
+            )
+            init_wait_future = task_wait_for_tx.submit(
+                tx_hash=cast_future(init_future), block=tna_block
+            )
+            _ = init_wait_future.result(raise_on_failure=True)
+            return "initialized"
+        try:
+            deploy_future = task_deploy_primitive.submit(
+                stream_id=stream_id, block=tna_block, is_unix=is_unix
+            )
+            deploy_wait_future = task_wait_for_tx.submit(
+                tx_hash=cast_future(deploy_future), block=tna_block
+            )
+            init_future = task_init_stream.submit(
+                stream_id=stream_id, block=tna_block, return_state=False, wait_for=cast_future(deploy_wait_future)
+            )
+            init_wait_future = task_wait_for_tx.submit(
+                tx_hash=cast_future(init_future), block=tna_block
+            )
+            _ = init_wait_future.result(raise_on_failure=True)
+            return "deployed"
+        except StreamAlreadyExistsError:
+            logger.info(f"Stream {stream_id} already exists, attempting initialization.")
+            init_future = task_init_stream.submit(
+                stream_id=stream_id, block=tna_block, return_state=False
+            )
+            init_wait_future = task_wait_for_tx.submit(
+                tx_hash=cast_future(init_future), block=tna_block
+            )
+            _ = init_wait_future.result(raise_on_failure=True)
+            return "initialized"
+    except Exception as e:
+        logger.error(f"Failed to deploy/init stream {stream_id}: {e}")
+        return "failed"
 
 
 class DeployStreamResult(TypedDict):
@@ -59,144 +172,6 @@ class DeployStreamResults(TypedDict):
 
     deployed_count: int
     skipped_count: int
-
-
-@task(
-    name="Check, Deploy and Initialize Stream",
-    tags=["tn", "tn-write"],
-    retries=DEFAULT_RETRY_ATTEMPTS,
-    retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS,
-)
-def check_deploy_and_init_stream(stream_id: str, tna_block: TNAccessBlock, is_unix: bool = False) -> DeployStreamResult:
-    """
-    Check if a stream exists and deploy/initialize it if it doesn't.
-
-    Args:
-        stream_id: ID of the stream to check and potentially deploy
-        tna_block: TNAccessBlock instance for TN interactions
-        is_unix: Whether to use Unix timestamps (default: False)
-
-    Returns:
-        A DeployStreamResult indicating whether the stream was deployed or skipped
-    """
-    logger = get_run_logger()
-    tn_client = tna_block.client
-    account = tn_client.get_current_account()
-
-    # Skip deployment if stream already exists
-    if tna_block.stream_exists(account, stream_id):
-        logger.debug(f"Stream {stream_id} already exists. Skipping deployment.")
-        return DeployStreamResult(stream_id=stream_id, status="skipped")
-
-    # Deploy the stream if it doesn't exist
-    logger.debug(f"Deploying stream {stream_id}.")
-
-    # Step 1: Create deployment transaction and wait for confirmation
-    tx_deploy = task_deploy_primitive(block=tna_block, stream_id=stream_id, wait=False, is_unix=is_unix)
-    task_wait_for_tx(block=tna_block, tx_hash=tx_deploy)
-    logger.debug(f"Deployed stream {stream_id} (tx: {tx_deploy}).")
-
-    # Step 2: Initialize the stream and wait for confirmation
-    tx_init = task_init_stream(block=tna_block, stream_id=stream_id, wait=False)
-    task_wait_for_tx(block=tna_block, tx_hash=tx_init)
-    logger.debug(f"Initialized stream {stream_id} (tx: {tx_init}).")
-
-    return DeployStreamResult(stream_id=stream_id, status="deployed")
-
-
-@task(
-    name="Filter Already Deployed Streams",
-    retries=DEFAULT_RETRY_ATTEMPTS,
-    retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS,
-)
-def filter_deployed_streams_task(
-    descriptor_df: DataFrame[PrimitiveSourceDataModel], deployment_state: DeploymentStateBlock, tna_block: TNAccessBlock
-) -> DataFrame[PrimitiveSourceDataModel]:
-    """
-    Filter out already deployed streams using deployment state and TN verification.
-
-    A stream is considered already deployed if:
-    1. It is marked as deployed in the DeploymentStateBlock AND
-    2. It actually exists in TN (verified with TN client using batch filtering)
-
-    Args:
-        descriptor_df: DataFrame containing streams to filter
-        deployment_state: Block for tracking deployment state
-        tna_block: Block for TN access to verify stream existence
-
-    Returns:
-        Filtered DataFrame containing only streams that need deployment
-    """
-    logger = get_run_logger()
-
-    # Get all stream IDs from the descriptor
-    all_stream_ids: list[str] = [str(sid) for sid in descriptor_df["stream_id"]]
-
-    if not all_stream_ids:
-        logger.info("No streams to filter, returning empty DataFrame.")
-        return descriptor_df
-
-    # Step 1: Check deployment status in deployment state
-    try:
-        deployed_in_state: dict[str, bool] = deployment_state.check_multiple_streams(all_stream_ids)
-    except Exception as e:
-        logger.warning(f"Failed to check deployment status: {e!s}. Assuming no streams are deployed.", exc_info=True)
-        # If deployment status check fails, assume nothing is deployed
-        deployed_in_state = {stream_id: False for stream_id in all_stream_ids}
-
-    # Step 2: For streams marked as deployed, verify their existence on the network using batch filtering
-    streams_to_verify = [stream_id for stream_id in all_stream_ids if deployed_in_state.get(stream_id, False)]
-
-    # Track streams that are verified to exist on the network
-    streams_verified_on_network: set[str] = set()
-
-    if streams_to_verify:
-        logger.debug(f"Verifying existence of {len(streams_to_verify)} streams marked as deployed using batch task...")
-        try:
-            account = tna_block.client.get_current_account()
-            # Create DataFrame for batch verification task
-            locators_to_verify_df = DataFrame[StreamLocatorModel](
-                pd.DataFrame({"stream_id": streams_to_verify, "data_provider": account})
-            )
-
-            # Submit the batch verification task
-            filter_future = task_filter_batch_initialized_streams.submit(
-                block=tna_block, stream_locators=locators_to_verify_df
-            )
-            verified_locators_df = filter_future.result()
-
-            # Update the set of verified streams
-            streams_verified_on_network = set(verified_locators_df["stream_id"].tolist())
-            logger.debug(
-                f"Batch verification complete: {len(streams_verified_on_network)} streams confirmed to exist on the network."
-            )
-
-        except Exception as e:
-            # If batch verification fails, log a warning and assume none of the streams_to_verify exist on the network
-            # This ensures we attempt to deploy them rather than incorrectly skipping them.
-            logger.warning(
-                f"Batch verification of stream existence failed: {e!s}. "
-                f"Proceeding assuming streams marked deployed might not exist.",
-                exc_info=True,
-            )
-            streams_verified_on_network = set()
-
-    # Keep streams that need deployment
-    # (Not marked as deployed or not verified on network)
-    streams_to_deploy = [stream_id for stream_id in all_stream_ids if stream_id not in streams_verified_on_network]
-
-    # Filter the DataFrame to keep only streams that need deployment
-    filtered_df = descriptor_df[descriptor_df["stream_id"].isin(streams_to_deploy)]
-
-    # Log summary
-    filtered_count = len(all_stream_ids) - len(filtered_df)
-    logger.info(
-        f"Filtered {filtered_count} streams that are already deployed. "
-        f"{len(filtered_df)} streams remain for processing."
-    )
-
-    # Return filtered DataFrame
-    return filtered_df
 
 
 @task(name="Mark Batch as Deployed", retries=DEFAULT_RETRY_ATTEMPTS, retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS)
@@ -233,209 +208,280 @@ def mark_batch_deployed_task(
         logger.warning(f"Failed to mark streams as deployed: {e!s}. Continuing with flow execution.", exc_info=True)
 
 
-def _create_stream_batches(stream_ids: list[str], batch_size: int, start_from_batch: int) -> list[list[str]]:
-    """
-    Split a list of stream IDs into batches of specified size.
-
-    Args:
-        stream_ids: List of stream IDs to batch
-        batch_size: Maximum number of streams per batch
-        start_from_batch: Index of the first batch to process
-
-    Returns:
-        List of batches, where each batch is a list of stream IDs
-    """
-    # Create batches of specified size
-    all_batches = [stream_ids[i : i + batch_size] for i in range(0, len(stream_ids), batch_size)]
-
-    # Return only batches starting from the specified index
-    return all_batches[start_from_batch:]
-
-
-def _process_deployment_results(
-    deployment_results: list[DeployStreamResult],
-    deployment_state: Optional[DeploymentStateBlock] = None,
-    batch_timestamp: Optional[datetime] = None,
-) -> None:
-    """
-    Process deployment results and update deployment state if provided.
-
-    Args:
-        deployment_results: List of individual stream deployment results
-        deployment_state: Optional block for tracking deployment state
-        batch_timestamp: Timestamp to use for this batch (required if deployment_state is provided)
-    """
-    logger = get_run_logger()
-
-    # Skip if no deployment state provided
-    if deployment_state is None:
-        return
-
-    # We need a timestamp to mark streams as deployed
-    if batch_timestamp is None:
-        batch_timestamp = datetime.now(timezone.utc)
-
-    # Collect successfully deployed stream IDs
-    deployed_stream_ids = [result["stream_id"] for result in deployment_results if result["status"] == "deployed"]
-
-    # Skip if no streams were deployed
-    if not deployed_stream_ids:
-        return
-
-    # Mark batch as deployed in deployment state
-    try:
-        mark_batch_deployed_task.submit(
-            stream_ids=deployed_stream_ids, deployment_state=deployment_state, timestamp=batch_timestamp
-        )
-    except Exception as e:
-        logger.warning(f"Failed to submit marking task: {e!s}. Continuing with next batch.")
-
-
 @flow(name="Stream Deployment Flow")
 def deploy_streams_flow(
     psd_block: PrimitiveSourcesDescriptorBlock,
     tna_block: TNAccessBlock,
+    check_stream_state: bool = True,
     is_unix: bool = False,
+    max_filter_size: int = 1000,
     batch_size: int = DEFAULT_BATCH_SIZE,
     start_from_batch: int = 0,
     deployment_state: Optional[DeploymentStateBlock] = None,
 ) -> DeployStreamResults:
     """
-    Deploy primitive streams from a descriptor, with optional deployment state tracking.
-
-    This flow handles the entire stream deployment process:
-    1. Retrieves stream descriptors from the provided block
-    2. Filters out already deployed streams (if deployment_state is provided)
-    3. Deploys streams in batches with concurrency control
-    4. Updates deployment state for successfully deployed streams
-    5. Returns summary statistics of deployed and skipped streams
+    Deploys primitive streams in batches, using state-aware logic for idempotency and efficiency.
 
     Args:
-        psd_block: Block providing the stream descriptors
-        tna_block: Block for TN interactions
-        is_unix: Whether to use Unix timestamps (default: False)
-        batch_size: Number of streams to deploy in each batch (default: 500)
-        start_from_batch: Batch number to start from (default: 0)
-        deployment_state: Optional block for tracking deployment state
+        psd_block: Provides stream descriptors.
+        tna_block: Truflation Network access block.
+        check_stream_state: If True, checks each stream's detailed state against TN to minimize unnecessary deploy/init.
+        is_unix: Whether streams use Unix timestamps.
+        batch_size: Number of streams per batch.
+        start_from_batch: Batch index to start from.
+        deployment_state: Optional block to track and skip already deployed streams.
 
     Returns:
-        Statistics on deployed and skipped streams
+        DeployStreamResults: Counts of deployed and skipped streams.
+
+    Why:
+        This flow ensures robust, efficient, and idempotent deployment of streams, supporting both
+        high-throughput and fine-grained state management scenarios.
     """
     logger = get_run_logger()
-    stream_type = "Unix" if is_unix else "Date"
+    start_time = datetime.now(timezone.utc)
+    logger.info(f"Starting stream deployment flow at {start_time.isoformat()}...")
     logger.info(
-        f"Starting stream deployment flow. Batch size: {batch_size}, Start batch: {start_from_batch},  Stream type: {stream_type}."
+        f"Parameters: check_stream_state={check_stream_state}, is_unix={is_unix}, "
+        f"batch_size={batch_size}, start_from_batch={start_from_batch}, "
+        f"deployment_state provided: {deployment_state is not None}"
     )
 
-    # SECTION 1: Retrieve and validate descriptor DataFrame
+    # Retrieve all stream descriptors to process.
     try:
-        descriptor_df: DataFrame[PrimitiveSourceDataModel] = psd_block.get_descriptor()
-    except Exception as e:
-        logger.error(f"Failed to retrieve stream descriptors: {e!s}", exc_info=True)
-        raise  # Cannot proceed without descriptors
-
-    if descriptor_df.empty:
-        logger.info("No stream descriptors found. Exiting flow.")
-        return DeployStreamResults(deployed_count=0, skipped_count=0)
-
-    # Track original stream count for calculating filtered count
-    original_stream_count = len(descriptor_df)
-    logger.info(f"Retrieved {original_stream_count} stream descriptors.")
-    filtered_by_state_count = 0
-
-    # SECTION 2: Filter already deployed streams if deployment state is provided
-    if deployment_state is not None:
-        logger.info("Deployment state block provided. Filtering already deployed streams...")
-        try:
-            filter_future = filter_deployed_streams_task.submit(
-                descriptor_df=descriptor_df, deployment_state=deployment_state, tna_block=tna_block
-            )
-            descriptor_df = filter_future.result()  # Wait for filtering to complete
-            # Calculate how many streams were filtered out
-            filtered_by_state_count = original_stream_count - len(descriptor_df)
-        except Exception as e:
-            logger.error(f"Failed during stream filtering: {e!s}. Aborting flow.", exc_info=True)
-            raise  # Stop flow if filtering fails
-
-        # Exit early if all streams are already deployed
+        descriptor_df = psd_block.get_descriptor()
         if descriptor_df.empty:
-            logger.info("All streams are already deployed. Exiting flow.")
-            return DeployStreamResults(deployed_count=0, skipped_count=original_stream_count)
-    else:
-        logger.info("No deployment state block provided. Processing all streams from descriptor.")
+            logger.info("No primitive sources found in the descriptor block. Exiting.")
+            return DeployStreamResults(deployed_count=0, skipped_count=0)
+        logger.info(f"Retrieved {len(descriptor_df)} stream descriptors.")
+    except Exception as e:
+        logger.error(f"Failed to retrieve primitive sources: {e!s}", exc_info=True)
+        # Cannot proceed without descriptors
+        raise e
 
-    # SECTION 3: Prepare for batch processing
-    # Extract stream IDs from filtered descriptor and ensure proper typing
-    stream_ids: list[str] = [str(sid) for sid in descriptor_df["stream_id"]]
+    total_streams = len(descriptor_df)
+    total_deployed = 0
+    total_skipped_state = 0
+    total_skipped_already_initialized = 0 
 
-    logger.info(f"Found {len(stream_ids)} stream descriptors to process.")
+    num_batches = (len(descriptor_df) + batch_size - 1) // batch_size
+    logger.info(f"Processing {total_streams} streams in {num_batches} batches of size {batch_size}.")
 
-    # Create batches for processing
-    batches = _create_stream_batches(stream_ids, batch_size, start_from_batch)
-    total_batches = len(batches)
+    # 3. Iterate through batches
+    for i in range(start_from_batch, num_batches):
+        batch_start_time = datetime.now(timezone.utc)
+        logger.info(f"Processing batch {i+1}/{num_batches}...")
 
-    # Check if start_from_batch is out of range
-    if start_from_batch >= total_batches and total_batches > 0:
-        logger.warning(
-            f"Start batch {start_from_batch} is out of range (total batches: {total_batches}). "
-            f"No batches will be processed."
+        # Get the current batch DataFrame
+        start_index = i * batch_size
+        end_index = start_index + batch_size
+        current_batch_df = descriptor_df.iloc[start_index:end_index].copy()
+        batch_stream_ids = current_batch_df["stream_id"].tolist()
+        logger.debug(
+            f"Batch {i+1} contains {len(current_batch_df)} streams: {batch_stream_ids[:5]}{'...' if len(batch_stream_ids) > 5 else ''}"
         )
-        return DeployStreamResults(deployed_count=0, skipped_count=filtered_by_state_count)
-    elif start_from_batch > 0:
-        logger.info(f"Starting processing from batch {start_from_batch+1}/{total_batches}.")
 
-    # SECTION 4: Process batches
-    all_deployment_results: list[DeployStreamResult] = []
+        # Initialize batch-specific variables
+        filtered_batch_df = current_batch_df  # Start with the full batch
+        skipped_in_batch_state = 0
+        successfully_processed_in_batch_ids: list[str] = []  # To track success for marking state later
 
-    for batch_index, batch in enumerate(batches, start=start_from_batch):
-        # Log batch progress
-        logger.info(f"Processing batch {batch_index + 1}/{total_batches} with {len(batch)} streams.")
-
-        # Process each stream in the batch, in parallel
-        batch_futures: dict[str, PrefectFuture[DeployStreamResult]] = {}
-        for stream_id in batch:
-            # Submit the task with the new name
-            future = check_deploy_and_init_stream.submit(stream_id=stream_id, tna_block=tna_block, is_unix=is_unix)
-            batch_futures[stream_id] = future
-
-        # Collect batch results
-        batch_results: list[DeployStreamResult] = []
-        for stream_id, future in batch_futures.items():
-            try:
-                result = future.result()
-                batch_results.append(result)
-            except Exception as e:
-                logger.error(f"Task failed for stream {stream_id} even after retries: {e!s}", exc_info=True)
-                # Continue with other streams even if one fails
-
-        # Add to overall results
-        all_deployment_results.extend(batch_results)
-
-        # Update deployment state if provided
+        # Batch-Level State Block Filtering:
+        # Skip streams already marked as deployed in the deployment state block to avoid redundant work.
         if deployment_state is not None:
-            batch_timestamp = datetime.now(timezone.utc)
-            _process_deployment_results(batch_results, deployment_state, batch_timestamp)
+            logger.debug(f"Checking deployment state for batch {i+1}...")
+            deployed_status_dict: dict[str, bool] = {}
+            try:
+                deployed_status_dict = task_check_deployment_state(
+                    deployment_state=deployment_state, stream_ids=batch_stream_ids
+                )
+                logger.debug(f"State check successful for batch {i+1}.")
 
-        logger.info(f"Finished processing batch {batch_index + 1}/{total_batches}.")
+                # Filter out streams already marked as deployed
+                already_deployed_ids = {stream_id for stream_id, deployed in deployed_status_dict.items() if deployed}
 
-    # SECTION 5: Aggregate and summarize results
-    deployed_results = [result for result in all_deployment_results if result["status"] == "deployed"]
-    skipped_during_deploy = [result for result in all_deployment_results if result["status"] == "skipped"]
+                if already_deployed_ids:
+                    initial_batch_count = len(filtered_batch_df)
+                    filtered_batch_df = filtered_batch_df[~filtered_batch_df["stream_id"].isin(already_deployed_ids)]
+                    skipped_in_batch_state = initial_batch_count - len(filtered_batch_df)
+                    total_skipped_state += skipped_in_batch_state
+                    logger.info(
+                        f"Batch {i+1}: Filtered out {skipped_in_batch_state} streams based on deployment state. "
+                        f"{len(filtered_batch_df)} streams remain for processing in this batch."
+                    )
+                else:
+                    logger.debug(f"Batch {i+1}: No streams were marked as deployed in the state block.")
 
-    # Calculate summary statistics
-    deployed_count = len(deployed_results)
-    skipped_during_processing = len(skipped_during_deploy)
-    total_skipped_count = skipped_during_processing + filtered_by_state_count
+            except Exception as e:
+                logger.warning(
+                    f"Failed to check deployment state for batch {i+1} after retries: {e!s}. "
+                    f"Proceeding without state filtering for this batch.",
+                    exc_info=True,
+                )
+                # Keep filtered_batch_df as the original current_batch_df
 
-    # Prepare final results
-    summary_results = DeployStreamResults(deployed_count=deployed_count, skipped_count=total_skipped_count)
+        # Check if any streams remain in the batch after filtering
+        if filtered_batch_df.empty:
+            logger.info(
+                f"Batch {i+1}: All streams were filtered out by the deployment state block. Skipping to next batch."
+            )
+            continue
 
-    # Log summary
+        # --- Conditional Stream Processing based on check_stream_state ---
+        final_wait_futures_map: dict[str, PrefectFuture[Any]] = {}
+
+        if check_stream_state:
+            logger.info(f"Batch {i+1}: Processing with check_stream_state=True (Detailed check)")
+            try:
+                # Build StreamLocatorModel DataFrame for the batch.
+                if not filtered_batch_df.empty:
+                    batch_locators_df = DataFrame[StreamLocatorModel](
+                        {
+                            "stream_id": filtered_batch_df["stream_id"],
+                            "data_provider": tna_block.current_account,
+                        }
+                    )
+                else:
+                    batch_locators_df = create_empty_stream_locator_df()
+
+                if not batch_locators_df.empty:
+                    logger.debug(
+                        f"Batch {i+1}: Calling task_get_stream_states_divide_conquer for {len(batch_locators_df)} streams."
+                    )
+                    # Partition streams by detailed state to minimize unnecessary deploy/init.
+                    stream_states = task_get_stream_states_divide_conquer(
+                        block=tna_block,
+                        stream_locators=batch_locators_df,
+                        max_filter_size=max_filter_size,
+                    )
+                    logger.debug(
+                        f"Batch {i+1}: State check result: "
+                        f"NonDeployed={len(stream_states['non_deployed'])}, "
+                        f"DeployedButNotInit={len(stream_states['deployed_but_not_initialized'])}, "
+                        f"DeployedAndInit={len(stream_states['deployed_and_initialized'])}"
+                    )
+
+                    # Count streams already deployed and initialized, so we can report them as skipped.
+                    deployed_and_init_df = stream_states["deployed_and_initialized"]
+                    skipped_in_batch_already_initialized = len(deployed_and_init_df)
+                    total_skipped_already_initialized += skipped_in_batch_already_initialized
+
+                    # Submit deploy+init for non-deployed streams.
+                    non_deployed_df = stream_states["non_deployed"]
+                    if not non_deployed_df.empty:
+                        logger.info(
+                            f"Batch {i+1}: Submitting deploy+init for {len(non_deployed_df)} non-deployed streams."
+                        )
+                        for stream_id in non_deployed_df["stream_id"].tolist():
+                            final_wait_future = task_check_exist_deploy_init.submit(
+                                stream_id=stream_id,
+                                tna_block=tna_block,
+                                is_unix=is_unix,
+                                force_init_only=False,
+                            )
+                            final_wait_futures_map[stream_id] = final_wait_future
+
+                    # Submit init only for deployed but not initialized streams.
+                    dep_not_init_df = stream_states["deployed_but_not_initialized"]
+                    if not dep_not_init_df.empty:
+                        logger.info(
+                            f"Batch {i+1}: Submitting init for {len(dep_not_init_df)} deployed but not initialized streams."
+                        )
+                        for stream_id in dep_not_init_df["stream_id"].tolist():
+                            final_wait_future = task_check_exist_deploy_init.submit(
+                                stream_id=stream_id,
+                                tna_block=tna_block,
+                                is_unix=is_unix,
+                                force_init_only=True,
+                            )
+                            final_wait_futures_map[stream_id] = final_wait_future
+
+                else:
+                    logger.info(f"Batch {i+1}: No streams remaining in batch after state filtering for detailed check.")
+
+            except Exception as state_check_err:
+                logger.error(
+                    f"Batch {i+1}: Failed during detailed stream state check (task_get_stream_states_divide_conquer): {state_check_err!s}. Skipping processing for this batch.",
+                    exc_info=True,
+                )
+
+        else:
+            logger.info(f"Batch {i+1}: Processing with check_stream_state=False (Direct deploy/init)")
+            logger.info(f"Batch {i+1}: Submitting direct deploy/init tasks for {len(filtered_batch_df)} streams.")
+            for _, row in filtered_batch_df.iterrows():
+                stream_id = row["stream_id"]
+                final_wait_future = task_check_exist_deploy_init.submit(
+                    stream_id=stream_id,
+                    tna_block=tna_block,
+                    is_unix=is_unix,
+                    force_init_only=False,
+                )
+                final_wait_futures_map[stream_id] = final_wait_future
+
+        # Unified Waiting Logic:
+        # Wait for all submitted deploy/init tasks to complete, and track which streams succeeded.
+        if final_wait_futures_map:
+            logger.info(f"Batch {i+1}: Waiting for results of {len(final_wait_futures_map)} submitted tasks...")
+            stream_final_status: dict[str, bool] = {}
+
+            for stream_id, future in final_wait_futures_map.items():
+                try:
+                    result = future.result(raise_on_failure=True)
+                    if result in ("deployed", "initialized"):
+                        stream_final_status[stream_id] = True
+                        logger.debug(f"Batch {i+1}: Stream {stream_id} processed successfully ({result}).")
+                    else:
+                        stream_final_status[stream_id] = False
+                        logger.error(f"Batch {i+1}: Stream {stream_id} failed with status: {result}")
+                except Exception as wait_err:
+                    logger.error(f"Batch {i+1}: Failed processing stream {stream_id}: {wait_err!s}", exc_info=False)
+                    stream_final_status[stream_id] = False
+
+            successfully_processed_in_batch_ids = [sid for sid, success in stream_final_status.items() if success]
+            failed_count_batch = len(final_wait_futures_map) - len(successfully_processed_in_batch_ids)
+            logger.info(f"Batch {i+1}: Processing complete. Successfully processed: {len(successfully_processed_in_batch_ids)}, Failed: {failed_count_batch}")
+        else:
+            logger.info(f"Batch {i+1}: No tasks submitted or all submission failed.")
+
+        # Mark Batch Deployed:
+        # Update the deployment state block for all streams successfully processed in this batch.
+        if deployment_state and successfully_processed_in_batch_ids:
+            logger.debug(
+                f"Batch {i+1}: Marking {len(successfully_processed_in_batch_ids)} streams as deployed in state block."
+            )
+            current_time = datetime.now(timezone.utc)
+            mark_batch_deployed_task.submit(
+                stream_ids=successfully_processed_in_batch_ids,
+                deployment_state=deployment_state,
+                timestamp=current_time,
+            )
+        elif deployment_state:
+            logger.debug(f"Batch {i+1}: No streams successfully processed in this batch, skipping state marking.")
+
+        # Aggregate results for the batch:
+        # Update running totals for deployed and skipped streams.
+        deployed_in_batch = len(successfully_processed_in_batch_ids)
+        total_deployed += deployed_in_batch
+        logger.info(
+            f"Batch {i+1} aggregated results - Deployed/Initialized this batch: {deployed_in_batch}, Skipped by State: {skipped_in_batch_state}"
+        )
+
+        batch_end_time = datetime.now(timezone.utc)
+        batch_duration = batch_end_time - batch_start_time
+        logger.info(f"Finished processing batch {i+1}/{num_batches}. Duration: {batch_duration}")
+
+    # Final Result Aggregation:
+    # The final skipped count includes those skipped by state block and those skipped by TSN checks (already deployed+initialized).
+    final_skipped_count = total_skipped_state + total_skipped_already_initialized
+
+    end_time = datetime.now(timezone.utc)
+    duration = end_time - start_time
+    logger.info(f"Stream deployment flow finished at {end_time.isoformat()}. Duration: {duration}.")
     logger.info(
-        f"Deployment summary: {summary_results['deployed_count']} deployed, "
-        f"{summary_results['skipped_count']} skipped "
-        f"({filtered_by_state_count} filtered by deployment state, "
-        f"{skipped_during_processing} skipped during processing)."
+        f"Flow Summary: Deployed/Initialized={total_deployed}, "
+        f"Skipped(StateBlock)={total_skipped_state}, "
+        f"Skipped(AlreadyInitialized)={total_skipped_already_initialized}, "
+        f"Total Skipped={final_skipped_count} (Total Initially={total_streams})"
     )
 
-    return summary_results
+    return DeployStreamResults(deployed_count=total_deployed, skipped_count=final_skipped_count)

--- a/src/tsn_adapters/utils/__init__.py
+++ b/src/tsn_adapters/utils/__init__.py
@@ -2,11 +2,12 @@ from .create_empty_df import create_empty_df
 from .logging import get_logger_safe
 from .deroutine import deroutine, force_sync
 from .time_utils import convert_date_str_series_to_unix_ts
-
+from .cast_future import cast_future
 __all__ = [
     "create_empty_df", 
     "get_logger_safe", 
     "deroutine",
     "force_sync",
     "convert_date_str_series_to_unix_ts",
+    "cast_future",
 ]

--- a/tests/argentina/flows/test_full_pipeline_integration.py
+++ b/tests/argentina/flows/test_full_pipeline_integration.py
@@ -19,7 +19,7 @@ from prefect_aws import S3Bucket
 import pytest
 from sqlalchemy import text
 from sqlalchemy.orm import Session as SqlaSession
-from src.tsn_adapters.flows.stream_deploy_flow import deploy_streams_flow
+from tsn_adapters.flows.stream_deploy_flow import deploy_streams_flow
 from tests.argentina.helpers import upload_df_to_s3_csv_zip
 
 from tsn_adapters.blocks.models.sql_models import primitive_sources_table  # For DB verification

--- a/tests/blocks/test_deployment_state.py
+++ b/tests/blocks/test_deployment_state.py
@@ -6,7 +6,7 @@ import io
 
 from prefect_aws import S3Bucket  # type: ignore
 
-from src.tsn_adapters.blocks.deployment_state import S3DeploymentStateBlock
+from tsn_adapters.blocks.deployment_state import S3DeploymentStateBlock
 
 
 @pytest.fixture
@@ -172,7 +172,7 @@ def test_update_deployment_states_valid(s3_block: S3DeploymentStateBlock) -> Non
         'deployment_timestamp': [timestamp, timestamp]
     }
     df = pd.DataFrame(data)
-    from src.tsn_adapters.blocks.deployment_state import DataFrame, DeploymentStateModel
+    from tsn_adapters.blocks.deployment_state import DataFrame, DeploymentStateModel
     states = DataFrame[DeploymentStateModel](df)
     
     # Update the states
@@ -191,7 +191,7 @@ def test_update_deployment_states_valid(s3_block: S3DeploymentStateBlock) -> Non
 def test_update_deployment_states_empty(s3_block: S3DeploymentStateBlock) -> None:
     # Create an empty DataFrame with the correct schema
     df = pd.DataFrame(columns=['stream_id', 'deployment_timestamp'])
-    from src.tsn_adapters.blocks.deployment_state import DataFrame, DeploymentStateModel
+    from tsn_adapters.blocks.deployment_state import DataFrame, DeploymentStateModel
     states = DataFrame[DeploymentStateModel](df)
     
     # Update with empty states

--- a/tests/blocks/test_prefect_task_error_catch.py
+++ b/tests/blocks/test_prefect_task_error_catch.py
@@ -1,0 +1,34 @@
+"""
+Minimal test to verify a Prefect task catches an exception from a mock and emits a log message.
+"""
+from unittest.mock import patch
+from prefect import task
+import logging
+import pytest
+
+class MyCustomError(Exception):
+    pass
+
+# The function to be mocked
+
+@task(retries=1)
+def may_raise():
+    return "ok"
+
+# The Prefect task that catches the error
+@task(retries=1)
+def task_catch_error():
+    logger = logging.getLogger("test_logger")
+    try:
+        return may_raise()
+    except MyCustomError:
+        logger.info("Caught MyCustomError inside the task!")
+        return "caught"
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_prefect_task_catches_error_and_logs(caplog: pytest.LogCaptureFixture):
+    with patch(__name__ + ".may_raise", side_effect=MyCustomError("fail")):
+        with caplog.at_level(logging.INFO, logger="test_logger"):
+            result = task_catch_error()
+            assert result == "caught"
+            assert any("Caught MyCustomError inside the task!" in r.getMessage() for r in caplog.records) 

--- a/tests/blocks/test_sql_source_descriptor.py
+++ b/tests/blocks/test_sql_source_descriptor.py
@@ -11,9 +11,9 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
-from src.tsn_adapters.blocks.models import primitive_sources_table  # Corrected import path
-from src.tsn_adapters.blocks.primitive_source_descriptor import PrimitiveSourceDataModel
-from src.tsn_adapters.blocks.sql_source_descriptor import SqlAlchemySourceDescriptor
+from tsn_adapters.blocks.models import primitive_sources_table  # Corrected import path
+from tsn_adapters.blocks.primitive_source_descriptor import PrimitiveSourceDataModel
+from tsn_adapters.blocks.sql_source_descriptor import SqlAlchemySourceDescriptor
 from tests.fixtures.test_sql import DB_CONFIG
 
 # --- Fixtures ---

--- a/tests/blocks/test_stream_deployment_initialization.py
+++ b/tests/blocks/test_stream_deployment_initialization.py
@@ -1,8 +1,12 @@
+import logging
 import pytest
 from datetime import datetime
+from unittest.mock import MagicMock, patch
 
-from tsn_adapters.blocks.tn_access import TNAccessBlock
+from tsn_adapters.blocks.tn_access import StreamAlreadyExistsError, TNAccessBlock
 from trufnetwork_sdk_py.utils import generate_stream_id
+from tsn_adapters.common.trufnetwork.tn import task_deploy_primitive
+import trufnetwork_sdk_c_bindings.exports as truf_sdk
 
 
 @pytest.fixture
@@ -71,4 +75,53 @@ def test_get_stream_type(tn_block: TNAccessBlock, test_stream_id: str):
     
     # Clean up: destroy the stream
     destroy_tx = tn_block.destroy_stream(test_stream_id, wait=True)
-    assert destroy_tx is not None, "Stream destruction should return a transaction hash" 
+    assert destroy_tx is not None, "Stream destruction should return a transaction hash"
+
+
+# --- Tests for task_deploy_primitive --- #
+
+def test_task_deploy_primitive_success():
+    """Test task_deploy_primitive successfully deploys."""
+    mock_block = MagicMock(spec=TNAccessBlock)
+    mock_block.deploy_stream.return_value = "dummy_tx_hash"
+
+    result = task_deploy_primitive.fn(block=mock_block, stream_id="test_stream_success")
+
+    mock_block.deploy_stream.assert_called_once_with(
+        stream_id="test_stream_success",
+        wait=True, # Default value
+        stream_type=truf_sdk.StreamTypePrimitive # Default value for is_unix=False
+    )
+    assert result == "dummy_tx_hash"
+
+
+def test_task_deploy_primitive_already_exists(caplog: pytest.LogCaptureFixture):
+    """Test task_deploy_primitive handles 'already exists' error by raising StreamAlreadyExistsError."""
+    mock_block = MagicMock(spec=TNAccessBlock)
+    # Simulate the specific error message
+    mock_block.deploy_stream.side_effect = StreamAlreadyExistsError("test_stream_exists")
+
+    # Expect the custom exception
+    with pytest.raises(StreamAlreadyExistsError) as excinfo:
+        with caplog.at_level(logging.INFO):
+            task_deploy_primitive.fn(block=mock_block, stream_id="test_stream_exists")
+
+    # Assert the exception has the correct stream ID
+    assert excinfo.value.stream_id == "test_stream_exists"
+    mock_block.deploy_stream.assert_called_once()
+    assert "Stream test_stream_exists already exists. Skipping deployment." in caplog.text
+
+
+def test_task_deploy_primitive_other_error(caplog: pytest.LogCaptureFixture):
+    """Test task_deploy_primitive re-raises other errors."""
+    mock_block = MagicMock(spec=TNAccessBlock)
+    mock_block.deploy_stream.side_effect = ValueError("Some other deployment error")
+
+    with pytest.raises(ValueError, match="Some other deployment error"):
+        with caplog.at_level(logging.ERROR):
+            task_deploy_primitive.fn(block=mock_block, stream_id="test_stream_other_error")
+
+    mock_block.deploy_stream.assert_called_once()
+    assert "Error deploying stream test_stream_other_error: Some other deployment error" in caplog.text
+
+# --- Existing integration tests below --- # 

--- a/tests/blocks/test_stream_filtering.py
+++ b/tests/blocks/test_stream_filtering.py
@@ -1,22 +1,38 @@
 """Unit tests for the stream filtering functionality."""
 
-from unittest.mock import MagicMock, Mock, patch
+# import logging # Removed unused import
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
-from src.tsn_adapters.blocks.stream_filtering import (
+from prefect import flow
+import pytest
+from tsn_adapters.blocks.stream_filtering import (
     DivideAndConquerResult,
+    StreamStatesResult,
     batch_method_filter_streams,
     combine_divide_conquer_results,
     fallback_method_filter_streams,
     task_filter_streams_divide_conquer,
+    task_get_stream_states_divide_conquer,
 )
-from src.tsn_adapters.blocks.tn_access import (
+from tsn_adapters.blocks.tn_access import (
     MetadataProcedureNotFoundError,
     StreamLocatorModel,
-    TNAccessBlock,
     convert_to_typed_df,
     create_empty_df,
+    create_empty_stream_locator_df,
 )
+from tests.utils.fake_tn_access import FakeTNAccessBlock
+
+
+@pytest.fixture(autouse=True)
+def patch_stream_filtering_tasks(monkeypatch: Any):
+    from tsn_adapters.blocks import stream_filtering
+
+    monkeypatch.setattr(stream_filtering.task_get_stream_states_divide_conquer, "retries", 0)
+    monkeypatch.setattr(stream_filtering.task_filter_batch_initialized_streams, "retries", 0)
+    monkeypatch.setattr(stream_filtering.task_filter_streams_divide_conquer, "retries", 0)
 
 
 class TestStreamFiltering:
@@ -24,8 +40,8 @@ class TestStreamFiltering:
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.mock_block = MagicMock(spec=TNAccessBlock)
-        self.mock_logger = MagicMock()
+        from tests.utils.fake_tn_access import FakeTNAccessBlock
+        self.mock_block = FakeTNAccessBlock()
 
         # Create test data
         self.stream_data = pd.DataFrame(
@@ -35,6 +51,7 @@ class TestStreamFiltering:
 
         # Sample results
         self.empty_df = create_empty_df(["data_provider", "stream_id"])
+        self.empty_typed_df = create_empty_stream_locator_df()
         self.sample_result = DivideAndConquerResult(
             initialized_streams=convert_to_typed_df(
                 pd.DataFrame({"data_provider": ["provider1"], "stream_id": ["stream1"]}), StreamLocatorModel
@@ -46,51 +63,58 @@ class TestStreamFiltering:
             fallback_used=False,
         )
 
-    @patch("src.tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
+    @patch("tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
     def test_fallback_method_filter_streams(self, mock_batch_init: MagicMock):
-        """Test fallback_method_filter_streams."""
-        # Mock stream_exists on the block instance directly
-        # Simulate first stream exists, second does not
-        self.mock_block.stream_exists.side_effect = [True, False]
+        """
+        Test fallback_method_filter_streams using FakeTNAccessBlock state for stream_exists,
+        but mocking the task called internally.
+        
+        This test simulates a scenario where only 'stream1' is deployed and initialized,
+        and 'stream2' does not exist. The intent is to verify that the fallback method
+        correctly partitions initialized and uninitialized streams based on the block's state.
+        """
+        self.mock_block.reset()
+        self.mock_block.set_deployed_streams({"stream1"})
+        self.mock_block.set_initialized_streams({"stream1"})
 
-        # Mock the subsequent batch initialization check on the streams found to exist
-        expected_df = pd.DataFrame([{"data_provider": "provider1", "stream_id": "stream1"}])
-        mock_batch_init.return_value = expected_df
+        # Mock the return value of the internal task call
+        mock_batch_init.return_value = convert_to_typed_df(
+            pd.DataFrame([{"data_provider": "provider1", "stream_id": "stream1"}]),
+            StreamLocatorModel
+        )
 
-        # Call the function
-        # Process only the first two locators for this test case
-        result = fallback_method_filter_streams(self.mock_block, self.stream_locators.iloc[:2], 1, self.mock_logger)
+        # Only the first two locators are processed for this test case
+        result = fallback_method_filter_streams(self.mock_block, self.stream_locators.iloc[:2], 1)
 
-        # Verify stream_exists was called twice
-        assert self.mock_block.stream_exists.call_count == 2
-        # Verify batch init was called once
+        # Verify the mock was called correctly
         mock_batch_init.assert_called_once()
+        called_args = mock_batch_init.call_args[0]
+        assert called_args[0] == self.mock_block
+        pd.testing.assert_frame_equal(called_args[1], self.stream_locators.iloc[[0]]) # Should be called only with existing stream1
 
-        # Check that the right streams were passed to task_filter_batch_initialized_streams
-        # We don't need exact DataFrame comparison which can be tricky with conversions
-        called_stream_locators = mock_batch_init.call_args[1]["stream_locators"]
-        assert len(called_stream_locators) == 1
-        assert called_stream_locators.iloc[0]["data_provider"] == "provider1"
-        assert called_stream_locators.iloc[0]["stream_id"] == "stream1"
-
-        # Verify the result
+        # The result should reflect that 'stream1' is initialized and 'stream2' is uninitialized
         assert not result["initialized_streams"].empty
         assert not result["uninitialized_streams"].empty
         assert result["initialized_streams"].iloc[0]["stream_id"] == "stream1"
-        assert result["uninitialized_streams"].iloc[0]["stream_id"] == "stream2"  # Stream 2 didn't exist
+        assert result["uninitialized_streams"].iloc[0]["stream_id"] == "stream2"
         assert result["depth"] == 1
         assert result["fallback_used"] is True
 
-    @patch("src.tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
-    def test_batch_method_filter_streams_success(self, mock_batch_init: MagicMock):
-        """Test batch_method_filter_streams when successful."""
-        # Mock batch initialization check
-        mock_batch_init.return_value = [{"data_provider": "provider1", "stream_id": "stream1"}]
+    def test_batch_method_filter_streams_success(self):
+        """
+        Test batch_method_filter_streams when the batch call succeeds.
+        
+        This test configures the FakeTNAccessBlock so that only 'stream1' is both deployed and initialized.
+        The intent is to verify that the batch method correctly identifies initialized and uninitialized streams.
+        """
+        self.mock_block.reset()
+        # Only 'stream1' is deployed and initialized; others are deployed but not initialized
+        self.mock_block.set_deployed_streams({"stream1", "stream2", "stream3"})
+        self.mock_block.set_initialized_streams({"stream1"})
 
-        # Call the function
-        result = batch_method_filter_streams(self.mock_block, self.stream_locators, 1, self.mock_logger)
+        result = batch_method_filter_streams(self.mock_block, self.stream_locators, 1)
 
-        # Verify the result
+        # The result should reflect that only 'stream1' is initialized
         assert result is not None
         assert not result["initialized_streams"].empty
         assert not result["uninitialized_streams"].empty
@@ -98,19 +122,21 @@ class TestStreamFiltering:
         assert result["depth"] == 1
         assert result["fallback_used"] is False
 
-    @patch("src.tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
-    def test_batch_method_filter_streams_metadata_error(self, mock_batch_init: MagicMock):
-        """Test batch_method_filter_streams with metadata procedure not found error."""
+    def test_batch_method_filter_streams_metadata_error(self):
+        """
+        Test batch_method_filter_streams when the batch call raises MetadataProcedureNotFoundError.
+        
+        This test configures the FakeTNAccessBlock to raise the error on batch init, simulating a metadata error.
+        The function should handle this error gracefully and return None.
+        """
+        self.mock_block.reset()
+        self.mock_block.set_deployed_streams({"stream1", "stream2", "stream3"})
+        self.mock_block.set_initialized_streams({"stream1"})
+        self.mock_block.set_error("batch_init", MetadataProcedureNotFoundError("Test error"))
 
-        # We need to adjust how we mock this - the side_effect needs to be a function
-        # that raises the exception to allow proper try/except behavior
+        result = batch_method_filter_streams(self.mock_block, self.stream_locators, 1)
 
-        mock_batch_init.raiseError.side_effect = MetadataProcedureNotFoundError("Test error")
-
-        # Call the function
-        result = batch_method_filter_streams(self.mock_block, self.stream_locators, 1, self.mock_logger)
-
-        # Verify the result is None, as the function should handle this error gracefully
+        # The result should be None, as the function should handle the error gracefully
         assert result is None
 
     def test_combine_divide_conquer_results(self):
@@ -139,7 +165,7 @@ class TestStreamFiltering:
         )
 
         # Call the function
-        result = combine_divide_conquer_results(left_result, right_result, self.mock_logger)
+        result = combine_divide_conquer_results(left_result, right_result)
 
         # Verify the result
         assert len(result["initialized_streams"]) == 2
@@ -147,9 +173,9 @@ class TestStreamFiltering:
         assert result["depth"] == 2  # max of left and right
         assert result["fallback_used"] is True  # OR of left and right
 
-    @patch("src.tsn_adapters.blocks.stream_filtering.fallback_method_filter_streams")
-    @patch("src.tsn_adapters.blocks.stream_filtering.batch_method_filter_streams")
-    @patch("src.tsn_adapters.blocks.stream_filtering.task_filter_streams_divide_conquer")
+    @patch("tsn_adapters.blocks.stream_filtering.fallback_method_filter_streams")
+    @patch("tsn_adapters.blocks.stream_filtering.batch_method_filter_streams")
+    @patch("tsn_adapters.blocks.stream_filtering.task_filter_streams_divide_conquer")
     def test_task_filter_streams_divide_conquer_empty(
         self, mock_task: MagicMock, mock_batch: MagicMock, mock_fallback: MagicMock
     ):
@@ -157,63 +183,58 @@ class TestStreamFiltering:
         # Create empty DataFrame
         empty_locators = convert_to_typed_df(pd.DataFrame(columns=["data_provider", "stream_id"]), StreamLocatorModel)
 
-        # Call the function with get_run_logger mocked
-        with patch("src.tsn_adapters.blocks.stream_filtering.get_run_logger") as mock_logger:
-            mock_logger.return_value = self.mock_logger
+        # Call the function, pass a MagicMock logger if needed
+        result = task_filter_streams_divide_conquer.fn(self.mock_block, empty_locators, 10, 0, False, 5000)
 
-            result = task_filter_streams_divide_conquer.fn(self.mock_block, empty_locators, 10, 0, False, 5000)
+        # Verify the result
+        assert result["initialized_streams"].empty
+        assert result["uninitialized_streams"].empty
+        assert result["depth"] == 0
+        assert result["fallback_used"] is False
 
-            # Verify the result
-            assert result["initialized_streams"].empty
-            assert result["uninitialized_streams"].empty
-            assert result["depth"] == 0
-            assert result["fallback_used"] is False
+        # Verify none of the methods were called
+        mock_batch.assert_not_called()
+        mock_fallback.assert_not_called()
+        mock_task.assert_not_called()
 
-            # Verify none of the methods were called
-            mock_batch.assert_not_called()
-            mock_fallback.assert_not_called()
-            mock_task.assert_not_called()
-
-    @patch("src.tsn_adapters.blocks.stream_filtering.fallback_method_filter_streams")
+    @patch("tsn_adapters.blocks.stream_filtering.fallback_method_filter_streams")
     def test_task_filter_streams_divide_conquer_max_depth(self, mock_fallback: MagicMock):
         """Test task_filter_streams_divide_conquer with max depth reached."""
         # Mock fallback method
         mock_fallback.return_value = self.sample_result
 
-        # Call the function with get_run_logger mocked
-        with patch("src.tsn_adapters.blocks.stream_filtering.get_run_logger") as mock_logger:
-            mock_logger.return_value = self.mock_logger
+        # Call the function, pass a MagicMock logger if needed
+        result = task_filter_streams_divide_conquer.fn(self.mock_block, self.stream_locators, 10, 10, False, 5000)
 
-            result = task_filter_streams_divide_conquer.fn(self.mock_block, self.stream_locators, 10, 10, False, 5000)
+        # Verify fallback was called
+        mock_fallback.assert_called_once()
 
-            # Verify fallback was called
-            mock_fallback.assert_called_once_with(self.mock_block, self.stream_locators, 10, self.mock_logger)
+        # Verify the result
+        assert result == self.sample_result
 
-            # Verify the result
-            assert result == self.sample_result
-
-    @patch("src.tsn_adapters.blocks.stream_filtering.batch_method_filter_streams")
+    @patch("tsn_adapters.blocks.stream_filtering.batch_method_filter_streams")
     def test_task_filter_streams_divide_conquer_batch_success(self, mock_batch: MagicMock):
         """Test task_filter_streams_divide_conquer when batch method succeeds."""
         # Mock batch method
         mock_batch.return_value = self.sample_result
 
-        # Call the function with get_run_logger mocked
-        with patch("src.tsn_adapters.blocks.stream_filtering.get_run_logger") as mock_logger:
-            mock_logger.return_value = self.mock_logger
+        # Call the function, pass a MagicMock logger if needed
+        result = task_filter_streams_divide_conquer.fn(self.mock_block, self.stream_locators, 10, 0, False, 5000)
 
-            result = task_filter_streams_divide_conquer.fn(self.mock_block, self.stream_locators, 10, 0, False, 5000)
+        # Verify batch was called
+        mock_batch.assert_called_once_with(self.mock_block, self.stream_locators, 0)
 
-            # Verify batch was called
-            mock_batch.assert_called_once_with(self.mock_block, self.stream_locators, 0, self.mock_logger)
+        # Verify the result
+        assert result == self.sample_result
 
-            # Verify the result
-            assert result == self.sample_result
-
-    @patch("src.tsn_adapters.blocks.stream_filtering.batch_method_filter_streams")
-    @patch("src.tsn_adapters.blocks.stream_filtering.combine_divide_conquer_results")
+    @patch("tsn_adapters.blocks.stream_filtering.batch_method_filter_streams")
+    @patch("tsn_adapters.blocks.stream_filtering.combine_divide_conquer_results")
+    @pytest.mark.usefixtures("prefect_test_fixture")
     def test_task_filter_streams_divide_conquer_recursive(self, mock_combine: MagicMock, mock_batch: MagicMock):
-        """Test task_filter_streams_divide_conquer with recursive calls."""
+        """Test task_filter_streams_divide_conquer with recursive calls.
+
+        Uses a flow wrapper to ensure the task runs in a context where .submit() works.
+        """
         # Mock batch method to return None (forcing divide and conquer)
         mock_batch.return_value = None
 
@@ -228,22 +249,337 @@ class TestStreamFiltering:
         right_future = MagicMock()
         right_future.result.return_value = self.sample_result
 
-        # Call the function with get_run_logger and task.submit mocked
-        with patch("src.tsn_adapters.blocks.stream_filtering.get_run_logger") as mock_logger:
-            mock_logger.return_value = self.mock_logger
+        # Call the function, pass a MagicMock logger if needed
+        with patch.object(task_filter_streams_divide_conquer, "submit") as mock_submit:
+            mock_submit.side_effect = [left_future, right_future]
 
-            with patch.object(task_filter_streams_divide_conquer, "submit") as mock_submit:
-                mock_submit.side_effect = [left_future, right_future]
+            # Wrap the .fn call in a flow
+            @flow
+            def recursive_test_flow():
+                return task_filter_streams_divide_conquer.fn(self.mock_block, self.stream_locators, 10, 0, False, 5000)
+            
+            result = recursive_test_flow()
 
-                result = task_filter_streams_divide_conquer.fn(
-                    self.mock_block, self.stream_locators, 10, 0, False, 5000
-                )
+            # Verify submit was called twice (for left and right halves)
+            assert mock_submit.call_count == 2
 
-                # Verify submit was called twice (for left and right halves)
-                assert mock_submit.call_count == 2
+            # Verify combine was called
+            mock_combine.assert_called_once_with(self.sample_result, self.sample_result)
 
-                # Verify combine was called
-                mock_combine.assert_called_once_with(self.sample_result, self.sample_result, self.mock_logger)
+            # Verify the result
+            assert result == combined_result
 
-                # Verify the result
-                assert result == combined_result
+
+# --- Tests for task_get_stream_states_divide_conquer ---
+
+
+@pytest.fixture
+def test_filtering_fixture() -> TestStreamFiltering:
+    """Fixture to provide an instance of TestStreamFiltering for setup."""
+    fixture_instance = TestStreamFiltering()
+    fixture_instance.setup_method()
+    return fixture_instance
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_get_stream_states_empty_input(
+    test_filtering_fixture: TestStreamFiltering, caplog: pytest.LogCaptureFixture
+):
+    """Test task_get_stream_states_divide_conquer with empty input DataFrame."""
+    result = task_get_stream_states_divide_conquer(
+        block=test_filtering_fixture.mock_block,
+        stream_locators=test_filtering_fixture.empty_typed_df,
+        current_depth=0,  # Explicitly set depth for clarity
+    )
+    assert result["non_deployed"].empty
+    assert result["deployed_but_not_initialized"].empty
+    assert result["deployed_and_initialized"].empty
+    assert result["depth"] == 0
+    assert not result["fallback_used"]
+    assert "Input stream_locators is empty, returning empty result." in caplog.text
+
+
+# Remove the patch decorator as we will control behavior via the fake block directly
+# @patch("tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
+def test_task_get_stream_states_fallback_single_non_deployed(
+    # mock_batch_init: MagicMock,  <- Remove mock parameter
+    test_filtering_fixture: TestStreamFiltering
+):
+    """Test fallback: single stream that does not exist."""
+    # Configure the fake block: No streams are deployed
+    test_filtering_fixture.mock_block.reset() # Ensure clean state
+    test_filtering_fixture.mock_block.set_deployed_streams(set())
+    single_stream_df = test_filtering_fixture.stream_locators.iloc[[0]]
+
+    # Call the function directly, forcing fallback path via flag or letting it fall naturally
+    result = task_get_stream_states_divide_conquer.fn( # Use .fn to bypass Prefect task runner for direct call
+        block=test_filtering_fixture.mock_block,
+        stream_locators=single_stream_df,
+        force_fallback=True, # Keep forcing fallback for this specific test scenario
+        current_depth=10,
+    )
+
+    # Assertions remain the same, mock_batch_init call check is removed
+    # mock_batch_init.assert_not_called() # No mock to check
+
+    assert len(result["non_deployed"]) == 1
+    assert result["non_deployed"].iloc[0]["stream_id"] == "stream1"
+    assert result["deployed_but_not_initialized"].empty
+    assert result["deployed_and_initialized"].empty
+    assert result["depth"] == 10
+    assert result["fallback_used"]
+
+
+# Remove patch
+# @patch("tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
+def test_task_get_stream_states_fallback_single_deployed_not_initialized(
+    # mock_batch_init: MagicMock, <- Remove mock parameter
+    test_filtering_fixture: TestStreamFiltering
+):
+    """Test fallback: single stream that exists but is not initialized."""
+    # Configure fake block: stream1 exists but is not initialized
+    test_filtering_fixture.mock_block.reset()
+    test_filtering_fixture.mock_block.set_deployed_streams({"stream1"})
+    test_filtering_fixture.mock_block.set_initialized_streams(set()) # Explicitly empty
+    # mock_batch_init.return_value = test_filtering_fixture.empty_df  <- Remove mock setup
+    single_stream_df = test_filtering_fixture.stream_locators.iloc[[0]]
+
+    # Call function directly using .fn
+    result = task_get_stream_states_divide_conquer.fn(
+        block=test_filtering_fixture.mock_block,
+        stream_locators=single_stream_df,
+        force_fallback=True,  # Keep forcing fallback for this test
+        current_depth=1,
+    )
+
+    # Remove mock assertion
+    # mock_batch_init.assert_called_once()
+    # pd.testing.assert_frame_equal(mock_batch_init.call_args[1]["stream_locators"], single_stream_df)
+
+    # Verify results (should be the same)
+    assert result["non_deployed"].empty
+    assert len(result["deployed_but_not_initialized"]) == 1
+    assert result["deployed_but_not_initialized"].iloc[0]["stream_id"] == "stream1"
+    assert result["deployed_and_initialized"].empty
+    assert result["depth"] == 1
+    assert result["fallback_used"]
+
+
+# Remove patch
+# @patch("tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
+def test_task_get_stream_states_fallback_single_deployed_and_initialized(
+    # mock_batch_init: MagicMock, <- Remove mock parameter
+    test_filtering_fixture: TestStreamFiltering
+):
+    """Test fallback: single stream that exists and is initialized."""
+    # Configure fake block: stream1 deployed and initialized
+    test_filtering_fixture.mock_block.reset()
+    test_filtering_fixture.mock_block.set_deployed_streams({"stream1"})
+    test_filtering_fixture.mock_block.set_initialized_streams({"stream1"})
+    # Batch init returns the stream
+    # initialized_df = pd.DataFrame([{"data_provider": "provider1", "stream_id": "stream1"}]) <- Remove mock setup
+    # mock_batch_init.return_value = initialized_df <- Remove mock setup
+    single_stream_df = test_filtering_fixture.stream_locators.iloc[[0]]
+
+    # Call function directly using .fn
+    result = task_get_stream_states_divide_conquer.fn(
+        block=test_filtering_fixture.mock_block,
+        stream_locators=single_stream_df,
+        force_fallback=True, # Keep forcing fallback for this test
+        current_depth=2,
+    )
+
+    # Remove mock assertions
+    # mock_batch_init.assert_called_once()
+    # pd.testing.assert_frame_equal(mock_batch_init.call_args[1]["stream_locators"], single_stream_df)
+
+    # Verify results (should be the same)
+    assert result["non_deployed"].empty
+    assert result["deployed_but_not_initialized"].empty
+    assert len(result["deployed_and_initialized"]) == 1
+    assert result["deployed_and_initialized"].iloc[0]["stream_id"] == "stream1"
+    assert result["depth"] == 2
+    assert result["fallback_used"]
+
+
+# Remove patch
+# @patch("tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_get_stream_states_fallback_multiple_mixed_states(
+    # mock_batch_init: MagicMock, <- Remove mock parameter
+    test_filtering_fixture: TestStreamFiltering
+):
+    """Test fallback: multiple streams with various states."""
+    # Configure fake block:
+    # stream1: exists, initialized
+    # stream2: does not exist
+    # stream3: exists, not initialized
+    test_filtering_fixture.mock_block.reset()
+    test_filtering_fixture.mock_block.set_deployed_streams({"stream1", "stream3"})
+    test_filtering_fixture.mock_block.set_initialized_streams({"stream1"})
+
+    # Batch init is called only on existing (stream1, stream3)
+    # It returns only stream1 as initialized
+    # initialized_df = pd.DataFrame([{"data_provider": "provider1", "stream_id": "stream1"}]) <- Remove mock setup
+    # mock_batch_init.return_value = initialized_df <- Remove mock setup
+
+    # Call function directly using .fn
+    result = task_get_stream_states_divide_conquer.fn(
+        block=test_filtering_fixture.mock_block,
+        stream_locators=test_filtering_fixture.stream_locators,  # Use all 3 streams
+        force_fallback=True, # Keep forcing fallback for this test
+        current_depth=3,
+    )
+
+    # Remove mock assertions
+    # mock_batch_init.assert_called_once()
+    # expected_batch_input_df = test_filtering_fixture.stream_locators.iloc[[0, 2]].reset_index(drop=True)
+    # actual_batch_input_df = mock_batch_init.call_args[1]["stream_locators"].reset_index(drop=True)
+    # pd.testing.assert_frame_equal(actual_batch_input_df, expected_batch_input_df)
+
+    # Check results (should be the same)
+    assert len(result["non_deployed"]) == 1
+    assert result["non_deployed"].iloc[0]["stream_id"] == "stream2"
+
+    assert len(result["deployed_but_not_initialized"]) == 1
+    assert result["deployed_but_not_initialized"].iloc[0]["stream_id"] == "stream3"
+
+    assert len(result["deployed_and_initialized"]) == 1
+    assert result["deployed_and_initialized"].iloc[0]["stream_id"] == "stream1"
+
+    assert result["depth"] == 3
+    assert result["fallback_used"]
+
+
+# Remove patch, configure fake block to raise error
+# @patch("tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_get_stream_states_batch_metadata_error_falls_through(
+    # mock_batch_init: MagicMock, <- Remove mock parameter
+    test_filtering_fixture: TestStreamFiltering,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test that batch attempt failure (MetadataProcedureNotFoundError) falls through.
+
+    This test now uses the FakeTNAccessBlock's error injection.
+    The function should attempt the batch call, catch the error, log it, and then
+    proceed with the divide-and-conquer/fallback logic (which we don't explicitly
+    mock or check the final state for here, focusing only on the error handling).
+    """
+    # Configure fake block to raise MetadataProcedureNotFoundError on batch call
+    test_filtering_fixture.mock_block.reset()
+    # Ensure streams exist so the call doesn't fail early for non-existence
+    all_stream_ids = set(test_filtering_fixture.stream_locators['stream_id'])
+    test_filtering_fixture.mock_block.set_deployed_streams(all_stream_ids)
+    test_filtering_fixture.mock_block.set_error(
+        "batch_init", MetadataProcedureNotFoundError("Fake Batch init failed")
+    )
+    # mock_batch_init.side_effect = MetadataProcedureNotFoundError("Batch init failed") <- Remove mock setup
+
+    with caplog.at_level("DEBUG"):
+        @flow
+        def test_flow():
+            # Note: We call the actual task function here, not .fn, to test Prefect integration
+            task_get_stream_states_divide_conquer(
+            block=test_filtering_fixture.mock_block,
+            stream_locators=test_filtering_fixture.stream_locators,
+            current_depth=0,
+        )
+        test_flow()
+
+    # Assert that the batch method was attempted (implicitly, by checking the log)
+    # The exact number of calls isn't critical here, just that the error path was hit.
+    # assert mock_batch_init.call_count >= 1 <- Remove mock assertion
+    assert "Batch method failed with MetadataProcedureNotFoundError" in caplog.text
+
+
+# Remove patch, configure fake block to raise error for recursion test
+# @patch("tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams")
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_get_stream_states_recursive(
+    test_filtering_fixture: TestStreamFiltering,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test the recursive divide-and-conquer path."""
+    # Configure fake block to raise MetadataProcedureNotFoundError for recursion test
+    test_filtering_fixture.mock_block.reset()
+    test_filtering_fixture.mock_block.set_error(
+        "batch_init", MetadataProcedureNotFoundError("Force recursion")
+    )
+
+    # Define what the combine function should return
+    final_combined_result = StreamStatesResult(
+        non_deployed=test_filtering_fixture.stream_locators.iloc[[1]],  # stream2
+        deployed_but_not_initialized=test_filtering_fixture.stream_locators.iloc[[2]],  # stream3
+        deployed_and_initialized=test_filtering_fixture.stream_locators.iloc[[0]],  # stream1
+        depth=1,
+        fallback_used=False,
+    )
+
+    # Patch the combine function and recursive calls as before
+    with patch(
+        "tsn_adapters.blocks.stream_filtering._combine_stream_states_results",
+        return_value=final_combined_result,
+    ) as mock_combine, patch(
+        "tsn_adapters.blocks.stream_filtering.task_get_stream_states_divide_conquer",
+        side_effect=[
+            StreamStatesResult(
+                non_deployed=test_filtering_fixture.empty_typed_df,
+                deployed_but_not_initialized=test_filtering_fixture.empty_typed_df,
+                deployed_and_initialized=test_filtering_fixture.stream_locators.iloc[[0]],
+                depth=1,
+                fallback_used=False,
+            ),
+            StreamStatesResult(
+                non_deployed=test_filtering_fixture.stream_locators.iloc[[1]],
+                deployed_but_not_initialized=test_filtering_fixture.stream_locators.iloc[[2]],
+                deployed_and_initialized=test_filtering_fixture.empty_typed_df,
+                depth=1,
+                fallback_used=False,
+            ),
+        ],
+    ) as mock_recursive_call:
+        
+        # Wrap the .fn call in a flow
+        @flow
+        def recursive_test_flow_states():
+            return task_get_stream_states_divide_conquer.fn(
+                block=test_filtering_fixture.mock_block,
+                stream_locators=test_filtering_fixture.stream_locators,  # Use all 3 streams
+                current_depth=0,
+            )
+        
+        result = recursive_test_flow_states()
+
+        # Assertions
+        assert mock_recursive_call.call_count == 2  # Called for left and right halves
+        mock_combine.assert_called_once()
+        assert result == final_combined_result
+
+
+# --- Integration-style test with real TestTNAccessBlock ---
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_get_stream_states_divide_conquer_integration():
+    """Integration test: Use a real FakeTNAccessBlock to check stream state partitioning."""
+    # Set up a fake TNAccessBlock with two existing streams
+    block = FakeTNAccessBlock()
+    block.set_deployed_streams({"stream1", "stream3"})
+    # Prepare DataFrame with three streams
+    stream_data = pd.DataFrame(
+        {"data_provider": ["provider1", "provider1", "provider1"], "stream_id": ["stream1", "stream2", "stream3"]}
+    )
+    stream_locators = convert_to_typed_df(stream_data, StreamLocatorModel)
+
+    # Call the actual task (no patching/mocking)
+    result = task_get_stream_states_divide_conquer.fn(
+        block=block,
+        stream_locators=stream_locators,
+        max_depth=5,
+        current_depth=0,
+        force_fallback=True,  # Use fallback for deterministic behavior
+    )
+    # stream1 and stream3 exist, stream2 does not
+    # All existing streams are not initialized (FakeTNAccessBlock does not auto-initialize)
+    assert set(result["non_deployed"]["stream_id"]) == {"stream2"}
+    assert set(result["deployed_but_not_initialized"]["stream_id"]) == {"stream1", "stream3"}
+    assert result["deployed_and_initialized"].empty

--- a/tests/fixtures/test_trufnetwork.py
+++ b/tests/fixtures/test_trufnetwork.py
@@ -449,7 +449,7 @@ def disable_prefect_retries():
         "tsn_adapters.flows.fmp.historical_flow.fetch_historical_data",
         "tsn_adapters.flows.fmp.historical_flow.get_earliest_data_date",
         # Stream Deploy Flow
-        "tsn_adapters.flows.stream_deploy_flow.check_deploy_and_init_stream",
+        "tsn_adapters.flows.stream_deploy_flow.task_check_exist_deploy_init",
         # Primitive Source Descriptor
         "tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_url",
         "tsn_adapters.blocks.primitive_source_descriptor.get_descriptor_from_github",
@@ -484,6 +484,8 @@ def disable_prefect_retries():
         "tsn_adapters.blocks.tn_access.task_filter_initialized_streams",
         # Stream Filtering
         "tsn_adapters.blocks.stream_filtering.task_filter_batch_initialized_streams",
+        "tsn_adapters.blocks.stream_filtering.task_get_stream_states_divide_conquer",
+        "tsn_adapters.blocks.stream_filtering.task_filter_streams_divide_conquer",
         # TN Common
         "tsn_adapters.common.trufnetwork.tn.task_insert_tsn_records",
         "tsn_adapters.common.trufnetwork.tn.task_deploy_primitive",

--- a/tests/flows/test_stream_deploy_flow.py
+++ b/tests/flows/test_stream_deploy_flow.py
@@ -1,15 +1,16 @@
 from datetime import datetime, timezone
+import logging
 from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pandas as pd
 from pandera.typing import DataFrame
+from prefect import flow
 from prefect.futures import PrefectFuture
-from pydantic import ConfigDict, SecretStr
+from pydantic import ConfigDict
 import pytest
-from pytest import FixtureRequest, MonkeyPatch
-import trufnetwork_sdk_c_bindings.exports as truf_sdk  # type: ignore
-import trufnetwork_sdk_py.client as tn_client  # type: ignore
+from pytest import FixtureRequest, LogCaptureFixture, MonkeyPatch
+from tests.utils.fake_tn_access import FakeTNAccessBlock
 
 from tsn_adapters.blocks.deployment_state import DeploymentStateBlock, DeploymentStateModel
 from tsn_adapters.blocks.primitive_source_descriptor import (
@@ -17,12 +18,106 @@ from tsn_adapters.blocks.primitive_source_descriptor import (
     PrimitiveSourcesDescriptorBlock,
 )
 from tsn_adapters.blocks.shared_types import StreamLocatorModel
-from tsn_adapters.blocks.tn_access import TNAccessBlock
+from tsn_adapters.blocks.stream_filtering import StreamStatesResult
+from tsn_adapters.blocks.tn_access import StreamAlreadyExistsError
 from tsn_adapters.flows.stream_deploy_flow import (
     deploy_streams_flow,
-    filter_deployed_streams_task,
     mark_batch_deployed_task,
+    task_check_deployment_state,
+    task_check_exist_deploy_init,
 )
+
+
+class LoggingFakeTNAccessBlock(FakeTNAccessBlock):
+    def __init__(
+        self,
+        existing_streams: set[str] | None = None,
+        initialized_streams: set[str] | None = None,
+        error_on: dict[str, Any] | None = None,
+    ):
+        print("[TEST LOG] LoggingFakeTNAccessBlock.__init__ called")
+        super().__init__(existing_streams=existing_streams, initialized_streams=initialized_streams, error_on=error_on)
+
+    def deploy_stream(self, stream_id: str, stream_type: str = "primitive", wait: bool = True, **kwargs: object) -> str:
+        print(f"[TEST LOG] FakeTNAccessBlock.deploy_stream called for: {stream_id}")
+        return super().deploy_stream(stream_id, stream_type, wait=wait, **kwargs)
+
+    def init_stream(self, stream_id: str, wait: bool = True, **kwargs: object) -> str:
+        print(f"[TEST LOG] FakeTNAccessBlock.init_stream called for: {stream_id}")
+        return super().init_stream(stream_id, wait=wait, **kwargs)
+
+    def wait_for_tx(self, tx_hash: str, **kwargs: object) -> None:
+        print(f"[TEST LOG] FakeTNAccessBlock.wait_for_tx called for: {tx_hash}")
+        super().wait_for_tx(tx_hash, **kwargs)
+
+
+class ErrorBlock(LoggingFakeTNAccessBlock):
+    def __init__(
+        self,
+        existing_streams: Optional[set[str]] = None,
+        initialized_streams: Optional[set[str]] = None,
+        error_on: Optional[dict[str, Any]] = None,
+    ):
+        print("[TEST LOG] ErrorBlock.__init__ called")
+        super().__init__(existing_streams=existing_streams, initialized_streams=initialized_streams, error_on=error_on)
+
+    def deploy_stream(self, stream_id: str, stream_type: str = "primitive", wait: bool = True, **kwargs: object) -> str:
+        print(f"[TEST LOG] ErrorBlock.deploy_stream called for: {stream_id}")
+        raise StreamAlreadyExistsError(stream_id)
+
+    def init_stream(self, stream_id: str, wait: bool = True, **kwargs: object) -> str:
+        print(f"[TEST LOG] ErrorBlock.init_stream called for: {stream_id}")
+        return "init_tx_hash"
+
+
+# --- Helper Functions ---
+
+
+# Helper to create a mock PrefectFuture that returns a value or raises an exception
+def create_mock_prefect_future(return_value: Any = None, side_effect: Optional[Exception] = None) -> PrefectFuture[Any]:
+    """Creates a mock PrefectFuture that resolves to a given value or raises an exception."""
+    mock_future = MagicMock(spec=PrefectFuture)
+    if side_effect:
+        mock_future.result.side_effect = side_effect
+    else:
+        mock_future.result.return_value = return_value
+    return mock_future
+
+
+# Helper to create a mock StreamStatesResult
+def create_mock_stream_states_result(
+    non_deployed: list[str],
+    deployed_but_not_initialized: list[str],
+    deployed_and_initialized: list[str],
+    account: str = "dummy_account",
+) -> StreamStatesResult:
+    """Creates a mock StreamStatesResult TypedDict for testing."""
+
+    def _create_df(stream_ids: list[str]) -> DataFrame[StreamLocatorModel]:
+        if not stream_ids:
+            return DataFrame[StreamLocatorModel](pd.DataFrame(columns=["stream_id", "data_provider"]))
+        return DataFrame[StreamLocatorModel](pd.DataFrame({"stream_id": stream_ids, "data_provider": account}))
+
+    return StreamStatesResult(
+        non_deployed=_create_df(non_deployed),
+        deployed_but_not_initialized=_create_df(deployed_but_not_initialized),
+        deployed_and_initialized=_create_df(deployed_and_initialized),
+        depth=0,
+        fallback_used=False,
+    )
+
+
+# Helper to create a mock future for the batch filter task
+def create_mock_filter_future(
+    existing_stream_ids: list[str], account: str = "dummy_account"
+) -> PrefectFuture[DataFrame[StreamLocatorModel]]:
+    """Creates a mock PrefectFuture that resolves to a StreamLocatorModel DataFrame."""
+    mock_future = MagicMock(spec=PrefectFuture)
+    result_df = DataFrame[StreamLocatorModel](
+        pd.DataFrame({"stream_id": existing_stream_ids, "data_provider": account})
+    )
+    mock_future.result.return_value = result_df
+    return mock_future
 
 
 class TestPrimitiveSourcesDescriptor(PrimitiveSourcesDescriptorBlock):
@@ -40,60 +135,6 @@ class TestPrimitiveSourcesDescriptor(PrimitiveSourcesDescriptorBlock):
         return DataFrame[PrimitiveSourceDataModel](pd.DataFrame(data))
 
 
-class TestTNClient(tn_client.TNClient):
-    """Test implementation of TNClient that tracks deployed streams and can be initialized with existing streams."""
-
-    def __init__(self, existing_streams: set[str] | None = None):
-        # We don't call super().__init__ to avoid real client initialization
-        if existing_streams is None:
-            existing_streams = set()
-        self.existing_streams = existing_streams
-        self.deployed_streams: list[str] = []
-        # Set a dummy client to satisfy TNClient's expectations
-        self.client = object()
-
-    def get_current_account(self) -> str:
-        return "dummy_account"
-
-    def stream_exists(self, stream_id: str, data_provider: Optional[str] = None) -> bool:
-        # Check if the stream exists in either existing_streams or deployed_streams
-        return stream_id in self.existing_streams
-
-    def deploy_stream(self, stream_id: str, stream_type: str = truf_sdk.StreamTypePrimitive, wait: bool = True) -> str:
-        # Instead of calling the real SDK, we just track that the stream was deployed
-        self.deployed_streams.append(stream_id)
-        self.existing_streams.add(stream_id)
-        return "dummy_tx_hash"
-
-    def init_stream(self, stream_id: str, wait: bool = True) -> str:
-        # Simulate a successful stream initialization
-        return "dummy_tx_hash"
-
-    def wait_for_tx(self, tx_hash: str) -> None:
-        if tx_hash == "failed_tx_hash":
-            raise Exception("Failed to deploy stream")
-        pass
-
-
-class TestTNAccessBlock(TNAccessBlock):
-    """Test implementation of TNAccessBlock for testing."""
-
-    def __init__(self, existing_streams: set[str] | None = None):
-        super().__init__(
-            tn_provider="", tn_private_key=SecretStr(""), helper_contract_name="", helper_contract_deployer=None
-        )
-        self._test_client = TestTNClient(existing_streams=existing_streams)
-
-    def set_existing_streams(self, existing_streams: set[str]) -> None:
-        """Set the streams that exist in TN for testing."""
-        self._test_client = TestTNClient(existing_streams=existing_streams)
-
-    @property
-    def client(self) -> tn_client.TNClient:
-        """Override client property to return our test client instead of creating a real one."""
-        return self._test_client
-
-
 class TestDeploymentStateBlock(DeploymentStateBlock):
     """Test implementation of DeploymentStateBlock for testing."""
 
@@ -106,6 +147,11 @@ class TestDeploymentStateBlock(DeploymentStateBlock):
             {} if predeployed_streams is None else {s: True for s in predeployed_streams}
         )
         self._marked_streams: list[tuple[list[str], datetime]] = []
+
+    def reset(self) -> None:
+        """Reset the internal state of the block for testing."""
+        self._deployed_streams = {}
+        self._marked_streams = []
 
     def has_been_deployed(self, stream_id: str) -> bool:
         """Check if a stream has been marked as deployed."""
@@ -151,9 +197,9 @@ class TestDeploymentStateBlock(DeploymentStateBlock):
 
 
 @pytest.fixture
-def tn_access_block() -> TestTNAccessBlock:
-    """Fixture that provides a TestTNAccessBlock with no existing streams."""
-    return TestTNAccessBlock(existing_streams=set())
+def tn_access_block() -> LoggingFakeTNAccessBlock:
+    """Fixture that provides a FakeTNAccessBlock with no existing streams and logging."""
+    return LoggingFakeTNAccessBlock(existing_streams=set())
 
 
 @pytest.fixture
@@ -172,253 +218,301 @@ def deployment_state_block(request: FixtureRequest) -> TestDeploymentStateBlock:
 
 @pytest.mark.usefixtures("prefect_test_fixture")
 def test_deploy_streams_flow_all_new(
-    tn_access_block: TestTNAccessBlock, primitive_descriptor: TestPrimitiveSourcesDescriptor
+    tn_access_block: LoggingFakeTNAccessBlock,
+    primitive_descriptor: TestPrimitiveSourcesDescriptor,
+    # No monkeypatch needed
 ) -> None:
-    """Test that all streams are deployed when none exist."""
-    results = deploy_streams_flow(psd_block=primitive_descriptor, tna_block=tn_access_block)
+    """Test that all streams are deployed when none exist, relying on FakeTNAccessBlock."""
+    tn_access_block.reset()
+    # Use an empty TestDeploymentStateBlock because mark_batch_deployed_task needs it
+    deployment_state_block = TestDeploymentStateBlock()
+
+    # --- NO MOCKS for flow tasks --- #
+
+    # Run flow within a test flow context
+    @flow
+    def run_deployment_flow():
+        print("[TEST LOG] Starting run_deployment_flow...")
+        results = deploy_streams_flow(
+            psd_block=primitive_descriptor,
+            tna_block=tn_access_block,
+            deployment_state=deployment_state_block,  # Pass fake state block
+            check_stream_state=False,  # Explicitly use the simple path
+        )
+        print(f"[TEST LOG] deploy_streams_flow returned: {results}")
+        return results
+
+    results = run_deployment_flow()
+    print(f"[TEST LOG] Final results: {results}")
+    print(
+        f"[TEST LOG] Final tn_access_block state: deployed={tn_access_block.deployed_streams}, initialized={tn_access_block.initialized_streams}"
+    )
 
     # All three streams should be deployed
     assert results["deployed_count"] == 3
     assert results["skipped_count"] == 0
 
-    # Verify the actual streams that were deployed
-    client = tn_access_block.client
-    assert isinstance(client, TestTNClient)  # Type check for mypy
-    assert set(client.deployed_streams) == {"stream_0", "stream_1", "stream_2"}
+    # Verify the actual streams that were deployed using the fake block
+    assert tn_access_block.deployed_streams == {"stream_0", "stream_1", "stream_2"}
+    assert set(tn_access_block.deploy_calls) == {"stream_0", "stream_1", "stream_2"}
+    assert tn_access_block.initialized_streams == {"stream_0", "stream_1", "stream_2"}
+    # Verify state block was updated
+    assert len(deployment_state_block.marked_streams) > 0
+    marked_ids = set()
+    for streams, _ in deployment_state_block.marked_streams:
+        marked_ids.update(streams)
+    assert marked_ids == {"stream_0", "stream_1", "stream_2"}
 
 
 @pytest.mark.usefixtures("prefect_test_fixture")
-def test_deploy_streams_flow_with_existing() -> None:
-    """Test that only non-existing streams are deployed when some already exist."""
-    # Create TNAccessBlock with some existing streams
-    existing_streams = {"stream_0", "stream_2"}  # First and last streams exist
-    tn_access_block = TestTNAccessBlock(existing_streams=existing_streams)
-
-    # Create descriptor with 3 streams
+def test_deploy_streams_flow_with_existing(
+    # No monkeypatch needed
+) -> None:
+    """Test that only non-existing streams are deployed when some already exist, relying on FakeTNAccessBlock."""
+    existing_streams = {"stream_0", "stream_2"}
+    # Use LoggingFakeTNAccessBlock if you want logs
+    tn_access_block = LoggingFakeTNAccessBlock(existing_streams=existing_streams)
+    tn_access_block.set_deployed_streams(existing_streams)  # Initial state matches existing
+    # Need a deployment state block for mark task
+    deployment_state_block = TestDeploymentStateBlock()
     primitive_descriptor = TestPrimitiveSourcesDescriptor(num_streams=3)
 
-    results = deploy_streams_flow(psd_block=primitive_descriptor, tna_block=tn_access_block)
+    # --- NO MOCKS for flow tasks --- #
 
-    # Only stream_1 should be deployed, others should be skipped
-    assert results["deployed_count"] == 1
-    assert results["skipped_count"] == 2
+    # Run flow within a test flow context
+    from prefect import flow
 
-    # Verify the actual streams that were deployed
-    client = tn_access_block.client
-    assert isinstance(client, TestTNClient)  # Type check for mypy
-    assert client.deployed_streams == ["stream_1"]  # Changed from len check to exact match
+    @flow
+    def run_flow():
+        return deploy_streams_flow(
+            psd_block=primitive_descriptor,
+            tna_block=tn_access_block,
+            deployment_state=deployment_state_block,
+            check_stream_state=False,  # Use simple path
+        )
+
+    results = run_flow()
+
+    # When check_stream_state=False, the flow attempts deploy/init for all.
+    # Existing streams (0, 2) will raise StreamAlreadyExistsError on deploy,
+    # but task_check_exist_deploy_init will proceed to init them.
+    # Stream 1 will be deployed and initialized.
+    assert results["deployed_count"] == 3  # All streams are processed (1 D+I, 2 I)
+    assert results["skipped_count"] == 0  # No streams skipped by state check
+
+    # Verify the state of the fake block
+    assert tn_access_block.deploy_calls == ["stream_1"]  # Only stream_1 deploy attempted
+    assert tn_access_block.deployed_streams == {
+        "stream_0",
+        "stream_1",
+        "stream_2",
+    }  # All end up deployed (0, 2 existed, 1 added)
+    assert tn_access_block.initialized_streams == {"stream_0", "stream_1", "stream_2"}  # All end up initialized
+
+    # Verify state block was updated for all processed streams
+    marked_ids = set()
+    for streams, _ in deployment_state_block.marked_streams:
+        marked_ids.update(streams)
+    assert marked_ids == {"stream_0", "stream_1", "stream_2"}
 
 
 @pytest.mark.usefixtures("prefect_test_fixture")
+# Remove all patches
 def test_deploy_streams_flow_with_deployment_state(
-    tn_access_block: TestTNAccessBlock,
+    # Remove mocks
+    tn_access_block: FakeTNAccessBlock,  # Use fixture
     primitive_descriptor: TestPrimitiveSourcesDescriptor,
-    deployment_state_block: TestDeploymentStateBlock,
-    monkeypatch: MonkeyPatch,
+    # Remove monkeypatch
 ) -> None:
-    """Test that the flow uses deployment state to filter and mark streams."""
-    # Pre-mark stream_0 as deployed
-    deployment_state_block.deployed_streams = {"stream_0": True}
+    """Test that the flow uses deployment state to filter and mark streams, relying on fakes."""
+    # Set up initial state
+    tn_access_block.reset()
+    deployment_state_block = TestDeploymentStateBlock(predeployed_streams={"stream_0"})
+    # Configure tn_access_block to match state (stream_0 exists)
+    tn_access_block.set_deployed_streams({"stream_0"})
 
-    # Configure TN to have stream_0 exist (so it will be filtered out)
-    tn_access_block.set_existing_streams({"stream_0"})
+    # --- NO MOCKS for flow tasks --- #
 
-    # --- Mock the batch filter task ---
-    mock_filter_submit = MagicMock(return_value=create_mock_filter_future(existing_stream_ids=["stream_0"]))
-    monkeypatch.setattr(
-        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_filter_submit
-    )
-    # --- End Mock ---
-
-    # --- Mock the batch mark task submission to run synchronously ---
-    def mock_mark_submit(*args: Any, **kwargs: Any) -> PrefectFuture[None]:
-        # Directly call the marking logic on the provided state block
-        stream_ids = kwargs.get("stream_ids", [])
-        state_block = kwargs.get("deployment_state")
-        timestamp = kwargs.get("timestamp")
-        if state_block and stream_ids and timestamp:
-            # Simulate the task's core logic
-            if timestamp.tzinfo is None or timestamp.tzinfo.utcoffset(timestamp) is None:
-                timestamp = timestamp.replace(tzinfo=timezone.utc)
-            elif timestamp.tzinfo != timezone.utc:
-                timestamp = timestamp.astimezone(timezone.utc)
-            state_block.mark_multiple_as_deployed(stream_ids, timestamp)
-        # Return a dummy future-like object if needed, though not strictly necessary here
-        mock_future = MagicMock(spec=PrefectFuture)
-        mock_future.result.return_value = None
-        return mock_future
-
-    monkeypatch.setattr("tsn_adapters.flows.stream_deploy_flow.mark_batch_deployed_task.submit", mock_mark_submit)
-    # --- End Mock ---
-
-    # Run flow with deployment state
+    # --- Run the flow ---
     results = deploy_streams_flow(
-        psd_block=primitive_descriptor, tna_block=tn_access_block, deployment_state=deployment_state_block
+        psd_block=primitive_descriptor,
+        tna_block=tn_access_block,  # Pass the fake block
+        deployment_state=deployment_state_block,  # Pass the configured fake state block
+        check_stream_state=False,  # Use simple path
     )
 
-    # Only streams 1 and 2 should be deployed, stream_0 should be skipped due to deployment state
+    # Assertions
+    # stream_0 skipped by state
+    # stream_1, stream_2 processed
     assert results["deployed_count"] == 2
-    assert results["skipped_count"] == 1
+    assert results["skipped_count"] == 1  # stream_0 filtered by state
 
-    # Verify that only streams 1 and 2 were deployed
-    client = tn_access_block.client
-    assert isinstance(client, TestTNClient)  # Type check for mypy
-    assert set(client.deployed_streams) == {"stream_1", "stream_2"}
+    # Verify the final state of FakeTNAccessBlock
+    assert tn_access_block.deploy_calls == ["stream_1", "stream_2"]
+    assert tn_access_block.deployed_streams == {"stream_0", "stream_1", "stream_2"}
+    assert tn_access_block.initialized_streams == {"stream_1", "stream_2"}  # stream_0 was never initialized
 
-    # Verify that streams 1 and 2 were marked as deployed in the deployment state
-    for stream_id in ["stream_1", "stream_2"]:
-        assert deployment_state_block.deployed_streams.get(
-            stream_id, False
-        ), f"Stream {stream_id} was not marked deployed"
-
-    # Verify that the mark_multiple_as_deployed method was called
+    # Verify that the state marking task was submitted for the deployed streams
     assert len(deployment_state_block.marked_streams) > 0
-    # The first element is the list of stream IDs, check that it contains the expected streams
-    stream_ids_list = deployment_state_block.marked_streams[0][0]
-    assert set(stream_ids_list) == {"stream_1", "stream_2"}
+    marked_ids = set()
+    for streams, _ in deployment_state_block.marked_streams:
+        marked_ids.update(streams)
+    assert marked_ids == {"stream_1", "stream_2"}
 
 
 @pytest.mark.usefixtures("prefect_test_fixture")
 def test_deploy_streams_flow_all_deployed_in_state(
-    tn_access_block: TestTNAccessBlock, primitive_descriptor: TestPrimitiveSourcesDescriptor, monkeypatch: MonkeyPatch
+    tn_access_block: LoggingFakeTNAccessBlock,
+    primitive_descriptor: TestPrimitiveSourcesDescriptor,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     """Test that if all streams are already deployed in the state, none are deployed."""
     # Create a deployment state with all streams already deployed
     deployment_state_block = TestDeploymentStateBlock(predeployed_streams={"stream_0", "stream_1", "stream_2"})
+    # Ensure tn_access_block state matches for consistency (optional but good practice)
+    tn_access_block.reset()
+    tn_access_block.set_deployed_streams({"stream_0", "stream_1", "stream_2"})
 
-    # Configure TN to have all streams exist (so they will all be filtered out)
-    tn_access_block.set_existing_streams({"stream_0", "stream_1", "stream_2"})
+    # Run flow within a test flow context
+    from prefect import flow
 
-    # --- Mock the batch filter task ---
-    mock_filter_submit = MagicMock(
-        return_value=create_mock_filter_future(existing_stream_ids=["stream_0", "stream_1", "stream_2"])
-    )
-    monkeypatch.setattr(
-        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_filter_submit
-    )
-    # --- End Mock ---
+    @flow
+    def run_flow():
+        # Run flow with deployment state (check_state=True implicitly or explicitly if default changed)
+        # Let's assume check_state=True is needed here to test state block filtering
+        return deploy_streams_flow(
+            psd_block=primitive_descriptor,
+            tna_block=tn_access_block,
+            deployment_state=deployment_state_block,
+            check_stream_state=True,  # Test the state checking path
+        )
 
-    # --- Mock the batch mark task submission (shouldn't be called, but good practice) ---
-    mock_mark_submit = MagicMock()
-    monkeypatch.setattr("tsn_adapters.flows.stream_deploy_flow.mark_batch_deployed_task.submit", mock_mark_submit)
-    # --- End Mock ---
-
-    # Run flow with deployment state
-    results = deploy_streams_flow(
-        psd_block=primitive_descriptor, tna_block=tn_access_block, deployment_state=deployment_state_block
-    )
+    results = run_flow()
 
     # All streams should be skipped due to deployment state
     assert results["deployed_count"] == 0
     assert results["skipped_count"] == 3
 
-    # Verify that no streams were deployed
-    client = tn_access_block.client
-    assert isinstance(client, TestTNClient)  # Type check for mypy
-    assert len(client.deployed_streams) == 0
+    # Verify that no streams were deployed or initialized in the fake block
+    assert len(tn_access_block.deploy_calls) == 0
+    assert len(tn_access_block.initialized_streams) == 0
+    assert tn_access_block.deployed_streams == {"stream_0", "stream_1", "stream_2"}  # Should remain unchanged
 
-    # Verify that no streams were marked as deployed in the deployment state
+    # Verify that no streams were marked as deployed in the deployment state block
     assert len(deployment_state_block.marked_streams) == 0
-    mock_mark_submit.assert_not_called()  # Verify the mock submit wasn't called
 
 
 @pytest.mark.usefixtures("prefect_test_fixture")
 def test_deploy_streams_flow_backward_compatibility(
-    tn_access_block: TestTNAccessBlock, primitive_descriptor: TestPrimitiveSourcesDescriptor
+    tn_access_block: LoggingFakeTNAccessBlock, primitive_descriptor: TestPrimitiveSourcesDescriptor
 ) -> None:
     """Test that the flow still works without a deployment state (backward compatibility)."""
-    # Run flow without deployment state
-    results = deploy_streams_flow(psd_block=primitive_descriptor, tna_block=tn_access_block)
+    tn_access_block.reset()
+    # Run flow without deployment state within a test flow context
+    from prefect import flow
+
+    @flow
+    def run_flow():
+        # Pass deployment_state=None
+        return deploy_streams_flow(
+            psd_block=primitive_descriptor,
+            tna_block=tn_access_block,
+            deployment_state=None,
+            check_stream_state=False,  # Ensure simple path when no state block
+        )
+
+    results = run_flow()
 
     # All three streams should be deployed
     assert results["deployed_count"] == 3
     assert results["skipped_count"] == 0
 
     # Verify the actual streams that were deployed
-    client = tn_access_block.client
-    assert isinstance(client, TestTNClient)  # Type check for mypy
-    assert set(client.deployed_streams) == {"stream_0", "stream_1", "stream_2"}
+    assert tn_access_block.deployed_streams == {"stream_0", "stream_1", "stream_2"}
 
 
 @pytest.mark.usefixtures("prefect_test_fixture")
-def test_filter_deployed_streams_task(
-    primitive_descriptor: TestPrimitiveSourcesDescriptor, tn_access_block: TestTNAccessBlock, monkeypatch: MonkeyPatch
-) -> None:
-    """Test that filter_deployed_streams_task correctly filters streams."""
-    # Create a deployment state with stream_0 already deployed
-    deployment_state = TestDeploymentStateBlock(predeployed_streams={"stream_0"})
+def test_deploy_streams_flow_catastrophic_failure(caplog: LogCaptureFixture):
+    """Test that the flow handles catastrophic tn_access_block failure gracefully."""
+    primitive_descriptor = TestPrimitiveSourcesDescriptor(num_streams=2)
+    # Use LoggingFakeTNAccessBlock for logs
+    tn_access_block = LoggingFakeTNAccessBlock()
+    tn_access_block.set_deployed_streams(set())
 
-    # Verify deployment state has stream_0 marked as deployed
-    assert deployment_state.has_been_deployed("stream_0")
-    assert deployment_state.check_multiple_streams(["stream_0"])["stream_0"]
+    # Inject error into the fake block
+    tn_access_block.set_error("deploy_stream", RuntimeError("Catastrophic TN failure!"))
 
-    # Get descriptor DataFrame
-    descriptor_df = primitive_descriptor.get_descriptor()
+    # Run flow within a test flow context
+    from prefect import flow
 
-    # Configure TN to have stream_0 exist (important for verification)
-    tn_access_block.set_existing_streams({"stream_0"})
+    with caplog.at_level(logging.ERROR):
 
-    # --- Mock the batch filter task ---
-    # It will be called with stream_0, and since it exists, it should return stream_0
-    mock_submit = MagicMock(return_value=create_mock_filter_future(existing_stream_ids=["stream_0"]))
-    monkeypatch.setattr(
-        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_submit
-    )
-    # --- End Mock ---
+        @flow
+        def run_flow():
+            return deploy_streams_flow(
+                psd_block=primitive_descriptor,
+                tna_block=tn_access_block,
+                check_stream_state=False,  # Simple path
+            )
 
-    # Apply filter
-    filtered_df = filter_deployed_streams_task(
-        descriptor_df=descriptor_df, deployment_state=deployment_state, tna_block=tn_access_block
-    )
+        state = run_flow(return_state=True)
 
-    # Check that stream_0 is filtered out
-    filtered_stream_ids: list[str] = filtered_df["stream_id"].tolist()
-    assert "stream_0" not in filtered_stream_ids
-    assert "stream_1" in filtered_stream_ids
-    assert "stream_2" in filtered_stream_ids
-    assert len(filtered_df) == 2
+    assert state.is_failed()
+
+    assert "Catastrophic TN failure!" in caplog.text
 
 
 @pytest.mark.usefixtures("prefect_test_fixture")
-def test_filter_deployed_streams_task_with_tn_verification(
-    primitive_descriptor: TestPrimitiveSourcesDescriptor, monkeypatch: MonkeyPatch
-) -> None:
-    """Test that filter_deployed_streams_task verifies deployment with TN."""
-    # Create a deployment state with all streams already deployed
-    deployment_state = TestDeploymentStateBlock(predeployed_streams={"stream_0", "stream_1", "stream_2"})
+def test_deploy_streams_flow_retry_logic(caplog: LogCaptureFixture):
+    """Test that the flow retries task_check_exist_deploy_init on transient failure and eventually succeeds."""
+    primitive_descriptor = TestPrimitiveSourcesDescriptor(num_streams=1)
+    # Use LoggingFakeTNAccessBlock for logs
+    tn_access_block = LoggingFakeTNAccessBlock()
+    tn_access_block.reset()
 
-    # Verify all streams are marked as deployed in the deployment state
-    for stream_id in ["stream_0", "stream_1", "stream_2"]:
-        assert deployment_state.has_been_deployed(stream_id)
+    # Simulate task_check_exist_deploy_init failing once via the fake block error injection
+    call_count = {"count": 0}
+    original_deploy = tn_access_block.deploy_stream
 
-    # Create TN access block with only stream_0 existing in TN
-    tn_access_block = TestTNAccessBlock(existing_streams={"stream_0"})
+    def flaky_deploy(*args: object, **kwargs: object) -> str:
+        # Get stream_id carefully from either args or kwargs
+        if args:
+            stream_id = str(args[0])
+            other_kwargs = kwargs
+        else:
+            stream_id = str(kwargs.get("stream_id", "unknown"))
+            other_kwargs = {k: v for k, v in kwargs.items() if k != "stream_id"}
 
-    # Get descriptor DataFrame
-    descriptor_df = primitive_descriptor.get_descriptor()
+        if call_count["count"] == 0:
+            call_count["count"] += 1
+            raise RuntimeError("Transient failure!")
+        # Call original correctly, avoiding duplicate stream_id
+        return original_deploy(stream_id=stream_id, **other_kwargs)  # type: ignore
 
-    # --- Mock the batch filter task ---
-    # It will be called with stream_0, stream_1, stream_2.
-    # Since only stream_0 exists in TN, it should return only stream_0.
-    mock_submit = MagicMock(return_value=create_mock_filter_future(existing_stream_ids=["stream_0"]))
-    monkeypatch.setattr(
-        "tsn_adapters.flows.stream_deploy_flow.task_filter_batch_initialized_streams.submit", mock_submit
-    )
-    # --- End Mock ---
+    tn_access_block.deploy_stream = flaky_deploy  # type: ignore[assignment]
 
-    # Apply filter
-    filtered_df = filter_deployed_streams_task(
-        descriptor_df=descriptor_df, deployment_state=deployment_state, tna_block=tn_access_block
-    )
+    # Run flow within a test flow context
+    from prefect import flow
 
-    # Check that only stream_0 is filtered out (marked as deployed AND exists in TN)
-    # stream_1 and stream_2 should still be in the filtered_df because they're marked as
-    # deployed but don't exist in TN (as simulated by the mock)
-    filtered_stream_ids: list[str] = filtered_df["stream_id"].tolist()
-    assert "stream_0" not in filtered_stream_ids
-    assert "stream_1" in filtered_stream_ids
-    assert "stream_2" in filtered_stream_ids
-    assert len(filtered_df) == 2
+    with caplog.at_level(logging.ERROR):
+
+        @flow
+        def run_flow():
+            return deploy_streams_flow(
+                psd_block=primitive_descriptor,
+                tna_block=tn_access_block,
+                check_stream_state=False,  # Simple path
+            )
+
+        results = run_flow()
+
+    # Should succeed after retry
+    assert results["deployed_count"] == 1
+    assert results["skipped_count"] == 0
+    assert "stream_0" in tn_access_block.deployed_streams
+
+    # Should have logged an error for the transient failure
+    assert "Transient failure!" in caplog.text
 
 
 @pytest.mark.usefixtures("prefect_test_fixture")
@@ -462,17 +556,287 @@ def test_mark_batch_deployed_task_empty_list() -> None:
     assert len(deployment_state.marked_streams) == 0
 
 
-# Helper to create a mock future for the batch filter task
-def create_mock_filter_future(
-    existing_stream_ids: list[str], account: str = "dummy_account"
-) -> PrefectFuture[DataFrame[StreamLocatorModel]]:
-    """Creates a mock PrefectFuture that resolves to a StreamLocatorModel DataFrame."""
-    mock_future = MagicMock(spec=PrefectFuture)
-    result_df = DataFrame[StreamLocatorModel](
-        pd.DataFrame({"stream_id": existing_stream_ids, "data_provider": account})
+# --- Tests for Internal Tasks --- #
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_check_deployment_state(
+    deployment_state_block: TestDeploymentStateBlock,
+    monkeypatch: MonkeyPatch,
+):
+    """Test the task_check_deployment_state wrapper task."""
+    # Set up the mock deployment state
+    predeployed = {"stream_0": True, "stream_2": True}
+    deployment_state_block.deployed_streams = predeployed
+    stream_ids_to_check = ["stream_0", "stream_1", "stream_2", "stream_3"]
+
+    # Mock get_run_logger
+    mock_logger = MagicMock()
+    monkeypatch.setattr("tsn_adapters.flows.stream_deploy_flow.get_run_logger", lambda: mock_logger)
+
+    # Call the task's function directly
+    result = task_check_deployment_state.fn(deployment_state=deployment_state_block, stream_ids=stream_ids_to_check)
+
+    # Assert the result matches the expected state
+    expected_result = {
+        "stream_0": True,  # Predeployed
+        "stream_1": False,
+        "stream_2": True,  # Predeployed
+        "stream_3": False,
+    }
+    assert result == expected_result
+    mock_logger.debug.assert_any_call(f"Checking deployment state for {len(stream_ids_to_check)} streams.")
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_check_deployment_state_empty_input(
+    deployment_state_block: TestDeploymentStateBlock,
+    monkeypatch: MonkeyPatch,
+):
+    """Test task_check_deployment_state with empty input list."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr("tsn_adapters.flows.stream_deploy_flow.get_run_logger", lambda: mock_logger)
+
+    result = task_check_deployment_state.fn(deployment_state=deployment_state_block, stream_ids=[])
+
+    assert result == {}
+    mock_logger.debug.assert_any_call("No stream IDs provided to check deployment state.")
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_check_deployment_state_exception(
+    deployment_state_block: TestDeploymentStateBlock,
+    monkeypatch: MonkeyPatch,
+):
+    """Test task_check_deployment_state exception handling."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr("tsn_adapters.flows.stream_deploy_flow.get_run_logger", lambda: mock_logger)
+
+    # Make the mock block raise an error
+    mock_check = MagicMock(side_effect=ValueError("State check failed"))
+    deployment_state_block.check_multiple_streams = mock_check
+
+    with pytest.raises(ValueError, match="State check failed"):
+        task_check_deployment_state.fn(deployment_state=deployment_state_block, stream_ids=["stream_0"])
+
+    mock_check.assert_called_once_with(["stream_0"])
+    mock_logger.error.assert_called_once()
+
+
+# --- Tests for task_check_exist_deploy_init --- #
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_check_exist_deploy_init_deploys_and_inits(
+    tn_access_block: FakeTNAccessBlock,  # Use the fixture
+):
+    """Test task_check_exist_deploy_init when stream doesn't exist, using fakes and no patching."""
+    stream_id = "new_stream"
+    tn_access_block.reset()  # Ensure clean state
+    tn_access_block.set_deployed_streams(set())  # Ensure stream doesn't exist initially
+
+    # Call the task's function using .submit() to ensure Prefect context
+    @flow
+    def test_flow():
+        return task_check_exist_deploy_init(stream_id=stream_id, tna_block=tn_access_block)
+
+    status = test_flow()
+
+    # Assert the final status
+    assert status == "deployed"
+    # Assert the state of the fake block
+    assert tn_access_block.deploy_calls == [stream_id]
+    assert stream_id in tn_access_block.deployed_streams
+    assert stream_id in tn_access_block.initialized_streams
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_check_exist_deploy_init_skips_existing(
+    tn_access_block: LoggingFakeTNAccessBlock,  # Use base fixture
+):
+    """Test task_check_exist_deploy_init when deploy raises StreamAlreadyExistsError, using fakes and no patching."""
+    stream_id = "existing_stream"
+    # Create the specific ErrorBlock for this test
+    error_block = ErrorBlock(existing_streams=set())
+
+    from prefect import flow
+
+    @flow
+    def test_flow():
+        # Pass the error_block instance to the task
+        return task_check_exist_deploy_init(stream_id=stream_id, tna_block=error_block)
+
+    status = test_flow()
+
+    assert status == "initialized"
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_task_check_exist_deploy_init_already_exists_error(
+    tn_access_block: LoggingFakeTNAccessBlock,  # Use base fixture
+):
+    """Test task_check_exist_deploy_init handles StreamAlreadyExistsError from deploy, using fakes and no patching."""
+    stream_id = "error_stream"
+    # Create the specific ErrorBlock for this test
+    error_block = ErrorBlock(existing_streams=set())
+
+    from prefect import flow
+
+    @flow
+    def test_flow():
+        # Pass the error_block instance to the task
+        return task_check_exist_deploy_init(stream_id=stream_id, tna_block=error_block)
+
+    status = test_flow()
+
+    assert status == "initialized"
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+# Remove all patches
+def test_deploy_streams_flow_custom_batch_size(
+    # Remove mocks
+    tn_access_block: FakeTNAccessBlock,
+    primitive_descriptor: TestPrimitiveSourcesDescriptor,
+    deployment_state_block: TestDeploymentStateBlock,  # Use fixture
+    # Remove monkeypatch
+) -> None:
+    """Test flow with a custom batch size, relying on fakes."""
+    # Setup: All streams are new
+    tn_access_block.reset()
+    deployment_state_block.reset()
+
+    # --- NO MOCKS for flow tasks --- #
+
+    # --- Run the flow ---
+    results = deploy_streams_flow(
+        psd_block=primitive_descriptor,
+        tna_block=tn_access_block,
+        deployment_state=deployment_state_block,
+        batch_size=1,  # Test custom batch size
+        check_stream_state=False,
     )
-    mock_future.result.return_value = result_df
-    return mock_future
+
+    # Assertions: All 3 streams should be deployed
+    assert results["deployed_count"] == 3
+    assert results["skipped_count"] == 0
+
+    # Verify TN Access Block state
+    assert tn_access_block.deploy_calls == ["stream_0", "stream_1", "stream_2"]
+    assert tn_access_block.deployed_streams == {"stream_0", "stream_1", "stream_2"}
+    assert tn_access_block.initialized_streams == {"stream_0", "stream_1", "stream_2"}
+
+    # Verify Deployment State Block state (batches should be size 1)
+    assert len(deployment_state_block.marked_streams) == 3
+    marked_ids = set()
+    for streams, _ in deployment_state_block.marked_streams:
+        assert len(streams) == 1  # Check batch size
+        marked_ids.update(streams)
+    assert marked_ids == {"stream_0", "stream_1", "stream_2"}
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_deploy_streams_flow_start_from_batch(
+    tn_access_block: LoggingFakeTNAccessBlock,
+):
+    """Test that the flow respects the start_from_batch parameter, using fakes and no patching."""
+    num_streams = 5
+    batch_size = 2
+    start_batch = 1  # Start from the second batch (index 1)
+    primitive_descriptor = TestPrimitiveSourcesDescriptor(num_streams=num_streams)
+    deployment_state = TestDeploymentStateBlock()
+    tn_access_block.reset()
+
+    # Run flow starting from batch 1 within a test flow context
+    from prefect import flow
+
+    @flow
+    def run_flow():
+        return deploy_streams_flow(
+            psd_block=primitive_descriptor,
+            tna_block=tn_access_block,
+            deployment_state=deployment_state,
+            # Let's try check_stream_state=False first, as start_from_batch
+            # might work correctly even on the simple path. If not, we can change it.
+            check_stream_state=False,
+            batch_size=batch_size,
+            start_from_batch=start_batch,
+        )
+
+    results = run_flow()
+
+    # The first batch ([0, 1]) should be skipped, only [2, 3] and [4] processed
+    # So only streams 2, 3, 4 should be deployed/initialized
+    assert results["deployed_count"] == 3
+    # Streams skipped by start_from_batch aren't counted in skipped_count
+    assert results["skipped_count"] == 0
+    assert tn_access_block.deploy_calls == ["stream_2", "stream_3", "stream_4"]
+    assert tn_access_block.deployed_streams == {"stream_2", "stream_3", "stream_4"}
+    assert tn_access_block.initialized_streams == {"stream_2", "stream_3", "stream_4"}
+    # Verify state block was updated for only the processed streams
+    marked_ids = set()
+    for streams, _ in deployment_state.marked_streams:
+        marked_ids.update(streams)
+    assert marked_ids == {"stream_2", "stream_3", "stream_4"}
+
+
+@pytest.mark.usefixtures("prefect_test_fixture")
+def test_deploy_streams_flow_mixed_states_check_stream_state():
+    """Test deploy_streams_flow with check_stream_state=True and mixed stream states."""
+
+    # Arrange: Set up 4 streams with mixed states
+    class MixedStateDescriptor(TestPrimitiveSourcesDescriptor):
+        num_streams = 4
+
+        def get_descriptor(self) -> DataFrame[PrimitiveSourceDataModel]:
+            data = {
+                "stream_id": [f"stream_{i}" for i in range(self.num_streams)],
+                "source_id": [f"src_{i}" for i in range(self.num_streams)],
+                "source_type": ["type1" for _ in range(self.num_streams)],
+            }
+            return DataFrame[PrimitiveSourceDataModel](pd.DataFrame(data))
+
+    # stream_0: not deployed
+    # stream_1: deployed but not initialized
+    # stream_2: deployed and initialized
+    # stream_3: not deployed
+    deployed = {"stream_1", "stream_2"}
+    initialized = {"stream_2"}
+    tn_access_block = LoggingFakeTNAccessBlock(existing_streams=deployed, initialized_streams=initialized)
+    tn_access_block.reset()
+    tn_access_block.set_deployed_streams(deployed)
+    tn_access_block.set_initialized_streams(initialized)
+    deployment_state_block = TestDeploymentStateBlock()
+    primitive_descriptor = MixedStateDescriptor()
+
+    # Act: Run the flow with check_stream_state=True
+    @flow
+    def run_flow():
+        return deploy_streams_flow(
+            psd_block=primitive_descriptor,
+            tna_block=tn_access_block,
+            deployment_state=deployment_state_block,
+            check_stream_state=True,
+        )
+
+    results = run_flow()
+
+    # Assert: Only stream_0 and stream_3 are deployed+initialized, stream_1 is only initialized, stream_2 is skipped
+    assert results["deployed_count"] == 3  # stream_0, stream_1, stream_3 processed (stream_2 skipped)
+    assert results["skipped_count"] == 1  # stream_2 skipped (already deployed+initialized)
+
+    # Check deploy calls: should be for stream_0 and stream_3 only
+    assert set(tn_access_block.deploy_calls) == {"stream_0", "stream_3"}
+    # All processed streams should be initialized
+    assert tn_access_block.initialized_streams == {"stream_0", "stream_1", "stream_2", "stream_3"}
+    # Deployed streams should include all except stream_1 (which was only initialized)
+    assert tn_access_block.deployed_streams == {"stream_0", "stream_1", "stream_2", "stream_3"}
+
+    # Deployment state block should be updated for all processed streams except the skipped one
+    marked_ids = set()
+    for streams, _ in deployment_state_block.marked_streams:
+        marked_ids.update(streams)
+    assert marked_ids == {"stream_0", "stream_1", "stream_3"}
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_stream_deploy_flow_integration.py
+++ b/tests/integration/test_stream_deploy_flow_integration.py
@@ -1,0 +1,112 @@
+from prefect import flow
+import pytest
+from trufnetwork_sdk_py.utils import generate_stream_id
+
+from tsn_adapters.blocks.tn_access import TNAccessBlock
+from tsn_adapters.flows.stream_deploy_flow import task_check_exist_deploy_init
+
+# Marks all tests in this file as integration tests
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.usefixtures("prefect_test_fixture", "tn_node") # Ensure Prefect and TSN node are ready
+def test_task_check_exist_deploy_init_handles_already_deployed(tn_block: TNAccessBlock):
+    """
+    Integration test for task_check_exist_deploy_init.
+    Verifies that the task correctly handles a stream that is already deployed
+    by proceeding to initialize it without raising an error.
+    Uses the real tn_block fixture.
+    """
+    stream_id = generate_stream_id("integ_test_already_deployed")
+    print(f"Generated stream ID for test: {stream_id}") # Debug output
+
+    try:
+        # --- Setup: Deploy the stream first ---
+        print(f"Deploying stream {stream_id}...")
+        deploy_tx = tn_block.deploy_stream(stream_id, wait=True)
+        print(f"Stream {stream_id} deployed. Tx: {deploy_tx}")
+
+        # --- Execute the task within a flow ---
+        @flow
+        def test_flow_wrapper(block: TNAccessBlock):
+            print(f"Running task_check_exist_deploy_init for {stream_id}...")
+            # Call the task directly (since it's already decorated with @task)
+            status = task_check_exist_deploy_init(stream_id=stream_id, tna_block=block)
+            print(f"Task returned status: {status}")
+            return status
+
+        # Run the flow with the real block
+        result_status = test_flow_wrapper(block=tn_block)
+
+        # --- Assert ---
+        # If deploy already happened, the task should recognize this and proceed to init.
+        # The final status should indicate initialization occurred or was confirmed.
+        assert result_status == "initialized"
+        print(f"Assertion passed: Status is '{result_status}' as expected.")
+
+        # Verify initialization actually happened (e.g., check for first record)
+        try:
+            stream_type = tn_block.get_stream_type(tn_block.current_account, stream_id)
+            assert stream_type == "primitive"
+            print(f"Verified: Stream {stream_id} is initialized.")
+        except Exception as e:
+            pytest.fail(f"Failed to verify stream initialization for {stream_id}: {e}")
+
+
+    finally:
+        # --- Cleanup ---
+        print(f"Cleaning up stream {stream_id}...")
+        try:
+            tn_block.destroy_stream(stream_id, wait=True)
+            print(f"Stream {stream_id} destroyed successfully.")
+        except Exception as e:
+            # Log cleanup error but don't fail the test if the main logic passed
+            print(f"Warning: Failed to destroy stream {stream_id} during cleanup: {e}")
+
+
+@pytest.mark.usefixtures("prefect_test_fixture", "tn_node")
+def test_task_check_exist_deploy_init_handles_already_initialized(tn_block: TNAccessBlock):
+    """
+    Integration test for task_check_exist_deploy_init.
+    Verifies that the task correctly handles a stream that is already deployed *and* initialized
+    by recognizing the existing state without raising an error.
+    Uses the real tn_block fixture.
+    """
+    stream_id = generate_stream_id("integ_test_already_initialized")
+    print(f"Generated stream ID for test: {stream_id}")
+
+    try:
+        # --- Setup: Deploy and Initialize the stream first ---
+        print(f"Deploying stream {stream_id}...")
+        deploy_tx = tn_block.deploy_stream(stream_id, wait=True)
+        print(f"Stream {stream_id} deployed. Tx: {deploy_tx}")
+
+        print(f"Initializing stream {stream_id}...")
+        init_tx = tn_block.init_stream(stream_id, wait=True)
+        print(f"Stream {stream_id} initialized. Tx: {init_tx}")
+
+        # --- Execute the task within a flow ---
+        @flow
+        def test_flow_wrapper(block: TNAccessBlock):
+            print(f"Running task_check_exist_deploy_init for already initialized {stream_id}...")
+            status = task_check_exist_deploy_init(stream_id=stream_id, tna_block=block)
+            print(f"Task returned status: {status}")
+            return status
+
+        # Run the flow with the real block
+        result_status = test_flow_wrapper(block=tn_block)
+
+        # --- Assert ---
+        # If deploy and init already happened, the task should recognize this.
+        # The final status should indicate it's already initialized.
+        assert result_status == "initialized"
+        print(f"Assertion passed: Status is '{result_status}' as expected for already initialized stream.")
+
+    finally:
+        # --- Cleanup ---
+        print(f"Cleaning up stream {stream_id}...")
+        try:
+            tn_block.destroy_stream(stream_id, wait=True)
+            print(f"Stream {stream_id} destroyed successfully.")
+        except Exception as e:
+            print(f"Warning: Failed to destroy stream {stream_id} during cleanup: {e}") 

--- a/tests/integration/test_stream_filtering_integration.py
+++ b/tests/integration/test_stream_filtering_integration.py
@@ -1,0 +1,68 @@
+from typing import Any
+import pytest
+from tsn_adapters.blocks.tn_access import TNAccessBlock, StreamLocatorModel, convert_to_typed_df
+from tsn_adapters.blocks.stream_filtering import task_get_stream_states_divide_conquer
+import pandas as pd
+from trufnetwork_sdk_py.utils import generate_stream_id
+
+
+@pytest.mark.integration
+def test_stream_state_partitioning_with_real_tn(tn_block: TNAccessBlock):
+    """
+    Integration test: Verifies stream state partitioning against a real TN node.
+
+    - Deploys a new stream (should be non-deployed at first).
+    - Initializes it (should become deployed and initialized).
+    - Checks state partitioning at each step.
+    - Cleans up after itself.
+    """
+    # Arrange
+    data_provider = tn_block.current_account
+    stream_id = generate_stream_id("testintegrationstream00000000000001")
+    locators = pd.DataFrame([{"data_provider": data_provider, "stream_id": stream_id}])
+    locators_typed = convert_to_typed_df(locators, StreamLocatorModel)
+
+    # Ensure stream does not exist
+    try:
+        tn_block.destroy_stream(stream_id, wait=True)
+    except Exception:
+        pass  # Ignore if not found
+
+    # Act & Assert: 1. Should be non-deployed
+    result = task_get_stream_states_divide_conquer.fn(
+        block=tn_block,
+        stream_locators=locators_typed,
+        max_depth=2,
+        current_depth=0,
+    )
+    assert len(result["non_deployed"]) == 1
+    assert result["non_deployed"].iloc[0]["stream_id"] == stream_id
+
+    # Act: Deploy the stream (but do not initialize)
+    tn_block.deploy_stream(stream_id, wait=True)
+
+    # Assert: Should be deployed but not initialized
+    result2 = task_get_stream_states_divide_conquer.fn(
+        block=tn_block,
+        stream_locators=locators_typed,
+        max_depth=2,
+        current_depth=0,
+    )
+    assert len(result2["deployed_but_not_initialized"]) == 1
+    assert result2["deployed_but_not_initialized"].iloc[0]["stream_id"] == stream_id
+
+    # Act: Initialize the stream
+    tn_block.init_stream(stream_id, wait=True)
+
+    # Assert: Should be deployed and initialized
+    result3 = task_get_stream_states_divide_conquer.fn(
+        block=tn_block,
+        stream_locators=locators_typed,
+        max_depth=2,
+        current_depth=0,
+    )
+    assert len(result3["deployed_and_initialized"]) == 1
+    assert result3["deployed_and_initialized"].iloc[0]["stream_id"] == stream_id
+
+    # Cleanup
+    tn_block.destroy_stream(stream_id, wait=True)

--- a/tests/utils/fake_tn_access.py
+++ b/tests/utils/fake_tn_access.py
@@ -1,0 +1,168 @@
+from typing import Any, Optional
+
+from pandera.typing import DataFrame
+from pydantic import SecretStr
+
+from tsn_adapters.blocks.shared_types import StreamLocatorModel
+from tsn_adapters.blocks.tn_access import (
+    MetadataProcedureNotFoundError,
+    StreamAlreadyExistsError,
+    TNAccessBlock,
+    convert_to_typed_df,
+)
+
+
+class FakeTNAccessBlock(TNAccessBlock):
+    """
+    In-memory fake TNAccessBlock for testing.
+
+    - Tracks deployed and initialized streams in memory.
+    - No real network or SDK calls.
+    - Allows error injection for negative test cases.
+    - Extensible for future test scenarios.
+    - Provides public properties for test assertions: .deployed_streams, .deploy_calls
+    - Provides set_deployed_streams() for test setup.
+    """
+
+    def __init__(
+        self,
+        existing_streams: Optional[set[str]] = None,
+        initialized_streams: Optional[set[str]] = None,
+        error_on: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(
+            tn_provider="fake",
+            tn_private_key=SecretStr("fake"),
+            helper_contract_name="fake",
+            helper_contract_deployer=None,
+        )
+        # Override client to prevent real SDK initialization
+        self._client = None  # Fake block doesn't use a real client
+        self._current_account = "fake_account"  # Provide a dummy account
+        self._existing_streams: set[str] = set(existing_streams) if existing_streams else set()
+        self._initialized_streams: set[str] = set(initialized_streams) if initialized_streams else set()
+        self._error_on: dict[str, Any] = error_on or {}
+        self._destroyed_streams: set[str] = set()
+        self._deploy_calls: list[str] = []
+        self._init_calls: list[str] = []
+
+    # Keep the current_account override
+    @property
+    def current_account(self) -> str:
+        return self._current_account
+
+    def set_deployed_streams(self, streams: set[str]) -> None:
+        """Set the deployed streams for test setup."""
+        self._existing_streams = set(streams)
+
+    @property
+    def deployed_streams(self) -> set[str]:
+        """Set of currently deployed streams (for test assertions)."""
+        return set(self._existing_streams)
+
+    @property
+    def deploy_calls(self) -> list[str]:
+        """List of stream_ids passed to deploy_stream (for test assertions)."""
+        return list(self._deploy_calls)
+
+    @property
+    def initialized_streams(self) -> set[str]:
+        """Set of currently initialized streams (for test assertions)."""
+        return set(self._initialized_streams)
+
+    def set_initialized_streams(self, streams: set[str]) -> None:
+        """
+        Set the initialized streams for this fake block directly (for test setup).
+        Args:
+            streams (set[str]): The set of stream IDs to mark as initialized.
+        """
+        self._initialized_streams = set(streams)
+
+    def stream_exists(self, data_provider: str, stream_id: str) -> bool:
+        if self._error_on.get("stream_exists"):
+            raise self._error_on["stream_exists"]
+        return stream_id in self._existing_streams and stream_id not in self._destroyed_streams
+
+    def deploy_stream(self, stream_id: str, stream_type: str = "primitive", wait: bool = True) -> str:
+        if self._error_on.get("deploy_stream"):
+            raise self._error_on["deploy_stream"]
+        if stream_id in self._existing_streams:
+            raise StreamAlreadyExistsError(stream_id)
+        self._existing_streams.add(stream_id)
+        self._deploy_calls.append(stream_id)
+        return f"deploy_tx_{stream_id}"
+
+    def init_stream(self, stream_id: str, wait: bool = True) -> str:
+        if self._error_on.get("init_stream"):
+            raise self._error_on["init_stream"]
+        if stream_id not in self._existing_streams:
+            raise RuntimeError(f"Stream {stream_id} does not exist for init.")
+        self._initialized_streams.add(stream_id)
+        self._init_calls.append(stream_id)
+        return f"init_tx_{stream_id}"
+
+    def wait_for_tx(self, tx_hash: str) -> None:
+        if self._error_on.get("wait_for_tx"):
+            raise self._error_on["wait_for_tx"]
+        # No-op for fake
+
+    def destroy_stream(self, stream_id: str, wait: bool = True) -> str:
+        self._destroyed_streams.add(stream_id)
+        self._existing_streams.discard(stream_id)
+        self._initialized_streams.discard(stream_id)
+        return f"destroy_tx_{stream_id}"
+
+    def get_stream_type(self, data_provider: str, stream_id: str) -> str:
+        # First check existence
+        if stream_id not in self._existing_streams:
+            # Raise an error indicating the stream doesn't exist
+            # Using RuntimeError for now, adjust if a more specific error exists
+            raise RuntimeError(f"Stream {stream_id} not found for data_provider {data_provider}.")
+        
+        # Then check initialization status if it exists
+        if stream_id in self._initialized_streams:
+            return "primitive"
+        
+        # If it exists but isn't initialized
+        raise RuntimeError(f"Stream {stream_id} exists but is not initialized.")
+
+    def filter_initialized_streams(
+        self, stream_ids: list[str], data_providers: list[str]
+    ) -> DataFrame[StreamLocatorModel]:
+        """Fake batch filter for initialized streams, with error injection.
+
+        Mimics real behavior where the batch call fails if any stream doesn't exist.
+        """
+        if self._error_on.get("batch_init"):
+            raise self._error_on["batch_init"]
+
+        # Check for non-existent streams first - the real batch call would likely fail
+        non_existent = [sid for sid in stream_ids if sid not in self._existing_streams]
+        if non_existent:
+            # Raise MetadataProcedureNotFoundError, as this is what the real system might raise
+            raise MetadataProcedureNotFoundError(
+                f"Batch initialization check failed: Streams do not exist: {non_existent}"
+            )
+
+        # Return only streams that are both deployed and initialized
+        result = []
+        for stream_id, data_provider in zip(stream_ids, data_providers):
+            if stream_id in self._existing_streams and stream_id in self._initialized_streams:
+                result.append({"data_provider": data_provider, "stream_id": stream_id})
+        df = DataFrame(result, columns=["data_provider", "stream_id"])
+        return convert_to_typed_df(df, StreamLocatorModel)
+
+    # Utility methods for tests
+    def set_error(self, method: str, error: Exception) -> None:
+        self._error_on[method] = error
+
+    def clear_error(self, method: str) -> None:
+        if method in self._error_on:
+            del self._error_on[method]
+
+    def reset(self) -> None:
+        self._existing_streams.clear()
+        self._initialized_streams.clear()
+        self._destroyed_streams.clear()
+        self._deploy_calls.clear()
+        self._init_calls.clear()


### PR DESCRIPTION
## Description
* Introduced `FakeTNAccessBlock`: Created an in-memory fake implementation of `TNAccessBlock` in `tests/utils/fake_tn_access.py` to provide a more realistic and controllable testing environment for tasks interacting with the Truflation Network, reducing reliance on extensive mocking.
* Refactored Stream Filtering Logic:
    * Improved the logic within `src/tsn_adapters/blocks/stream_filtering.py` for clarity and efficiency.
    * Added `task_get_stream_states_divide_conquer` for scalable checking of stream deployment and initialization states, handling batching, fallbacks, and recursive checks.
* Updated Testing Strategy:
    * Modified existing tests in `tests/blocks/test_stream_filtering.py` and `tests/flows/test_stream_deploy_flow.py` to utilize the new `FakeTNAccessBlock`, replacing previous mocking strategies.
    * Added new unit tests for `task_deploy_primitive` error handling in `test_stream_deployment_initialization.py`.
* Improved Error Handling:
    * Added custom exceptions (`StreamAlreadyExistsError`, `StreamAlreadyInitializedError`) in `tn_access.py` for more specific error management.
    * Enhanced error handling and logging within deployment tasks and flows (`stream_deploy_flow.py`, `tn.py`).
* Added Integration Tests: Implemented new integration tests (`tests/integration/`) verifying stream state partitioning (`test_stream_state_partitioning.py`) and the `task_check_exist_deploy_init` logic against a real TN node or the fake block.
* Codebase Maintenance: Corrected various import paths across multiple test files for consistency.

## Related Problem
- fix https://github.com/trufnetwork/truf-data-provider/issues/580

## How Has This Been Tested?
* Existing unit and flow tests have been updated to use the new `FakeTNAccessBlock`, ensuring previous functionality remains intact within the new testing paradigm.
* New unit tests were added specifically for:
    * Error handling scenarios in `task_deploy_primitive`.
    * Behavior of the `task_get_stream_states_divide_conquer` under various conditions (fallback, batch failure).
* New integration tests were added to verify:
    * Correct stream state partitioning (`non_deployed`, `deployed_but_not_initialized`, `deployed_and_initialized`) logic.
    * Idempotency and state handling of `task_check_exist_deploy_init`.