### PR TITLE
fix: stale ingestors by bumping prefect version to 3.4.10

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
   prefect:
     restart: always
-    image: prefecthq/prefect:3.3.7-python3.10-conda
+    image: prefecthq/prefect:3.4.10-python3.10-conda
     environment:
       PREFECT_HOME: /data
       PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:password@prefect-postgres/prefect
@@ -29,7 +29,7 @@ services:
 
   prefect-worker:
     restart: always
-    image: prefecthq/prefect:3.3.7-python3.10-conda
+    image: prefecthq/prefect:3.4.10-python3.10-conda
     command: prefect worker start -p default-workers
     environment:
       PREFECT_API_URL: http://prefect:4200/api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A collection of prefect tasks and examples ingesting data into TS
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "prefect-client>=3.4.1",
+    "prefect-client==3.4.10",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20250618",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@5d320512a98fac703655595c07c84491d32d4519",
     "PyGithub",
@@ -33,7 +33,7 @@ argentina = [
 ]
 dev = [
     # we need this for the testing harness
-    "prefect==3.3.7",
+    "prefect==3.4.10",
     "pytest-timeout",
     "pytest-mock",
     "black",


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-data-provider/issues/744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Prefect and related dependencies to version 3.4.10.
  * Upgraded Prefect Docker images to version 3.4.10 for all services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->