### PR TITLE
feat(fmp): add IndexInfo model and get_index_list method

### DIFF
--- a/src/tsn_adapters/blocks/fmp.py
+++ b/src/tsn_adapters/blocks/fmp.py
@@ -181,6 +181,21 @@ class CommodityInfo(DataFrameModel):
         coerce = True
 
 
+class IndexInfo(DataFrameModel):
+    """
+    Schema for stock market indexes from FMP API.
+    https://site.financialmodelingprep.com/developer/docs/stable/indexes-list
+    """
+    symbol: Series[str]
+    name: Series[str] = Field(nullable=True)
+    exchange: Series[str] = Field(nullable=True)
+    currency: Series[str] = Field(nullable=True)
+
+    class Config(DataFrameModel.Config):
+        strict = "filter"
+        coerce = True
+
+
 class CommodityQuote(DataFrameModel):
     """
     Schema for commodity quotes from legacy FMP API endpoint /api/v3/quotes/commodity.
@@ -460,4 +475,16 @@ class FMPBlock(Block):
             endpoint=FMPEndpoint(FMPAPI.STABLE, "commodities-list"),
             model_type=CommodityInfo,
             log_entity_name="commodities list",
+        )
+
+    def get_index_list(self) -> DataFrame[IndexInfo]:
+        """
+        Fetch the list of available stock market indexes from FMP.
+        https://site.financialmodelingprep.com/developer/docs/stable/indexes-list
+        Endpoint: /stable/index-list
+        """
+        return self._fetch_fmp_list_data(
+            endpoint=FMPEndpoint(FMPAPI.STABLE, "index-list"),
+            model_type=IndexInfo,
+            log_entity_name="stock market indexes",
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Introduce `IndexInfo` class to define the schema for stock market indexes from the FMP API, enhancing data structure clarity.
- Implement `get_index_list` method in `FMPBlock` to fetch available stock market indexes, ensuring robust error handling and type safety.
- Add integration test for `get_index_list` to validate functionality and ensure the returned DataFrame contains expected columns and data.
- Maintain existing functionality and type safety throughout the updates.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix https://github.com/trufnetwork/truf-data-provider/issues/680

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

new tests are ok