### PR TITLE
chore: normalize id_producto across Argentina SEPA pipeline

### DIFF
--- a/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
@@ -209,6 +209,12 @@ async def insert_argentina_products_flow(
     try:
         descriptor_df: DataFrame[PrimitiveSourceDataModel] = descriptor_block.get_descriptor()
         logger.info(f"Successfully loaded product descriptor with {len(descriptor_df)} entries from block.")
+        # Mirror the daily-averages reader: any descriptor row upserted while the
+        # upstream `.0`-suffix bug was active would otherwise miss the join
+        # against now-normalized daily IDs.
+        descriptor_df["source_id"] = (
+            descriptor_df["source_id"].astype("string").str.replace(r"\.0$", "", regex=True)
+        )
     except Exception as e_desc:
         # load_product_descriptor already logs critically and raises DescriptorError
         logger.critical(

--- a/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/insert_products_flow.py
@@ -209,9 +209,8 @@ async def insert_argentina_products_flow(
     try:
         descriptor_df: DataFrame[PrimitiveSourceDataModel] = descriptor_block.get_descriptor()
         logger.info(f"Successfully loaded product descriptor with {len(descriptor_df)} entries from block.")
-        # Mirror the daily-averages reader: any descriptor row upserted while the
-        # upstream `.0`-suffix bug was active would otherwise miss the join
-        # against now-normalized daily IDs.
+        # Apply the same `.0`-stripping the daily-averages reader does so the
+        # descriptor's source_id and the daily id_producto stay in one shape.
         descriptor_df["source_id"] = (
             descriptor_df["source_id"].astype("string").str.replace(r"\.0$", "", regex=True)
         )

--- a/src/tsn_adapters/tasks/argentina/provider/base.py
+++ b/src/tsn_adapters/tasks/argentina/provider/base.py
@@ -85,9 +85,8 @@ class SepaS3BaseProvider(ABC, Generic[T]):
         content_in_bytes = force_sync(self.s3_block.read_path)(self.get_full_path(file_key))
         buffer = io.BytesIO(content_in_bytes)
         df = pd.read_csv(buffer, compression="zip")
-        # Pandas infers `id_producto` as float64 when even one row carries a `.0`
-        # suffix (upstream preprocessing artifact). Downstream `astype(str)` then
-        # strands every value with `.0` and breaks the descriptor join.
+        # A `.0` suffix in even one row widens id_producto to float64 — normalize
+        # all values to integer-strings so downstream consumers see one shape.
         if "id_producto" in df.columns:
             df["id_producto"] = (
                 df["id_producto"].astype("string").str.replace(r"\.0$", "", regex=True)

--- a/src/tsn_adapters/tasks/argentina/provider/base.py
+++ b/src/tsn_adapters/tasks/argentina/provider/base.py
@@ -84,7 +84,15 @@ class SepaS3BaseProvider(ABC, Generic[T]):
         """Read a CSV file from S3."""
         content_in_bytes = force_sync(self.s3_block.read_path)(self.get_full_path(file_key))
         buffer = io.BytesIO(content_in_bytes)
-        return pd.read_csv(buffer, compression="zip")
+        df = pd.read_csv(buffer, compression="zip")
+        # Pandas infers `id_producto` as float64 when even one row carries a `.0`
+        # suffix (upstream preprocessing artifact). Downstream `astype(str)` then
+        # strands every value with `.0` and breaks the descriptor join.
+        if "id_producto" in df.columns:
+            df["id_producto"] = (
+                df["id_producto"].astype("string").str.replace(r"\.0$", "", regex=True)
+            )
+        return df
 
     def write_csv(self, file_key: str, data: PandasDataFrame) -> None:
         """Write a CSV file to S3."""

--- a/tests/argentina/provider/test_product_averages_provider.py
+++ b/tests/argentina/provider/test_product_averages_provider.py
@@ -114,9 +114,6 @@ def _build_zip_csv_bytes(csv_text: str) -> bytes:
 
 
 def test_read_csv_strips_dot_zero_from_id_producto(provider: ProductAveragesProvider, mock_s3_block: MagicMock):
-    # Real-world fingerprint: one `.0`-tainted row poisons pandas dtype inference
-    # for the whole column. The reader must normalize so the downstream join
-    # against the descriptor's clean integer-strings does not collapse.
     csv_text = (
         "id_producto,productos_descripcion,productos_precio_lista_avg,date,product_count\n"
         "100119,Item A,10.5,2025-12-23,1\n"

--- a/tests/argentina/provider/test_product_averages_provider.py
+++ b/tests/argentina/provider/test_product_averages_provider.py
@@ -1,3 +1,4 @@
+import io
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -103,4 +104,54 @@ def test_exists_false(mock_path_exists: MagicMock, provider: ProductAveragesProv
     result = provider.exists(test_date)
 
     mock_path_exists.assert_called_once_with(expected_relative_key) # Assert relative key
-    assert result is False 
+    assert result is False
+
+
+def _build_zip_csv_bytes(csv_text: str) -> bytes:
+    buf = io.BytesIO()
+    pd.read_csv(io.StringIO(csv_text)).to_csv(buf, index=False, compression="zip")
+    return buf.getvalue()
+
+
+def test_read_csv_strips_dot_zero_from_id_producto(provider: ProductAveragesProvider, mock_s3_block: MagicMock):
+    # Real-world fingerprint: one `.0`-tainted row poisons pandas dtype inference
+    # for the whole column. The reader must normalize so the downstream join
+    # against the descriptor's clean integer-strings does not collapse.
+    csv_text = (
+        "id_producto,productos_descripcion,productos_precio_lista_avg,date,product_count\n"
+        "100119,Item A,10.5,2025-12-23,1\n"
+        "7790260013058.0,Item B,20.0,2025-12-23,2\n"
+        "7791290795013.0,Item C,30.0,2025-12-23,3\n"
+    )
+    mock_s3_block.read_path = MagicMock(return_value=_build_zip_csv_bytes(csv_text))
+
+    df = provider.read_csv("2025-12-23/product_averages.zip")
+
+    assert df["id_producto"].tolist() == ["100119", "7790260013058", "7791290795013"]
+
+
+def test_read_csv_passes_clean_integer_ids_through_unchanged(
+    provider: ProductAveragesProvider, mock_s3_block: MagicMock
+):
+    csv_text = (
+        "id_producto,productos_descripcion,productos_precio_lista_avg,date,product_count\n"
+        "100119,Item A,10.5,2025-11-19,1\n"
+        "100121,Item B,20.0,2025-11-19,2\n"
+    )
+    mock_s3_block.read_path = MagicMock(return_value=_build_zip_csv_bytes(csv_text))
+
+    df = provider.read_csv("2025-11-19/product_averages.zip")
+
+    assert df["id_producto"].tolist() == ["100119", "100121"]
+
+
+def test_read_csv_without_id_producto_column_is_unchanged(
+    provider: ProductAveragesProvider, mock_s3_block: MagicMock
+):
+    csv_text = "some_other_col,value\nalpha,1\nbeta,2\n"
+    mock_s3_block.read_path = MagicMock(return_value=_build_zip_csv_bytes(csv_text))
+
+    df = provider.read_csv("anything.zip")
+
+    assert "id_producto" not in df.columns
+    assert df["some_other_col"].tolist() == ["alpha", "beta"]


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Argentina product data now has normalized product IDs, removing formatting inconsistencies that previously prevented proper data alignment and lookups.

* **Tests**
  * Added comprehensive test coverage for product ID normalization, validating correct behavior across different input formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->