### PR TITLE
chore: use sdk-py BulkInserter for pipelined insert_records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "prefect-client>=3.4.10",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20250618",
-    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@5d320512a98fac703655595c07c84491d32d4519",
+    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@7799703e674aacd7a1d2c5e9d80da97d44dd28c0",
     "PyGithub",
     "pandera>=0.23.1",
     "pandas<2.3",

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -21,6 +21,7 @@ from prefect.client.schemas.objects import State, TaskRun
 from prefect.concurrency.sync import concurrency, rate_limit
 from pydantic import ConfigDict, SecretStr
 import trufnetwork_sdk_c_bindings.exports as truf_sdk
+from trufnetwork_sdk_py import BulkInserter, BulkInsertError
 import trufnetwork_sdk_py.client as tn_client
 from typing_extensions import ParamSpec
 
@@ -511,19 +512,11 @@ class TNAccessBlock(Block):
 
         return tx_hash
 
-    @handle_tn_errors
-    def batch_insert_tn_records(
+    def _records_to_batches(
         self,
         records: DataFrame[TnDataRowModel],
-    ) -> Optional[str]:
-        """Batch insert records into multiple streams.
-
-        Args:
-            records: DataFrame containing records with stream_id column
-
-        Returns:
-            Transaction hash if successful, None otherwise
-        """
+    ) -> list[tn_client.RecordBatch]:
+        """Filter zero-values and group a TnDataRow DataFrame into per-stream RecordBatches."""
         if "value" in records.columns and not records.empty:
             original_count = len(records)
             mask = records["value"].apply(self._value_is_nonzero_str)
@@ -536,9 +529,8 @@ class TNAccessBlock(Block):
 
         if len(records) == 0:
             self.logger.info("No records to insert from the batch.")
-            return None
+            return []
 
-        # Convert DataFrame to format expected by client
         batches: list[tn_client.RecordBatch] = []
         stream_locators = records[["data_provider", "stream_id"]].drop_duplicates()
         for _, row in stream_locators.iterrows():
@@ -552,12 +544,31 @@ class TNAccessBlock(Block):
                 for record in stream_records.to_dict(orient="records")
             ]
 
-            # check that all dates are unix timestamps
             if not all(check_unix_timestamp(int(record["date"])) for record in inputs):
                 raise ValueError("All dates must be unix timestamps")
 
             batches.append(tn_client.RecordBatch(stream_id=row["stream_id"], inputs=inputs))
 
+        return batches
+
+    @handle_tn_errors
+    def batch_insert_tn_records(
+        self,
+        records: DataFrame[TnDataRowModel],
+    ) -> Optional[str]:
+        """Batch insert records into multiple streams in a single transaction.
+
+        Note: subject to the node's per-tx insert cap (currently 10 rows).
+        For large batches, prefer ``bulk_insert_tn_records`` which chunks
+        and pipelines automatically.
+
+        Args:
+            records: DataFrame containing records with stream_id column
+
+        Returns:
+            Transaction hash if successful, None otherwise
+        """
+        batches = self._records_to_batches(records)
         if not batches:
             return None
 
@@ -566,6 +577,36 @@ class TNAccessBlock(Block):
                 batches=batches,
                 wait=False,
             )
+
+    @handle_tn_errors
+    def bulk_insert_tn_records(
+        self,
+        records: DataFrame[TnDataRowModel],
+        batch_size: int = 10,
+    ) -> list[str]:
+        """Pipelined high-throughput insert via sdk-py BulkInserter.
+
+        Chunks records into ``batch_size`` per insert_records tx (must be
+        <= the node's protocol cap, currently 10) and broadcasts with a
+        cached nonce so admission (~50ms) becomes the rate limit instead
+        of inclusion (~1-2s/block). Returns one tx hash per chunk; raises
+        ``BulkInsertError`` on chunk failure (carrying partial tx_hashes
+        and the failed_chunk_index for recovery).
+
+        Args:
+            records: DataFrame with stream_id, data_provider, date, value.
+            batch_size: Records per insert_records tx (default 10 = cap).
+
+        Returns:
+            List of tx hashes in submission order.
+        """
+        batches = self._records_to_batches(records)
+        if not batches:
+            return []
+
+        with concurrency("tn-write", occupy=1):
+            inserter = BulkInserter(self.client, batch_size=batch_size)
+            return inserter.insert_all(batches)
 
     @handle_tn_errors
     def wait_for_tx(self, tx_hash: str) -> None:

