### PR TITLE
chore: bump sdk-py to pull catchup retry + progress logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "prefect-client>=3.4.10",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20250618",
-    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@7799703e674aacd7a1d2c5e9d80da97d44dd28c0",
+    "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@7c15dec4f037729efb65bc24253fba5795ffee94",
     "PyGithub",
     "pandera>=0.23.1",
     "pandas<2.3",


### PR DESCRIPTION
## Summary
- Bumps trufnetwork-sdk-py pin to `7c15dec4` (main HEAD) — was pinned at the pre-BulkInserter SHA `7799703e`.

## What this unlocks in production
- **Phase A — catchup retry**: kwild "node is catching up" rejections now get a separate 20-attempt × 15s linear backoff budget (~47.5 min per chunk) instead of sharing the 5-attempt transient bucket. Fixes the 2026-04-25 incident pattern where a 75 s catch-up event aborted multi-hour bulk loads.
- **Phase C — Go-side stderr logger**: BulkInserter WARN lines (catchup / nonce reset / mempool / infra) and progress logs (every 500 chunks by default) now reach stderr, which Prefect's task subprocess wrapper captures into task logs. Closes the silent-for-hours gap between \`Submitting N records\` and the final result.
- **Infra retry**: pre-broadcast errors (KGW \`no available backend\`, TCP \`connection refused\`, DNS \`no such host\`) now retry up to 10 attempts × 2 s linear backoff (~90 s wait per chunk). Mid-request errors (EOF, connection reset, context deadline) deliberately stay fatal at the SDK layer — retrying could double-broadcast.
- **Default attempts bumped**: \`max_attempts=15\` (was 5), sized so a thousand-chunk insert can ride out brief mempool congestion without bottlenecking on the adapter resume layer above.

## Risk
Low — pure pin bump, no source changes in adapters. The new sdk-py defaults are strictly more conservative (higher retry budgets) than the previous pin, so any workload that worked before still works. Existing resume tests pass against the new pin.

## Test plan
- [x] Local: \`uv pip install --reinstall \"trufnetwork-sdk-py@git+...@7c15dec4...\"\` — installed cleanly
- [x] Local: \`pytest tests/blocks/test_bulk_insert_resume.py -v\` — 2 passed (resume loop still works against new sdk-py)
- [x] Verified \`BulkInserter.__init__\` exposes all new knobs (max_attempts=15, catchup_max_attempts=20, infra_max_attempts=10, progress_log_every_n=500)
- [ ] CI integration tests pass

## Follow-ups (separate PRs after this lands)
- truf-data-provider: bump pinned adapters + sdk-py SHAs in \`deployments/ingestors/pyproject.toml\`
- ECR: trigger image build + pull on Prefect ingestor host (closes the gap left by the 2026-04-25 \`docker cp\` hot-patch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated trufnetwork-sdk-py dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->