### PR TITLE
chore: route EPS streams per source to dedicated TN access blocks

### DIFF
--- a/src/tsn_adapters/flows/eps/deploy_flow.py
+++ b/src/tsn_adapters/flows/eps/deploy_flow.py
@@ -37,6 +37,7 @@ from tsn_adapters.tasks.eps.config import (
     truf_eps_stream_name,
     yahoo_eps_stream_name,
 )
+from tsn_adapters.utils.logging import get_logger_safe
 
 ALL_EPS_SOURCE_TYPES: tuple[str, ...] = ("fmp_eps", "yahoo_eps", "truf_eps")
 
@@ -101,7 +102,20 @@ def eps_deploy_flow(
     DeploymentStateBlock to persist deployment state across runs and
     avoid redundant TN existence checks.
     """
+    logger = get_logger_safe(__name__)
     descriptor = EpsSourceDescriptor(source_types=source_types)
+
+    # Log the symbol → stream_id mapping under the active wallet so the
+    # operator can paste a (data_provider, label, stream_id) table
+    # straight from the Prefect run into deployment documentation.
+    mapping_df = descriptor.get_descriptor()
+    wallet = tn_block.current_account
+    logger.info(f"EPS deploy mapping (wallet={wallet}, source_types={source_types}):")
+    for _, row in mapping_df.iterrows():
+        logger.info(
+            f"  {row['source_id']:<6} {row['source_display_name']:<28} {row['stream_id']}"
+        )
+
     return deploy_streams_flow(
         psd_block=descriptor,
         tna_block=tn_block,

--- a/src/tsn_adapters/flows/eps/deploy_flow.py
+++ b/src/tsn_adapters/flows/eps/deploy_flow.py
@@ -38,54 +38,70 @@ from tsn_adapters.tasks.eps.config import (
     yahoo_eps_stream_name,
 )
 
+ALL_EPS_SOURCE_TYPES: tuple[str, ...] = ("fmp_eps", "yahoo_eps", "truf_eps")
+
 
 class EpsSourceDescriptor(PrimitiveSourcesDescriptorBlock):
     """In-memory descriptor for EPS streams — no external storage needed.
 
-    Generates all 21 EPS stream definitions (7 tickers × 3 source types)
-    deterministically from config. Stream IDs are computed via generate_stream_id
-    and never change for a given ticker/convention pair.
+    Generates EPS stream definitions (MAG7 × `source_types`) deterministically
+    from config. Stream IDs are computed via generate_stream_id and never
+    change for a given ticker/convention pair.
+
+    `source_types` selects which of {"fmp_eps", "yahoo_eps", "truf_eps"} to
+    include — useful when each source identity lives on its own TN wallet
+    and deployment must be routed accordingly.
     """
 
     _block_type_name = "EPS Source Descriptor"
     _block_type_slug = "eps-source-descriptor"
 
+    source_types: tuple[str, ...] = ALL_EPS_SOURCE_TYPES
+
     def get_descriptor(self) -> DataFrame[PrimitiveSourceDataModel]:
         rows = []
         for symbol in MAG7:
-            rows.append({
-                "stream_id": FMP_EPS_STREAM_IDS[symbol],
-                "source_id": symbol,
-                "source_type": "fmp_eps",
-                "source_display_name": fmp_eps_stream_name(symbol),
-            })
-            rows.append({
-                "stream_id": YAHOO_EPS_STREAM_IDS[symbol],
-                "source_id": symbol,
-                "source_type": "yahoo_eps",
-                "source_display_name": yahoo_eps_stream_name(symbol),
-            })
-            rows.append({
-                "stream_id": EPS_STREAM_IDS[symbol],
-                "source_id": symbol,
-                "source_type": "truf_eps",
-                "source_display_name": truf_eps_stream_name(symbol),
-            })
+            if "fmp_eps" in self.source_types:
+                rows.append({
+                    "stream_id": FMP_EPS_STREAM_IDS[symbol],
+                    "source_id": symbol,
+                    "source_type": "fmp_eps",
+                    "source_display_name": fmp_eps_stream_name(symbol),
+                })
+            if "yahoo_eps" in self.source_types:
+                rows.append({
+                    "stream_id": YAHOO_EPS_STREAM_IDS[symbol],
+                    "source_id": symbol,
+                    "source_type": "yahoo_eps",
+                    "source_display_name": yahoo_eps_stream_name(symbol),
+                })
+            if "truf_eps" in self.source_types:
+                rows.append({
+                    "stream_id": EPS_STREAM_IDS[symbol],
+                    "source_id": symbol,
+                    "source_type": "truf_eps",
+                    "source_display_name": truf_eps_stream_name(symbol),
+                })
         return DataFrame[PrimitiveSourceDataModel](pd.DataFrame(rows))
 
 
 @flow(name="EPS Stream Deployment Flow")
 def eps_deploy_flow(
     tn_block: TNAccessBlock,
+    source_types: tuple[str, ...] = ALL_EPS_SOURCE_TYPES,
     deployment_state: Optional[DeploymentStateBlock] = None,
 ) -> DeployStreamResults:
-    """Deploy all 21 EPS primitive streams to TN.
+    """Deploy EPS primitive streams to TN.
+
+    Streams written go to `tn_block.current_account`. Pass `source_types`
+    to restrict the descriptor to a single source identity per wallet
+    (e.g. `("fmp_eps",)` on the FMP wallet block).
 
     Idempotent — already-deployed streams are skipped. Pass a
     DeploymentStateBlock to persist deployment state across runs and
     avoid redundant TN existence checks.
     """
-    descriptor = EpsSourceDescriptor()
+    descriptor = EpsSourceDescriptor(source_types=source_types)
     return deploy_streams_flow(
         psd_block=descriptor,
         tna_block=tn_block,

--- a/src/tsn_adapters/flows/eps/historical_flow.py
+++ b/src/tsn_adapters/flows/eps/historical_flow.py
@@ -18,8 +18,12 @@ Usage (single-shot, idempotent — already-published dates are skipped):
     eps_historical_flow(
         fmp_block=FMPBlock.load("default"),
         yahoo_block=YahooBlock.load("default"),
-        tn_block=TNAccessBlock.load("default"),
+        fmp_tn_block=TNAccessBlock.load("fmp-eps"),
+        yahoo_tn_block=TNAccessBlock.load("yahoo-eps"),
     )
+
+`fmp_tn_block` and `yahoo_tn_block` may point at the same TN wallet
+when source identities are not split.
 """
 from __future__ import annotations
 
@@ -98,10 +102,15 @@ def build_new_records(
 def eps_historical_flow(
     fmp_block: FMPBlock,
     yahoo_block: YahooBlock,
-    tn_block: TNAccessBlock,
+    fmp_tn_block: TNAccessBlock,
+    yahoo_tn_block: TNAccessBlock,
     symbols: list[str] = MAG7,
 ) -> None:
     """Backfill Mag-7 historical EPS into FMP and Yahoo primitive streams on TN.
+
+    Each source writes via its own TN block: `fmp_tn_block` owns the
+    `fmp_eps_*` streams, `yahoo_tn_block` owns the `yahoo_eps_*` streams.
+    Pass the same block for both when source identities share a wallet.
 
     Safe to re-run: already-published dates are skipped. Both the FMP and Yahoo
     primitive streams must be deployed before running.
@@ -109,7 +118,8 @@ def eps_historical_flow(
     logger = get_logger_safe(__name__)
     logger.info(f"Starting EPS historical backfill for {symbols}")
 
-    all_records = pd.DataFrame(columns=["stream_id", "date", "value", "data_provider"])
+    fmp_records = pd.DataFrame(columns=["stream_id", "date", "value", "data_provider"])
+    yahoo_records = pd.DataFrame(columns=["stream_id", "date", "value", "data_provider"])
 
     for symbol in symbols:
         fmp_stream_id = FMP_EPS_STREAM_IDS[symbol]
@@ -117,7 +127,7 @@ def eps_historical_flow(
 
         # --- FMP source ---
         fmp_earnings = fetch_fmp_earnings(fmp_block=fmp_block, symbol=symbol)
-        fmp_published = read_published_dates(tn_block=tn_block, stream_id=fmp_stream_id)
+        fmp_published = read_published_dates(tn_block=fmp_tn_block, stream_id=fmp_stream_id)
         fmp_new = build_new_records(
             earnings_df=fmp_earnings,
             stream_id=fmp_stream_id,
@@ -127,7 +137,7 @@ def eps_historical_flow(
 
         # --- Yahoo source ---
         yahoo_earnings = fetch_yahoo_earnings(yahoo_block=yahoo_block, symbol=symbol)
-        yahoo_published = read_published_dates(tn_block=tn_block, stream_id=yahoo_stream_id)
+        yahoo_published = read_published_dates(tn_block=yahoo_tn_block, stream_id=yahoo_stream_id)
         yahoo_new = build_new_records(
             earnings_df=yahoo_earnings,
             stream_id=yahoo_stream_id,
@@ -135,17 +145,26 @@ def eps_historical_flow(
         )
         logger.info(f"{symbol}: {len(yahoo_new)} new Yahoo record(s)")
 
-        all_records = pd.concat([all_records, fmp_new, yahoo_new], ignore_index=True)
+        fmp_records = pd.concat([fmp_records, fmp_new], ignore_index=True)
+        yahoo_records = pd.concat([yahoo_records, yahoo_new], ignore_index=True)
 
-    if all_records.empty:
+    if fmp_records.empty and yahoo_records.empty:
         logger.info("No new EPS records to insert — backfill already up-to-date")
         return
 
-    task_split_and_insert_records(
-        block=tn_block,
-        records=DataFrame[TnDataRowModel](all_records),
-    )
-    logger.info(f"Inserted {len(all_records)} EPS records across FMP + Yahoo streams")
+    if not fmp_records.empty:
+        task_split_and_insert_records(
+            block=fmp_tn_block,
+            records=DataFrame[TnDataRowModel](fmp_records),
+        )
+        logger.info(f"Inserted {len(fmp_records)} EPS records into FMP streams")
+
+    if not yahoo_records.empty:
+        task_split_and_insert_records(
+            block=yahoo_tn_block,
+            records=DataFrame[TnDataRowModel](yahoo_records),
+        )
+        logger.info(f"Inserted {len(yahoo_records)} EPS records into Yahoo streams")
 
 
 if __name__ == "__main__":
@@ -155,7 +174,13 @@ if __name__ == "__main__":
     async def main() -> None:
         fmp_block = deroutine(FMPBlock.load("default"))
         yahoo_block = deroutine(YahooBlock.load("default"))
-        tn_block = deroutine(TNAccessBlock.load("default"))
-        eps_historical_flow(fmp_block=fmp_block, yahoo_block=yahoo_block, tn_block=tn_block)
+        fmp_tn_block = deroutine(TNAccessBlock.load("fmp-eps"))
+        yahoo_tn_block = deroutine(TNAccessBlock.load("yahoo-eps"))
+        eps_historical_flow(
+            fmp_block=fmp_block,
+            yahoo_block=yahoo_block,
+            fmp_tn_block=fmp_tn_block,
+            yahoo_tn_block=yahoo_tn_block,
+        )
 
     asyncio.run(main())

--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -28,8 +28,14 @@ Usage:
     eps_real_time_flow(
         fmp_block=FMPBlock.load("default"),
         yahoo_block=YahooBlock.load("default"),
-        tn_block=TNAccessBlock.load("default"),
+        fmp_tn_block=TNAccessBlock.load("fmp-eps"),
+        yahoo_tn_block=TNAccessBlock.load("yahoo-eps"),
+        truf_tn_block=TNAccessBlock.load("truf-eps"),
     )
+
+Each source identity owns a distinct TN wallet so the on-chain
+`data_provider` field reflects who produced the data. Pass the same
+block for all three when source identities share a wallet.
 """
 from __future__ import annotations
 
@@ -75,15 +81,22 @@ def _is_published(tn_block: TNAccessBlock, stream_id: str, date_unix: int) -> bo
 def detect_and_prepare_eps(
     fmp_block: FMPBlock,
     yahoo_block: YahooBlock,
-    tn_block: TNAccessBlock,
+    fmp_tn_block: TNAccessBlock,
+    yahoo_tn_block: TNAccessBlock,
+    truf_tn_block: TNAccessBlock,
     symbol: str,
-) -> list[dict]:
-    """Detect new EPS prints for one symbol and return all TN rows to insert.
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Detect new EPS prints for one symbol and return per-wallet TN rows.
 
-    Returns records for:
-    - the FMP primitive stream (raw value, when FMP has the data)
-    - the Yahoo primitive stream (raw value, when Yahoo has the data)
-    - the consensus stream (exact primary-source value, when ≥2 agree)
+    Returns a tuple `(fmp_rows, yahoo_rows, truf_rows)` where each list is
+    destined for the matching wallet's TN block:
+    - fmp_rows  → FMP primitive stream (raw value, when FMP has the data)
+    - yahoo_rows → Yahoo primitive stream (raw value, when Yahoo has the data)
+    - truf_rows → consensus stream (exact primary-source value, when ≥2 agree)
+
+    Read scoping: each stream's "already-published?" check uses the block
+    that owns it, so the underlying `read_records` query resolves to the
+    correct on-chain `data_provider`.
 
     Workset is the union of quarter dates from both sources so a quarter
     reported by only one source is still processed. Per spec §3: readings
@@ -116,13 +129,15 @@ def detect_and_prepare_eps(
     # Union of all quarter dates with at least one source reporting
     all_dates = sorted(set(fmp_by_date) | set(yahoo_by_date))
 
-    records: list[dict] = []
+    fmp_rows: list[dict] = []
+    yahoo_rows: list[dict] = []
+    truf_rows: list[dict] = []
 
     for date_str in all_dates:
         date_unix = date_string_to_unix(date_str)
 
         # Skip entirely if consensus is already committed
-        if _is_published(tn_block, consensus_stream, date_unix):
+        if _is_published(truf_tn_block, consensus_stream, date_unix):
             continue
 
         # Build readings in priority order (spec §3: fmp first)
@@ -130,8 +145,8 @@ def detect_and_prepare_eps(
 
         fmp_eps = fmp_by_date.get(date_str)
         if fmp_eps is not None:
-            if not _is_published(tn_block, fmp_stream, date_unix):
-                records.append({
+            if not _is_published(fmp_tn_block, fmp_stream, date_unix):
+                fmp_rows.append({
                     "stream_id": fmp_stream,
                     "date": date_unix,
                     "value": str(fmp_eps),
@@ -147,8 +162,8 @@ def detect_and_prepare_eps(
 
         yahoo_eps = yahoo_by_date.get(date_str)
         if yahoo_eps is not None:
-            if not _is_published(tn_block, yahoo_stream, date_unix):
-                records.append({
+            if not _is_published(yahoo_tn_block, yahoo_stream, date_unix):
+                yahoo_rows.append({
                     "stream_id": yahoo_stream,
                     "date": date_unix,
                     "value": str(yahoo_eps),
@@ -166,7 +181,7 @@ def detect_and_prepare_eps(
         result = reconcile(readings)
 
         if result.status == "settled":
-            records.append({
+            truf_rows.append({
                 "stream_id": consensus_stream,
                 "date": date_unix,
                 "value": str(result.value),  # exact primary-source figure
@@ -187,42 +202,71 @@ def detect_and_prepare_eps(
                 f"{len(readings)} source(s) available, need ≥2 to settle"
             )
 
-    return records
+    return fmp_rows, yahoo_rows, truf_rows
 
 
 @flow(name="EPS Real-Time Detection Flow")
 def eps_real_time_flow(
     fmp_block: FMPBlock,
     yahoo_block: YahooBlock,
-    tn_block: TNAccessBlock,
+    fmp_tn_block: TNAccessBlock,
+    yahoo_tn_block: TNAccessBlock,
+    truf_tn_block: TNAccessBlock,
     symbols: list[str] = MAG7,
 ) -> None:
     """Detect and publish Mag-7 EPS prints to TN.
 
     Writes raw values to per-source primitive streams and, when ≥2 sources
     agree within $0.01, commits the consensus value to the truf_eps stream.
-    Single-shot — driven by external scheduler.
+    Each destination uses its own wallet block so the on-chain `data_provider`
+    reflects the identity that produced the data. Single-shot — driven by
+    external scheduler.
     """
     logger = get_logger_safe(__name__)
     logger.info(f"EPS real-time detection starting for {symbols}")
 
-    all_rows: list[dict] = []
+    fmp_rows: list[dict] = []
+    yahoo_rows: list[dict] = []
+    truf_rows: list[dict] = []
+
     for symbol in symbols:
-        new_rows = detect_and_prepare_eps(
+        fmp_new, yahoo_new, truf_new = detect_and_prepare_eps(
             fmp_block=fmp_block,
             yahoo_block=yahoo_block,
-            tn_block=tn_block,
+            fmp_tn_block=fmp_tn_block,
+            yahoo_tn_block=yahoo_tn_block,
+            truf_tn_block=truf_tn_block,
             symbol=symbol,
         )
-        all_rows.extend(new_rows)
+        fmp_rows.extend(fmp_new)
+        yahoo_rows.extend(yahoo_new)
+        truf_rows.extend(truf_new)
 
-    if not all_rows:
+    total = len(fmp_rows) + len(yahoo_rows) + len(truf_rows)
+    if total == 0:
         logger.info("No new EPS records to publish")
         return
 
-    records_df = DataFrame[TnDataRowModel](pd.DataFrame(all_rows))
-    task_split_and_insert_records(block=tn_block, records=records_df)
-    logger.info(f"Published {len(all_rows)} EPS record(s) across source + consensus streams")
+    if fmp_rows:
+        task_split_and_insert_records(
+            block=fmp_tn_block,
+            records=DataFrame[TnDataRowModel](pd.DataFrame(fmp_rows)),
+        )
+        logger.info(f"Published {len(fmp_rows)} record(s) to FMP streams")
+
+    if yahoo_rows:
+        task_split_and_insert_records(
+            block=yahoo_tn_block,
+            records=DataFrame[TnDataRowModel](pd.DataFrame(yahoo_rows)),
+        )
+        logger.info(f"Published {len(yahoo_rows)} record(s) to Yahoo streams")
+
+    if truf_rows:
+        task_split_and_insert_records(
+            block=truf_tn_block,
+            records=DataFrame[TnDataRowModel](pd.DataFrame(truf_rows)),
+        )
+        logger.info(f"Published {len(truf_rows)} record(s) to Truf consensus streams")
 
 
 if __name__ == "__main__":
@@ -232,7 +276,15 @@ if __name__ == "__main__":
     async def main() -> None:
         fmp_block = deroutine(FMPBlock.load("default"))
         yahoo_block = deroutine(YahooBlock.load("default"))
-        tn_block = deroutine(TNAccessBlock.load("default"))
-        eps_real_time_flow(fmp_block=fmp_block, yahoo_block=yahoo_block, tn_block=tn_block)
+        fmp_tn_block = deroutine(TNAccessBlock.load("fmp-eps"))
+        yahoo_tn_block = deroutine(TNAccessBlock.load("yahoo-eps"))
+        truf_tn_block = deroutine(TNAccessBlock.load("truf-eps"))
+        eps_real_time_flow(
+            fmp_block=fmp_block,
+            yahoo_block=yahoo_block,
+            fmp_tn_block=fmp_tn_block,
+            yahoo_tn_block=yahoo_tn_block,
+            truf_tn_block=truf_tn_block,
+        )
 
     asyncio.run(main())

--- a/tests/eps/test_deploy_flow.py
+++ b/tests/eps/test_deploy_flow.py
@@ -38,3 +38,32 @@ def test_descriptor_stream_ids_match_config():
         ids = set(sym_rows["stream_id"].tolist())
         expected = {FMP_EPS_STREAM_IDS[symbol], YAHOO_EPS_STREAM_IDS[symbol], EPS_STREAM_IDS[symbol]}
         assert ids == expected, f"Stream IDs mismatch for {symbol}"
+
+
+# --- source_types filter ---
+
+@pytest.mark.parametrize(
+    "source_types,expected_count,expected_ids_fn",
+    [
+        (("fmp_eps",), 7, lambda sym: FMP_EPS_STREAM_IDS[sym]),
+        (("yahoo_eps",), 7, lambda sym: YAHOO_EPS_STREAM_IDS[sym]),
+        (("truf_eps",), 7, lambda sym: EPS_STREAM_IDS[sym]),
+    ],
+)
+def test_descriptor_single_source_type(source_types, expected_count, expected_ids_fn):
+    df = EpsSourceDescriptor(source_types=source_types).get_descriptor()
+    assert len(df) == expected_count
+    assert set(df["source_type"].unique()) == set(source_types)
+    assert set(df["stream_id"].tolist()) == {expected_ids_fn(sym) for sym in MAG7}
+
+
+def test_descriptor_two_source_types():
+    df = EpsSourceDescriptor(source_types=("fmp_eps", "yahoo_eps")).get_descriptor()
+    assert len(df) == 14
+    assert set(df["source_type"].unique()) == {"fmp_eps", "yahoo_eps"}
+
+
+def test_descriptor_default_includes_all_three():
+    df = EpsSourceDescriptor().get_descriptor()
+    assert len(df) == 21
+    assert set(df["source_type"].unique()) == {"fmp_eps", "yahoo_eps", "truf_eps"}

--- a/tests/eps/test_historical_flow.py
+++ b/tests/eps/test_historical_flow.py
@@ -97,15 +97,25 @@ AAPL_YAHOO_ROW = {"symbol": "AAPL", "date": "2024-03-31", "epsActual": 1.53, "ep
 def test_historical_flow_inserts_fmp_and_yahoo_records():
     fmp_block = make_fmp_block({"AAPL": [AAPL_FMP_ROW]})
     yahoo_block = make_yahoo_block({"AAPL": [AAPL_YAHOO_ROW]})
-    tn_block = FakeTNAccessBlock(existing_streams={FMP_EPS_STREAM_IDS["AAPL"], YAHOO_EPS_STREAM_IDS["AAPL"]})
+    fmp_tn_block = FakeTNAccessBlock(existing_streams={FMP_EPS_STREAM_IDS["AAPL"]})
+    yahoo_tn_block = FakeTNAccessBlock(existing_streams={YAHOO_EPS_STREAM_IDS["AAPL"]})
 
-    eps_historical_flow(fmp_block=fmp_block, yahoo_block=yahoo_block, tn_block=tn_block, symbols=["AAPL"])
+    eps_historical_flow(
+        fmp_block=fmp_block,
+        yahoo_block=yahoo_block,
+        fmp_tn_block=fmp_tn_block,
+        yahoo_tn_block=yahoo_tn_block,
+        symbols=["AAPL"],
+    )
 
-    all_inserted = pd.concat(tn_block.inserted_records, ignore_index=True)
-    inserted_streams = set(all_inserted["stream_id"].tolist())
+    fmp_inserted = pd.concat(fmp_tn_block.inserted_records, ignore_index=True)
+    yahoo_inserted = pd.concat(yahoo_tn_block.inserted_records, ignore_index=True)
 
-    assert FMP_EPS_STREAM_IDS["AAPL"] in inserted_streams
-    assert YAHOO_EPS_STREAM_IDS["AAPL"] in inserted_streams
+    assert FMP_EPS_STREAM_IDS["AAPL"] in set(fmp_inserted["stream_id"].tolist())
+    assert YAHOO_EPS_STREAM_IDS["AAPL"] in set(yahoo_inserted["stream_id"].tolist())
+    # Each wallet only receives its own source's records — no cross-wallet leak
+    assert YAHOO_EPS_STREAM_IDS["AAPL"] not in set(fmp_inserted["stream_id"].tolist())
+    assert FMP_EPS_STREAM_IDS["AAPL"] not in set(yahoo_inserted["stream_id"].tolist())
 
 
 @pytest.mark.timeout(30, func_only=True)
@@ -114,10 +124,18 @@ def test_historical_flow_no_insert_when_all_published():
 
     fmp_block = make_fmp_block({"AAPL": [AAPL_FMP_ROW]})
     yahoo_block = make_yahoo_block({"AAPL": [AAPL_YAHOO_ROW]})
-    tn_block = FakeTNAccessBlock()
-    tn_block.seed_records(FMP_EPS_STREAM_IDS["AAPL"], [already_unix])
-    tn_block.seed_records(YAHOO_EPS_STREAM_IDS["AAPL"], [already_unix])
+    fmp_tn_block = FakeTNAccessBlock()
+    yahoo_tn_block = FakeTNAccessBlock()
+    fmp_tn_block.seed_records(FMP_EPS_STREAM_IDS["AAPL"], [already_unix])
+    yahoo_tn_block.seed_records(YAHOO_EPS_STREAM_IDS["AAPL"], [already_unix])
 
-    eps_historical_flow(fmp_block=fmp_block, yahoo_block=yahoo_block, tn_block=tn_block, symbols=["AAPL"])
+    eps_historical_flow(
+        fmp_block=fmp_block,
+        yahoo_block=yahoo_block,
+        fmp_tn_block=fmp_tn_block,
+        yahoo_tn_block=yahoo_tn_block,
+        symbols=["AAPL"],
+    )
 
-    assert tn_block.inserted_records == []
+    assert fmp_tn_block.inserted_records == []
+    assert yahoo_tn_block.inserted_records == []


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3936

## Summary

- `EpsSourceDescriptor` and `eps_deploy_flow` accept a `source_types: tuple[str, ...]` filter so deployment can be scoped to a single source identity per wallet (e.g. `("fmp_eps",)` on the FMP wallet block). Default still emits all 21 streams.
- `eps_historical_flow` now takes `fmp_tn_block` + `yahoo_tn_block` and writes each source's records via its own block — `fmp_eps_*` flows through the FMP wallet, `yahoo_eps_*` through the Yahoo wallet. Pass the same block for both to keep the previous single-wallet shape.
- `eps_real_time_flow` takes `fmp_tn_block` + `yahoo_tn_block` + `truf_tn_block`. The `_is_published` read for each stream now uses the block that owns it (so the implicit `data_provider` resolves to the right wallet), and consensus inserts go through the dedicated `truf_tn_block`.
- Tests: parameterised `source_types` coverage for the descriptor (single + dual + default); historical-flow tests rewritten with two fake blocks to assert no cross-wallet leak.

Required for the matching truf-data-provider change in trufnetwork/truf-data-provider#795 follow-up, where testnet EPS is split across `testnet-fmp-eps` / `testnet-yahoo-eps` / `testnet-truf-eps`.

## Test plan

- [ ] `pytest tests/eps/ -x` — all 26 tests pass locally.
- [ ] CI green.
- [ ] After merge, downstream tdp branch can pin to this SHA and the five-deployment testnet rollout (3 deploy + 1 historical + 1 real-time) registers cleanly against the new block names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EPS streams can now be deployed selectively by source type instead of all at once.
  * EPS data from FMP, Yahoo, and consensus sources are now written to isolated streams with proper source attribution.

* **Tests**
  * Added test coverage for selective EPS stream deployment configurations.
  * Updated tests to validate source-specific data isolation across wallet boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->