### PR TITLE
chore: pin prefect and prefect-client to 3.6.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ description = "A collection of prefect tasks and examples ingesting data into TS
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "prefect-client>=3.4.10",
+    "prefect==3.6.29",
+    "prefect-client==3.6.29",
     "truflation-data@git+https://github.com/truflation/truflation.git@deploy-production-20250618",
     "trufnetwork-sdk-py@git+https://github.com/trufnetwork/sdk-py.git@v0.7.4",
     "PyGithub",
@@ -34,7 +35,7 @@ argentina = [
 ]
 dev = [
     # we need this for the testing harness
-    "prefect>=3.4.10",
+    "prefect==3.6.29",
     "pytest-timeout",
     "pytest-mock",
     "black",


### PR DESCRIPTION
## Summary
- Pin `prefect` and `prefect-client` to `3.6.29` in both runtime dependencies and the `dev` extra so adapters stays in step with the matching pin in `truf-data-provider`.

## Test plan
- [ ] CI install / test suite resolves cleanly with `prefect==3.6.29` + `prefect-client==3.6.29` + `prefect-aws` resolved to the latest compatible (currently `0.7.7`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Prefect and Prefect Client dependencies from version 3.4.10+ to pinned versions 3.6.29 across both main and development environments. This ensures consistent library versions across all installations, improving system reliability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->