### PR TITLE
feat: Add `source_display_name` and stream init filtering

### DIFF
--- a/src/tsn_adapters/blocks/models/sql_models.py
+++ b/src/tsn_adapters/blocks/models/sql_models.py
@@ -22,6 +22,7 @@ primitive_sources_table = Table(
     Column("stream_id", TEXT, primary_key=True, nullable=False),
     Column("source_id", TEXT, nullable=False),
     Column("source_type", TEXT, nullable=False),
+    Column("source_display_name", TEXT, nullable=True),
     Column("is_deployed", Boolean, nullable=False, server_default=text('false')),
     Column("deployed_at", DateTime(timezone=True), nullable=True),
     Column(

--- a/src/tsn_adapters/blocks/primitive_source_descriptor.py
+++ b/src/tsn_adapters/blocks/primitive_source_descriptor.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import pandas as pd
 import pandera as pa
-from pandera import DataFrameModel
+from pandera import DataFrameModel, Field
 from pandera.typing import DataFrame, Series
 from prefect import Task, task
 from prefect.blocks.core import Block
@@ -20,6 +20,11 @@ class PrimitiveSourceDataModel(DataFrameModel):
     stream_id: Series[str]
     source_id: Series[str]
     source_type: Series[str]
+    source_display_name: Series[str] = Field(
+        description="The display name of the source",
+        default=None,
+        nullable=True,
+    )
 
     class Config(pa.DataFrameModel.Config):
         strict = "filter"

--- a/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
@@ -13,7 +13,7 @@ from prefect_aws import S3Bucket
 
 from tsn_adapters.blocks.deployment_state import DeploymentStateBlock
 from tsn_adapters.blocks.primitive_source_descriptor import PrimitiveSourceDataModel, PrimitiveSourcesDescriptorBlock
-from tsn_adapters.blocks.tn_access import TNAccessBlock, task_split_and_insert_records
+from tsn_adapters.blocks.tn_access import TNAccessBlock, task_split_and_insert_records, task_filter_initialized_streams
 from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
 from tsn_adapters.tasks.argentina.config import ArgentinaFlowVariableNames  # Import config
 from tsn_adapters.tasks.argentina.models.sepa.sepa_models import SepaAvgPriceProductModel
@@ -204,12 +204,31 @@ State is managed by Prefect Variables.
             total_records_transformed += num_transformed
             logger.info(f"Transformed {num_transformed} records for date {date_str}.")
 
-            # Step 11: Insert Transformed Data to TN
+            # Step 11: Pre-Insertion Filtering and Insert Transformed Data to TN
             if not transformed_data.empty:
-                logger.info(
-                    f"Submitting {num_transformed} transformed records for date {date_str} to TN insertion task..."
-                )
-                
+                # Batch filtering of streams and fail fast on first uninitialized stream
+                logger.info(f"Filtering {len(transformed_data)} transformed records for date {date_str} in batches of size {max_filter_size}...")
+                total_records = len(transformed_data)
+                for start in range(0, total_records, max_filter_size):
+                    batch = transformed_data.iloc[start : start + max_filter_size]
+                    batch_result = task_filter_initialized_streams(
+                        block=tn_block,
+                        records=batch,
+                        max_filter_size=max_filter_size,
+                    )
+                    uninitialized_streams = batch_result["uninitialized_streams"]
+                    if not uninitialized_streams.empty:
+                        uninit_list = uninitialized_streams["stream_id"].tolist()[:20]
+                        error_msg = (
+                            f"Halting flow: Date {date_str} cannot be processed because the following streams "
+                            f"are not initialized: {uninit_list}..."
+                        )
+                        logger.error(error_msg)
+                        raise DeploymentCheckError(error_msg)
+                # All streams are initialized
+                logger.info(f"All streams are initialized for date {date_str}. Proceeding to insertion.")
+                # Proceed to insertion without additional filtering
+                logger.info(f"Submitting {num_transformed} transformed records for date {date_str} to TN insertion task...")
                 results = task_split_and_insert_records(
                     block=tn_block,
                     records=transformed_data,
@@ -218,7 +237,7 @@ State is managed by Prefect Variables.
                     wait=True,
                     return_state=False,
                     max_filter_size=max_filter_size,
-                    filter_deployed_streams=filter_deployed_streams,
+                    filter_deployed_streams=False,
                 )
                 if results["failed_records"].empty:
                     logger.info(f"Successfully submitted records for date {date_str} to TN insertion task.")

--- a/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
@@ -40,6 +40,7 @@ async def insert_argentina_products_flow(
     deployment_state: DeploymentStateBlock,
     batch_size: int = 10000,  # Default batch size (empirically chosen to balance API load and memory)
     max_filter_size: int = 500,  # Max number of streams per batch when filtering deployed streams
+    filter_deployed_streams: bool = True,
 ):
     """
     Inserts pre-calculated Argentina SEPA daily average product prices into TN streams.
@@ -217,6 +218,7 @@ State is managed by Prefect Variables.
                     wait=True,
                     return_state=False,
                     max_filter_size=max_filter_size,
+                    filter_deployed_streams=filter_deployed_streams,
                 )
                 if results["failed_records"].empty:
                     logger.info(f"Successfully submitted records for date {date_str} to TN insertion task.")

--- a/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
@@ -232,11 +232,17 @@ def _prepare_new_products_df(
         # Return empty DataFrame matching PrimitiveSourceDataModel schema
         return create_empty_df(PrimitiveSourceDataModel)
 
-    # Expect 'id_producto'
-    new_products_output = new_products[["id_producto"]].copy()
+    # Expect 'id_producto' and 'productos_descripcion' for display name
+    new_products_output = new_products[["id_producto", "productos_descripcion"]].copy()
 
-    # Rename 'id_producto' to 'source_id'
-    new_products_output.rename(columns={"id_producto": "source_id"}, inplace=True)
+    # Rename columns to match PrimitiveSourceDataModel fields
+    new_products_output.rename(
+        columns={
+            "id_producto": "source_id",
+            "productos_descripcion": "source_display_name",
+        },
+        inplace=True,
+    )
 
     # Generate stream_id
     new_products_output["stream_id"] = new_products_output["source_id"].apply(_generate_stream_id)

--- a/tests/argentina/flows/test_aggregate_products_flow.py
+++ b/tests/argentina/flows/test_aggregate_products_flow.py
@@ -138,6 +138,7 @@ def expected_df_day1() -> pd.DataFrame:
             "stream_id": ["arg_sepa_prod_1"],
             "source_id": ["1"],
             "source_type": ["argentina_sepa_product"],
+            "source_display_name": [None],
         }
     )
     return PrimitiveSourceDataModel.validate(df, lazy=True)
@@ -151,6 +152,7 @@ def expected_df_day2(expected_df_day1: pd.DataFrame) -> pd.DataFrame:
             "stream_id": ["arg_sepa_prod_1", "arg_sepa_prod_2"],
             "source_id": ["1", "2"],
             "source_type": ["argentina_sepa_product", "argentina_sepa_product"],
+            "source_display_name": [None, None],
         }
     )
     # Re-validate to ensure schema compliance
@@ -403,11 +405,13 @@ async def test_aggregate_flow_end_to_end_resume(
             "stream_id": "arg_sepa_prod_P001",
             "source_id": "P001",
             "source_type": "argentina_sepa_product",
+            "source_display_name": None,
         },
         {
             "stream_id": "arg_sepa_prod_P002",
             "source_id": "P002",
             "source_type": "argentina_sepa_product",
+            "source_display_name": None,
         },
     ]
     initial_data_df = pd.DataFrame(initial_products)
@@ -481,6 +485,7 @@ async def test_aggregate_flow_end_to_end_force_reprocess(
             "stream_id": "arg_sepa_prod_OLD",
             "source_id": "OLD",
             "source_type": "argentina_sepa_product",
+            "source_display_name": None,
         }
     ]
     initial_data_df = pd.DataFrame(initial_products)


### PR DESCRIPTION
## Description

- Add a nullable `source_display_name` column and model field; include in SQL queries.
- Map `productos_descripcion` to `source_display_name` in Argentina flows.
- Introduce `filter_deployed_streams` flag and pre-filter via `task_filter_initialized_streams`; remove redundant filtering.
- Update tests for `source_display_name`, refactor Prefect mocks, and enhance error handling.

## Related Problem

- fix https://github.com/trufnetwork/truf-data-provider/issues/590

## How Has This Been Tested?
