### PR TITLE
chore: surface yfinance rate limits and retry with jitter in YahooBlock

### DIFF
--- a/src/tsn_adapters/blocks/yahoo.py
+++ b/src/tsn_adapters/blocks/yahoo.py
@@ -2,14 +2,24 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 
 import pandas as pd
 from pandera.typing import DataFrame
 from prefect.blocks.core import Block
 
 from tsn_adapters.blocks.fmp import EarningsData
-from tsn_adapters.utils.create_empty_df import create_empty_df
 from tsn_adapters.utils.logging import get_logger_safe
+
+# Yahoo aggressively rate-limits non-residential IPs (notably AWS).
+# yfinance hides 429s — get_earnings_dates returns None and prints
+# "$SYM: possibly delisted; no earnings dates found" via its own logger.
+# We retry inside the block so the caller's @task retry stays a backstop.
+_PRE_CALL_JITTER_S: tuple[float, float] = (0.5, 2.0)
+_BACKOFF_BASE_S: float = 5.0
+_BACKOFF_JITTER_S: tuple[float, float] = (0.0, 3.0)
+_MAX_ATTEMPTS: int = 3
 
 
 class YahooBlock(Block):
@@ -31,18 +41,49 @@ class YahooBlock(Block):
         limit=40 covers ~10 years of quarterly data.
         Returns an EarningsData-compatible DataFrame; epsActual is NaN
         for future (not-yet-reported) quarters.
+
+        Raises on persistent yfinance failures so the calling @task retry
+        decorator can take over. An empty result after _MAX_ATTEMPTS is
+        treated as a failure and raised — yfinance returns None on HTTP 429
+        without surfacing an exception.
         """
-        try:
-            import yfinance as yf
+        import yfinance as yf
 
-            df = yf.Ticker(symbol).get_earnings_dates(limit=limit)
-        except Exception as exc:
-            self.logger.warning(f"yfinance fetch failed for {symbol}: {exc}")
-            return create_empty_df(EarningsData)
+        time.sleep(random.uniform(*_PRE_CALL_JITTER_S))
 
-        if df is None or df.empty:
-            return create_empty_df(EarningsData)
+        last_exc: Exception | None = None
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            try:
+                df = yf.Ticker(symbol).get_earnings_dates(limit=limit)
+            except Exception as exc:
+                last_exc = exc
+                self.logger.error(
+                    f"yfinance fetch raised for {symbol} (attempt {attempt}/{_MAX_ATTEMPTS}): {exc}"
+                )
+                df = None
 
+            if df is not None and not df.empty:
+                return self._normalize(df, symbol)
+
+            if attempt < _MAX_ATTEMPTS:
+                delay = _BACKOFF_BASE_S * (2 ** (attempt - 1)) + random.uniform(*_BACKOFF_JITTER_S)
+                self.logger.warning(
+                    f"yfinance returned no data for {symbol} (attempt {attempt}/{_MAX_ATTEMPTS}) — "
+                    f"likely HTTP 429; sleeping {delay:.1f}s before retry"
+                )
+                time.sleep(delay)
+
+        msg = (
+            f"yfinance returned no earnings for {symbol} after {_MAX_ATTEMPTS} attempts — "
+            f"Yahoo Finance is likely rate-limiting this worker (HTTP 429)"
+        )
+        self.logger.error(msg)
+        if last_exc is not None:
+            raise RuntimeError(msg) from last_exc
+        raise RuntimeError(msg)
+
+    @staticmethod
+    def _normalize(df: pd.DataFrame, symbol: str) -> DataFrame[EarningsData]:
         df = df.reset_index()
         date_col = df.columns[0]  # "Earnings Date" — timezone-aware DatetimeTZDtype
         df["date"] = pd.to_datetime(df[date_col]).dt.strftime("%Y-%m-%d")

--- a/src/tsn_adapters/blocks/yahoo.py
+++ b/src/tsn_adapters/blocks/yahoo.py
@@ -13,9 +13,9 @@ from tsn_adapters.blocks.fmp import EarningsData
 from tsn_adapters.utils.logging import get_logger_safe
 
 # Yahoo aggressively rate-limits non-residential IPs (notably AWS).
-# yfinance hides 429s — get_earnings_dates returns None and prints
-# "$SYM: possibly delisted; no earnings dates found" via its own logger.
-# We retry inside the block so the caller's @task retry stays a backstop.
+# On HTTP 429, yfinance.Ticker.get_earnings_dates returns None without
+# raising — so empty/None results must be treated as failures to retry.
+# We retry inside the block; the caller's @task retry stays a backstop.
 _PRE_CALL_JITTER_S: tuple[float, float] = (0.5, 2.0)
 _BACKOFF_BASE_S: float = 5.0
 _BACKOFF_JITTER_S: tuple[float, float] = (0.0, 3.0)


### PR DESCRIPTION
## Summary

- yfinance hides HTTP 429s — `get_earnings_dates` returns `None` and logs "$SYM: possibly delisted; no earnings dates found" via its own logger. Confirmed live from the on-prem worker against AAPL/MSFT/GOOGL (Yahoo returns 429 on `quoteSummary`).
- Today's behavior: `YahooBlock` swallows the empty result and returns an empty DataFrame at `warning` level. EPS flows see "0 new Yahoo record(s)" with no error, leaving 7 yahoo_eps + 7 truf_eps streams empty on TN (the consensus stream needs ≥2 sources to agree).
- This change:
  - Adds a 0.5–2s jittered pre-call sleep to spread concurrent symbol fetches.
  - Retries up to 3 attempts inside the block with 5s/10s/20s + 0–3s jitter exponential backoff when yfinance returns None/empty.
  - Logs at `error` (not `warning`) and explicitly names "HTTP 429" as the likely cause.
  - Raises `RuntimeError` after persistent failures so the outer `@task(retries=3, retry_delay_seconds=30)` on `fetch_yahoo_earnings` can take over instead of writing zero records silently.

## Test plan

- [ ] Run `eps-historical-flow` from a worker that is currently being rate-limited and confirm the flow now surfaces an `error` log + raises rather than completing with 0 Yahoo records.
- [ ] Run from a worker that is not rate-limited and confirm normal MAG7 fetches still succeed (extra latency from the 0.5–2s jitter is acceptable for the 7-symbol loop).
- [ ] `ruff check src/tsn_adapters/blocks/yahoo.py` — all checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of earnings data retrieval with automatic retry logic and exponential backoff when encountering rate limits or temporary failures.
  * Enhanced error handling to properly report failures instead of silently returning empty data.
  * Added detailed logging for better visibility into earnings data fetch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->