--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -551,6 +551,10 @@ class TNAccessBlock(Block):
 
         return batches
 
+    # Node-level per-tx insert cap (honored by bulk_insert_tn_records which
+    # chunks automatically; batch_insert_tn_records rejects over-cap inputs).
+    _INSERT_RECORDS_CAP = 10
+
     @handle_tn_errors
     def batch_insert_tn_records(
         self,
@@ -558,19 +562,30 @@ class TNAccessBlock(Block):
     ) -> Optional[str]:
         """Batch insert records into multiple streams in a single transaction.
 
-        Note: subject to the node's per-tx insert cap (currently 10 rows).
-        For large batches, prefer ``bulk_insert_tn_records`` which chunks
-        and pipelines automatically.
+        Enforces the node's per-tx insert cap (10 rows total, across streams).
+        For larger datasets, use ``bulk_insert_tn_records`` which chunks and
+        pipelines automatically.
 
         Args:
             records: DataFrame containing records with stream_id column
 
         Returns:
             Transaction hash if successful, None otherwise
+
+        Raises:
+            ValueError: if total rows exceed the protocol cap.
         """
         batches = self._records_to_batches(records)
         if not batches:
             return None
+
+        total_rows = sum(len(b["inputs"]) for b in batches)
+        if total_rows > self._INSERT_RECORDS_CAP:
+            raise ValueError(
+                f"batch_insert_tn_records received {total_rows} rows but the node's "
+                f"per-tx cap is {self._INSERT_RECORDS_CAP}. "
+                f"Use bulk_insert_tn_records for larger datasets."
+            )
 
         with concurrency("tn-write", occupy=1):
             return self.client.batch_insert_records(
@@ -599,7 +614,15 @@ class TNAccessBlock(Block):
 
         Returns:
             List of tx hashes in submission order.
+
+        Raises:
+            ValueError: if batch_size is outside [1, _INSERT_RECORDS_CAP].
         """
+        if not isinstance(batch_size, int) or not 1 <= batch_size <= self._INSERT_RECORDS_CAP:
+            raise ValueError(
+                f"batch_size must be an int in [1, {self._INSERT_RECORDS_CAP}]; got {batch_size!r}"
+            )
+
         batches = self._records_to_batches(records)
         if not batches:
             return []

--- a/src/tsn_adapters/common/trufnetwork/tasks/insert.py
+++ b/src/tsn_adapters/common/trufnetwork/tasks/insert.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pandera.typing import DataFrame
 from prefect import get_run_logger, task
 from prefect.states import Completed
+from trufnetwork_sdk_py import BulkInsertError
 import trufnetwork_sdk_py.client as tn_client
 
 from tsn_adapters.blocks.tn_access import (
@@ -41,21 +42,26 @@ def task_split_and_insert_records(
     max_streams_per_existence_check: int = 1000,
 ) -> SplitInsertResults:
     """
-    Splits records into batches and inserts them into TN, optionally filtering by stream existence first.
+    Inserts records into TN via BulkInserter (cached-nonce pipelining),
+    optionally filtering by stream existence first.
 
-    Orchestrates filtering and batch insertion logic.
+    The underlying node enforces a per-tx insert cap (currently 10 rows).
+    BulkInserter satisfies that by chunking internally at 10/tx and
+    pipelining broadcasts so throughput stays bounded by admission
+    (~50ms) rather than inclusion (~1-2s/block).
 
     Args:
         block: The TNAccessBlock instance.
         records: The records to insert.
-        max_batch_size: Maximum number of records per insert batch.
-        wait: Whether to wait for the insertion transaction(s) to be mined.
+        max_batch_size: Legacy. Ignored — BulkInserter chunks at the
+            protocol cap (10 rows/tx).
+        wait: Legacy. Effectively always-true — BulkInserter drains
+            in-flight broadcasts via WaitTx before returning.
         filter_deployed_streams: Whether to filter out streams that do not exist on TN.
-        filter_cache_duration: How long to cache the stream existence filter results.
         max_streams_per_existence_check: Max streams to check in one existence API call.
 
     Returns:
-        SplitInsertResults containing transaction hashes and any failed records/reasons.
+        SplitInsertResults with one tx_hash per chunk (~10 rows) and any failed records/reasons.
     """
     logger = get_logger_safe(__name__)
     processed_records = records.copy()
@@ -291,51 +297,50 @@ def _perform_batch_insertions(
     max_batch_size: int,
     wait: bool,
 ) -> SplitInsertResults:
-    """Splits records and performs batch insertions, collecting results.
+    """Insert records via sdk-py BulkInserter (cached-nonce pipelining).
 
     Args:
         block: TNAccessBlock instance.
         records_to_insert: DataFrame of records ready for insertion.
-        max_batch_size: Max records per insertion API call.
-        wait: Whether to wait for insertion transactions.
+        max_batch_size: Legacy. Ignored — BulkInserter chunks at the
+            protocol cap (10 rows/tx) internally.
+        wait: Legacy. Effectively always-true — BulkInserter drains all
+            in-flight broadcasts via WaitTx before returning.
 
     Returns:
-        SplitInsertResults dictionary.
+        SplitInsertResults with one tx_hash per chunk (~10 rows).
     """
+    del max_batch_size, wait  # parameters retained for API compat
+
     logger = get_logger_safe(__name__)
     failed_reasons: list[str] = []
     success_tx_hashes: list[str] = []
     failed_records_list: list[DataFrame[TnDataRowModel]] = []
 
-    split_records_batches = block.split_records(records_to_insert, max_batch_size)
-
-    if not split_records_batches:
-        logger.warning("No record batches to insert.")
-        # Fall through to return empty results
+    if records_to_insert.empty:
+        logger.warning("No records to insert.")
     else:
-        logger.info(
-            f"Submitting {len(records_to_insert)} records for insertion in {len(split_records_batches)} batches."
-        )
-        for i, batch in enumerate(split_records_batches):
-            batch_num_log = i + 1
-            logger.debug(
-                f"Submitting insertion batch {batch_num_log}/{len(split_records_batches)} ({len(batch)} records)..."
+        logger.info(f"Submitting {len(records_to_insert)} records via BulkInserter (chunk_size=10).")
+        try:
+            success_tx_hashes = block.bulk_insert_tn_records(records_to_insert)
+            logger.info(f"BulkInserter submitted {len(success_tx_hashes)} txs.")
+        except BulkInsertError as e:
+            logger.error(
+                f"BulkInserter failed at chunk {e.failed_chunk_index} "
+                f"(drain_failure={e.drain_failure}): {e!s}",
+                exc_info=True,
             )
-            try:
-                tx_hash_or_none = task_batch_insert_tn_records(
-                    block=block,
-                    records=batch,
-                    wait=wait,
-                )
-                if tx_hash_or_none:
-                    success_tx_hashes.append(tx_hash_or_none)
-                logger.debug(f"Insertion batch {batch_num_log} submitted. TX: {tx_hash_or_none}")
-            except Exception as e:
-                logger.error(f"Insertion batch {batch_num_log} failed: {e!s}", exc_info=True)
-                failed_records_list.append(batch)
-                failed_reasons.append(str(e))
+            success_tx_hashes = list(e.tx_hashes)
+            # Per-row mapping back to source DataFrame rows isn't reliable
+            # (BulkInserter groups by stream then flattens), so mark the
+            # whole submission as failed and let the caller retry.
+            failed_records_list.append(records_to_insert)
+            failed_reasons.append(str(e))
+        except Exception as e:
+            logger.error(f"Batch insertion failed: {e!s}", exc_info=True)
+            failed_records_list.append(records_to_insert)
+            failed_reasons.append(str(e))
 
-    # Combine failed records
     if failed_records_list:
         failed_records_df = DataFrame[TnDataRowModel](pd.concat(failed_records_list))
     else:

--- a/src/tsn_adapters/common/trufnetwork/tasks/insert.py
+++ b/src/tsn_adapters/common/trufnetwork/tasks/insert.py
@@ -4,12 +4,12 @@ from typing import (
     Optional,
     TypedDict,
 )
+import warnings
 
 import pandas as pd
 from pandera.typing import DataFrame
 from prefect import get_run_logger, task
 from prefect.states import Completed
-from trufnetwork_sdk_py import BulkInsertError
 import trufnetwork_sdk_py.client as tn_client
 
 from tsn_adapters.blocks.tn_access import (
@@ -63,6 +63,14 @@ def task_split_and_insert_records(
     Returns:
         SplitInsertResults with one tx_hash per chunk (~10 rows) and any failed records/reasons.
     """
+    if max_batch_size != 25000 or wait is not True:
+        warnings.warn(
+            "max_batch_size and wait are deprecated; BulkInserter chunks at the "
+            "protocol cap (10 rows/tx) and always drains before returning.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     logger = get_logger_safe(__name__)
     processed_records = records.copy()
 
@@ -299,6 +307,13 @@ def _perform_batch_insertions(
 ) -> SplitInsertResults:
     """Insert records via sdk-py BulkInserter (cached-nonce pipelining).
 
+    Exceptions propagate so the enclosing Prefect task
+    (`task_split_and_insert_records`, with `tn_special_retry_condition(5)`)
+    can retry. We don't catch `BulkInsertError` partially: retrying with
+    the known-committed txs removed would require mapping flattened chunks
+    back to source rows, which BulkInserter's stream-grouped flatten makes
+    unreliable. Letting the whole batch re-run is safer.
+
     Args:
         block: TNAccessBlock instance.
         records_to_insert: DataFrame of records ready for insertion.
@@ -308,46 +323,25 @@ def _perform_batch_insertions(
             in-flight broadcasts via WaitTx before returning.
 
     Returns:
-        SplitInsertResults with one tx_hash per chunk (~10 rows).
+        SplitInsertResults with one tx_hash per chunk (~10 rows). On
+        failure, raises (does not return partial results).
     """
     del max_batch_size, wait  # parameters retained for API compat
 
     logger = get_logger_safe(__name__)
-    failed_reasons: list[str] = []
-    success_tx_hashes: list[str] = []
-    failed_records_list: list[DataFrame[TnDataRowModel]] = []
 
     if records_to_insert.empty:
         logger.warning("No records to insert.")
-    else:
-        logger.info(f"Submitting {len(records_to_insert)} records via BulkInserter (chunk_size=10).")
-        try:
-            success_tx_hashes = block.bulk_insert_tn_records(records_to_insert)
-            logger.info(f"BulkInserter submitted {len(success_tx_hashes)} txs.")
-        except BulkInsertError as e:
-            logger.error(
-                f"BulkInserter failed at chunk {e.failed_chunk_index} "
-                f"(drain_failure={e.drain_failure}): {e!s}",
-                exc_info=True,
-            )
-            success_tx_hashes = list(e.tx_hashes)
-            # Per-row mapping back to source DataFrame rows isn't reliable
-            # (BulkInserter groups by stream then flattens), so mark the
-            # whole submission as failed and let the caller retry.
-            failed_records_list.append(records_to_insert)
-            failed_reasons.append(str(e))
-        except Exception as e:
-            logger.error(f"Batch insertion failed: {e!s}", exc_info=True)
-            failed_records_list.append(records_to_insert)
-            failed_reasons.append(str(e))
+        empty_df = DataFrame[TnDataRowModel](columns=["data_provider", "stream_id", "date", "value"])
+        return SplitInsertResults(success_tx_hashes=[], failed_records=empty_df, failed_reasons=[])
 
-    if failed_records_list:
-        failed_records_df = DataFrame[TnDataRowModel](pd.concat(failed_records_list))
-    else:
-        failed_records_df = DataFrame[TnDataRowModel](columns=["data_provider", "stream_id", "date", "value"])
+    logger.info(f"Submitting {len(records_to_insert)} records via BulkInserter (chunk_size=10).")
+    success_tx_hashes = block.bulk_insert_tn_records(records_to_insert)
+    logger.info(f"BulkInserter submitted {len(success_tx_hashes)} txs.")
 
+    empty_df = DataFrame[TnDataRowModel](columns=["data_provider", "stream_id", "date", "value"])
     return SplitInsertResults(
         success_tx_hashes=success_tx_hashes,
-        failed_records=failed_records_df,
-        failed_reasons=failed_reasons,
+        failed_records=empty_df,
+        failed_reasons=[],
     )

--- a/tests/fmp/test_historical_flow.py
+++ b/tests/fmp/test_historical_flow.py
@@ -7,6 +7,7 @@ actual network calls.
 """
 
 import datetime
+from math import ceil
 import time
 from typing import Any
 
@@ -16,6 +17,8 @@ from pydantic import SecretStr
 import pytest
 from pytest_mock import MockerFixture
 from trufnetwork_sdk_py.client import TNClient
+
+from tests.utils.constants import FAKE_PRIVATE_KEY
 
 from tsn_adapters.blocks.fmp import EODData, FMPBlock
 from tsn_adapters.blocks.primitive_source_descriptor import (
@@ -141,7 +144,7 @@ class FakeTNAccessBlock(TNAccessBlock):
         # time, and that leaks through any code path touching self.client.
         super().__init__(
             tn_provider="fake",
-            tn_private_key=SecretStr("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
+            tn_private_key=FAKE_PRIVATE_KEY,
         )
         # Initialize our tracking variables
         self._inserted_records: list[DataFrame[TnDataRowModel]] = []
@@ -188,9 +191,19 @@ class FakeTNAccessBlock(TNAccessBlock):
         records: DataFrame[TnDataRowModel],
         batch_size: int = 10,
     ) -> list[str]:
-        """Fake BulkInserter path: reuse the tracking done by batch_insert_tn_records."""
-        self.batch_insert_tn_records(records)
-        return ["fake_tx_hash"]
+        """Fake BulkInserter path: chunk records and call
+        batch_insert_tn_records per chunk for tracking parity with real
+        BulkInserter's one-tx-per-10-rows shape."""
+        if not isinstance(batch_size, int) or not 1 <= batch_size <= 10:
+            raise ValueError(f"batch_size must be an int in [1, 10]; got {batch_size!r}")
+        if len(records) == 0:
+            return []
+        hashes: list[str] = []
+        for i in range(0, len(records), batch_size):
+            chunk = records.iloc[i : i + batch_size]
+            self.batch_insert_tn_records(DataFrame[TnDataRowModel](chunk))
+            hashes.append(f"fake_tx_{i // batch_size}")
+        return hashes
 
     def wait_for_tx(self, tx_hash: str) -> None:
         """Mock waiting."""

--- a/tests/fmp/test_historical_flow.py
+++ b/tests/fmp/test_historical_flow.py
@@ -136,12 +136,22 @@ class FakeTNAccessBlock(TNAccessBlock):
     """Fake TN access block that tracks inserted records."""
 
     def __init__(self):
-        # Initialize Pydantic model with required fields
-        super().__init__(tn_provider="fake", tn_private_key=SecretStr("fake"))
+        # Initialize Pydantic model with required fields. Use a valid-looking
+        # hex private key — sdk-py rejects non-hex at TNClient construction
+        # time, and that leaks through any code path touching self.client.
+        super().__init__(
+            tn_provider="fake",
+            tn_private_key=SecretStr("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
+        )
         # Initialize our tracking variables
         self._inserted_records: list[DataFrame[TnDataRowModel]] = []
         self._insert_times: list[float] = []
         self._batch_sizes: list[int] = []
+
+    @property
+    def current_account(self) -> str:
+        # Skip self.client access — tests don't need the real account.
+        return "fake_account"
 
     @property
     def inserted_records(self) -> list[DataFrame[TnDataRowModel]]:
@@ -171,6 +181,15 @@ class FakeTNAccessBlock(TNAccessBlock):
         self._inserted_records.append(records)
         self._insert_times.append(time.time())
         self._batch_sizes.append(len(records))
+        return ["fake_tx_hash"]
+
+    def bulk_insert_tn_records(
+        self,
+        records: DataFrame[TnDataRowModel],
+        batch_size: int = 10,
+    ) -> list[str]:
+        """Fake BulkInserter path: reuse the tracking done by batch_insert_tn_records."""
+        self.batch_insert_tn_records(records)
         return ["fake_tx_hash"]
 
     def wait_for_tx(self, tx_hash: str) -> None:

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -1,0 +1,7 @@
+from pydantic import SecretStr
+
+# Public-domain Anvil/Hardhat dev private key. Not a secret — used across
+# test fakes so TNAccessBlock's signer construction (which sdk-py now
+# validates strictly at init time) doesn't fail on unrelated code paths.
+# Flagged here to silence secret scanners and avoid duplication.
+FAKE_PRIVATE_KEY = SecretStr("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")

--- a/tests/utils/fake_tn_access.py
+++ b/tests/utils/fake_tn_access.py
@@ -1,11 +1,12 @@
+from math import ceil
 from typing import Any, Optional
 
 import pandas as pd
 from pandera.typing import DataFrame as PanderaDataFrame
-from pydantic import SecretStr
 import trufnetwork_sdk_py.client as tn_client
 from trufnetwork_sdk_py.client import RecordBatch, StreamDefinitionInput, StreamLocatorInput
 
+from tests.utils.constants import FAKE_PRIVATE_KEY
 from tsn_adapters.blocks.tn_access import (
     StreamAlreadyExistsError,
     TNAccessBlock,
@@ -158,7 +159,7 @@ class FakeTNAccessBlock(TNAccessBlock):
         # if TNAccessBlock.__init__ attempts to create a real client early.
         super().__init__(
             tn_provider="fake_provider",
-            tn_private_key=SecretStr("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
+            tn_private_key=FAKE_PRIVATE_KEY,
         )
         # Override the client with our fake internal client
         self._internal_fake_client = FakeInternalTNClient(
@@ -210,11 +211,22 @@ class FakeTNAccessBlock(TNAccessBlock):
         records: PanderaDataFrame[TnDataRowModel],
         batch_size: int = 10,
     ) -> list[str]:
-        """Fake BulkInserter path: route through batch_insert_tn_records so
-        FakeInternalTNClient captures the inserted DataFrame. Bypasses the
-        real gopy BulkInserter (which would hit the C bindings)."""
-        tx_hash = self.batch_insert_tn_records(records=records)
-        return [tx_hash] if tx_hash else []
+        """Fake BulkInserter path: chunk records into ``batch_size`` groups
+        and route each chunk through batch_insert_tn_records so
+        FakeInternalTNClient captures each DataFrame. Bypasses the real
+        gopy BulkInserter. Returns one fake hash per chunk, matching
+        production's one-tx-per-chunk shape."""
+        if not isinstance(batch_size, int) or not 1 <= batch_size <= 10:
+            raise ValueError(f"batch_size must be an int in [1, 10]; got {batch_size!r}")
+        if len(records) == 0:
+            return []
+        hashes: list[str] = []
+        for i in range(0, len(records), batch_size):
+            chunk = records.iloc[i : i + batch_size]
+            tx_hash = self.batch_insert_tn_records(records=PanderaDataFrame[TnDataRowModel](chunk))
+            if tx_hash is not None:
+                hashes.append(tx_hash)
+        return hashes
 
     def stream_exists(self, data_provider: str, stream_id: str) -> bool:
         if self._block_error_on.get("stream_exists"):

--- a/tests/utils/fake_tn_access.py
+++ b/tests/utils/fake_tn_access.py
@@ -205,6 +205,17 @@ class FakeTNAccessBlock(TNAccessBlock):
     # The goal is to let TNAccessBlock.batch_insert_tn_records run its course,
     # which will call self.client.batch_insert_records (our faked one).
 
+    def bulk_insert_tn_records(
+        self,
+        records: PanderaDataFrame[TnDataRowModel],
+        batch_size: int = 10,
+    ) -> list[str]:
+        """Fake BulkInserter path: route through batch_insert_tn_records so
+        FakeInternalTNClient captures the inserted DataFrame. Bypasses the
+        real gopy BulkInserter (which would hit the C bindings)."""
+        tx_hash = self.batch_insert_tn_records(records=records)
+        return [tx_hash] if tx_hash else []
+
     def stream_exists(self, data_provider: str, stream_id: str) -> bool:
         if self._block_error_on.get("stream_exists"):
             raise self._block_error_on["stream_exists"]


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added high-throughput bulk insertion for TrueNetwork records with configurable chunking.

* **Dependencies**
  * Updated the TrueNetwork SDK dependency to a newer pinned version.

* **Improvements**
  * Stronger input validation, enforced 10-row-per-transaction cap, clearer empty-result behavior, and deprecation warnings for legacy parameters; failures now propagate for standard retry handling.

* **Tests**
  * Added test utilities and fakes to simulate bulk insert behavior reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->