### PR TITLE
chore: pin pandas <2.3 for pandas-datareader compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@5d320512a98fac703655595c07c84491d32d4519",
     "PyGithub",
     "pandera>=0.23.1",
-    "pandas",
+    "pandas>=2.0,<2.3",  # Pin to <2.3 for pandas-datareader compatibility (transitive dep from truflation-data)
     "prefect-sqlalchemy",
     "SQLAlchemy",
     "psycopg2-binary",


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3134
related: https://github.com/truflation/truflation/issues/77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pandas dependency version constraints to ensure compatibility with supported versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->