### PR TITLE
chore: bump prefect version to 3.3.7

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
   prefect:
     restart: always
-    image: prefecthq/prefect:3.2.1-python3.10-conda
+    image: prefecthq/prefect:3.3.7-python3.10-conda
     environment:
       PREFECT_HOME: /data
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:password@prefect-postgres/prefect
@@ -29,7 +29,7 @@ services:
 
   prefect-worker:
     restart: always
-    image: prefecthq/prefect:3.2.1-python3.10-conda
+    image: prefecthq/prefect:3.3.7-python3.10-conda
     command: prefect worker start -p default-workers
     environment:
       PREFECT_API_URL: http://prefect:4200/api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A collection of prefect tasks and examples ingesting data into TSN"
 readme = "README.md"
 dependencies = [
-    "prefect-client>=3.3.1",
+    "prefect-client==3.3.7",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@d7a4547ac6134e172c04f7d6aaccda85072a0242",
     "PyGithub",
@@ -32,7 +32,7 @@ argentina = [
 ]
 dev = [
     # we need this for the testing harness
-    "prefect>=3.3.1",
+    "prefect==3.3.7",
     "pytest-timeout",
     "pytest-mock",
     "black",


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-data-provider/issues/649

related: https://github.com/trufnetwork/truf-data-provider/pull/650

if not set, it will cause the version bumped to 3.4.1,
so I set it to the latest of 3.3.x