### PR TITLE
chore: align TN reads with sdk-py StreamRecord shape

### DIFF
--- a/src/tsn_adapters/blocks/tn_access.py
+++ b/src/tsn_adapters/blocks/tn_access.py
@@ -420,7 +420,7 @@ class TNAccessBlock(Block):
         if result is None:
             return None
 
-        return TnRecord(date=int(result["date"]), value=float(result["value"]))
+        return TnRecord(date=int(result["EventTime"]), value=float(result["Value"]))
 
     @handle_tn_errors
     def read_records(

--- a/src/tsn_adapters/common/trufnetwork/tn.py
+++ b/src/tsn_adapters/common/trufnetwork/tn.py
@@ -124,7 +124,6 @@ def get_all_tsn_records(
         {
             "date": rec["EventTime"],
             "value": float(rec["Value"]),
-            **{k: v for k, v in rec.items() if k not in ("EventTime", "Value")},
         }
         for rec in recs
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned data field mapping across all record-reading operations for consistency.

* **Refactor**
  * Simplified record output format to return essential fields only, removing additional metadata columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->