### PR TITLE
chore: less strict dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A collection of prefect tasks and examples ingesting data into TSN"
 readme = "README.md"
 dependencies = [
-    "prefect-client==3.3.7",
+    "prefect-client>=3.4.1",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20241008",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@d7a4547ac6134e172c04f7d6aaccda85072a0242",
     "PyGithub",


### PR DESCRIPTION
- Change the prefect-client dependency in pyproject.toml from a fixed version (3.3.7) to a minimum version (>=3.4.1) to allow for future updates and improvements.
- Ensure that the update maintains existing functionality and type safety throughout the project

---

- fix #196 