### PR TITLE
feat(argentina): parametrize filter_size

### DIFF
--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -1018,7 +1018,7 @@ def task_split_and_insert_records(
     is_unix: bool = False,
     fail_on_batch_error: bool = False,
     filter_deployed_streams: bool = True,
-    max_filter_size: int = 5000,
+    max_filter_size: int = 500,
     filter_cache_duration: timedelta = timedelta(days=1),
     max_filter_depth: int = 10,
     # this is used only by truflation's data adapter streams


### PR DESCRIPTION
# Align filter_size defaults and enhance Argentina SEPA insert flow

## Description

- Adjust default `max_filter_size` in `task_split_and_insert_records` from `5000` to `500` to align with filtering logic.
- Expose `max_filter_size` parameter in `insert_argentina_products_flow` signature and propagate it to the insertion task call.
- Enhance `insert_argentina_products_flow` documentation:
- Clarify parameter comments for both `batch_size` and `max_filter_size` to improve readability and maintainability.

## Related Problem

- fix https://github.com/trufnetwork/truf-data-provider/issues/589

## How Has This Been Tested?
