### PR TITLE
chore: use only block field for proxy, exclude local from proxy

### DIFF
--- a/src/tsn_adapters/blocks/yahoo.py
+++ b/src/tsn_adapters/blocks/yahoo.py
@@ -112,10 +112,11 @@ class YahooBlock(Block):
         if self._proxy_initialized:
             return
 
-        proxy = self.proxy_url or os.environ.get("YAHOO_PROXY_URL")
+        proxy = self.proxy_url
         if proxy:
             os.environ["HTTP_PROXY"] = proxy
             os.environ["HTTPS_PROXY"] = proxy
+            os.environ.setdefault("NO_PROXY", "localhost,127.0.0.1,172.17.0.1,169.254.169.254")
             _clear_stale_cookie_cache()
             self.logger.info("Yahoo proxy configured — routing yfinance through proxy")
 


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3978


## Summary
- Remove `YAHOO_PROXY_URL` env var fallback — proxy URL comes only from the `YahooBlock.proxy_url` Prefect block field
- Add `NO_PROXY` for local addresses (`localhost`, `127.0.0.1`, `172.17.0.1`, `169.254.169.254`) so process-wide `HTTP_PROXY`/`HTTPS_PROXY` env vars don't route Prefect API and other internal traffic through the external proxy

## Test plan
- [ ] Verified on the Prefect ingestor server: historical backfill completed for all 7 Mag-7 tickers (336 FMP + 28 Yahoo records), no 403 errors on Prefect API calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated proxy configuration handling to rely exclusively on the configured proxy setting, removing fallback to environment variable sources
  * Implemented automatic exclusion of local and link-local addresses from proxy requirements when proxy configuration is active

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->