### PR TITLE
chore: reconcile EPS sources by canonical event identity

### DIFF
--- a/src/tsn_adapters/blocks/fmp.py
+++ b/src/tsn_adapters/blocks/fmp.py
@@ -19,11 +19,6 @@ from tsn_adapters.utils.logging import get_logger_safe
 PanderaModelType = TypeVar("PanderaModelType", bound=DataFrameModel)
 
 
-
-
-
-
-
 class FMPExchange(Enum):
     NYSE = "nyse"
     NASDAQ = "nasdaq"
@@ -32,9 +27,11 @@ class FMPExchange(Enum):
     NYMEX = "NYMEX"
     COMEX = "COMEX"
 
+
 class FMPAPI(Enum):
     LEGACY = "api/v3/"
     STABLE = "stable/"
+
 
 CME_GROUP_EXCHANGES: set[str] = {
     FMPExchange.CME.value,
@@ -49,10 +46,9 @@ class FMPEndpoint:
         self.api = api
         self.path = path
         self.params = params
-    
+
     def get_url(self, base_url: str) -> str:
         return base_url + self.api.value + self.path + (f"?{urlencode(self.params)}" if self.params else "")
-
 
 
 class ActiveTicker(DataFrameModel):
@@ -157,6 +153,7 @@ class IndexConstituent(DataFrameModel):
     Schema for S&P 500 constituents from FMP API.
     https://site.financialmodelingprep.com/developer/docs/stable/sp-500
     """
+
     symbol: Series[str]
     name: Series[str] = Field(nullable=True)
     sector: Series[str] = Field(nullable=True)
@@ -173,8 +170,9 @@ class IndexConstituent(DataFrameModel):
 
 class CommodityInfo(DataFrameModel):
     """
-    https://site.financialmodelingprep.com/developer/docs/stable/commodities-list 
+    https://site.financialmodelingprep.com/developer/docs/stable/commodities-list
     """
+
     symbol: Series[str]
     name: Series[str]
     exchange: Series[str] = Field(nullable=True)
@@ -191,6 +189,7 @@ class IndexInfo(DataFrameModel):
     Schema for stock market indexes from FMP API.
     https://site.financialmodelingprep.com/developer/docs/stable/indexes-list
     """
+
     symbol: Series[str]
     name: Series[str] = Field(nullable=True)
     exchange: Series[str] = Field(nullable=True)
@@ -206,6 +205,7 @@ class CommodityQuote(DataFrameModel):
     Schema for commodity quotes from legacy FMP API endpoint /api/v3/quotes/commodity.
     https://site.financialmodelingprep.com/developer/docs/commodities-prices-api
     """
+
     symbol: Series[str]
     price: Series[pd.Float64Dtype]
     change: Series[pd.Float64Dtype] = Field(nullable=True)
@@ -221,6 +221,7 @@ class ExchangeQuote(DataFrameModel):
     Schema for bulk exchange quotes from FMP API endpoint /stable/batch-exchange-quote.
     Only relevant fields are captured; extras are filtered out by strict="filter".
     """
+
     symbol: Series[str]
     price: Series[pd.Float64Dtype] = Field(nullable=True)
     volume: Series[pd.Int64Dtype] = Field(nullable=True)
@@ -250,6 +251,38 @@ class EarningsData(DataFrameModel):
         coerce = True
 
 
+class QuarterlyIncomeStatementData(DataFrameModel):
+    """Schema for FMP /stable/income-statement?period=quarter rows.
+
+    Captures only the temporal/identity fields needed for cross-source EPS
+    reconciliation. The full FMP response carries ~40 line-item fields
+    (revenue, costs, eps, etc.); we filter the schema down to what the
+    reconciler actually consumes.
+
+    `filingDate` matches FMP's /stable/earnings `date` field exactly for the
+    same earnings event — that's the join column when enriching earnings
+    data with the fiscal-period-end. `date` is the fiscal-period-end itself,
+    used to derive a canonical (symbol, calendar_year, calendar_quarter)
+    join key that aligns FMP (announcement-date-keyed) with Yahoo
+    (period-end-keyed) for the same fiscal event.
+
+    Verified May 25 2026: this endpoint is populated within hours of the 8-K
+    earnings filing, not weeks later when the 10-Q lands — so it's usable
+    at real-time-reconciliation time.
+    """
+
+    symbol: Series[str]
+    period: Series[str]  # 'Q1' | 'Q2' | 'Q3' | 'Q4' | 'FY'
+    fiscalYear: Series[str] = Field(nullable=True)
+    date: Series[str]  # fiscal-period-end, ISO 'YYYY-MM-DD'
+    filingDate: Series[str] = Field(nullable=True)
+    acceptedDate: Series[str] = Field(nullable=True)
+
+    class Config(DataFrameModel.Config):
+        strict = "filter"
+        coerce = True
+
+
 class FMPBlock(Block):
     api_key: SecretStr
 
@@ -260,7 +293,6 @@ class FMPBlock(Block):
         if not hasattr(self, "_logger"):
             self._logger = get_logger_safe(__name__)
         return self._logger
-    
 
     def _get_jsonparsed_data(self, endpoint: FMPEndpoint) -> Union[dict[str, Any], list[dict[str, Any]]]:
         base_endpoint_url = endpoint.get_url(self.base_url)
@@ -441,7 +473,7 @@ class FMPBlock(Block):
                 if not processed_data:
                     self.logger.info(f"All records for {log_entity_name} were filtered out client-side.")
                     return create_empty_df(model_type)
-            
+
             # Convert list of dicts directly to a typed Pandera DataFrame
             self.logger.info(f"Successfully fetched {len(processed_data)} {log_entity_name} records.")
             try:
@@ -453,13 +485,15 @@ class FMPBlock(Block):
                 df_validated = model_type.validate(df_for_validation, lazy=True)
                 self.logger.info(f"Successfully fetched & validated {len(df_validated)} {log_entity_name} records.")
                 return df_validated
-            except Exception as e: # Catch PanderaError or other validation issues
-                self.logger.error(f"Schema validation failed for {log_entity_name} after processing: {e}", exc_info=True)
-                raise # Re-raise validation errors
+            except Exception as e:  # Catch PanderaError or other validation issues
+                self.logger.error(
+                    f"Schema validation failed for {log_entity_name} after processing: {e}", exc_info=True
+                )
+                raise  # Re-raise validation errors
 
-        except Exception as e: # Catch issues from _get_jsonparsed_data or other initial errors
+        except Exception as e:  # Catch issues from _get_jsonparsed_data or other initial errors
             self.logger.error(f"Error fetching or processing {log_entity_name}: {e}", exc_info=True)
-            raise # Re-raise fetching/processing errors
+            raise  # Re-raise fetching/processing errors
 
     def get_equities(self, exchange: FMPExchange) -> DataFrame[ExchangeQuote]:
         """
@@ -527,4 +561,28 @@ class FMPBlock(Block):
             endpoint=FMPEndpoint(FMPAPI.STABLE, "earnings", {"symbol": symbol, "limit": limit}),
             model_type=EarningsData,
             log_entity_name=f"{symbol} historical earnings",
+        )
+
+    def get_quarterly_income_statements(self, symbol: str, limit: int = 8) -> DataFrame[QuarterlyIncomeStatementData]:
+        """Per-ticker quarterly income statements.
+
+        Uses /stable/income-statement?period=quarter. The response includes
+        both `filingDate` (matches the /stable/earnings `date` for the same
+        earnings event) and `date` (the fiscal-period-end). Together they
+        let cross-source reconciliation derive a canonical event key that
+        aligns FMP earnings rows (keyed by announcement date) with Yahoo
+        rows (keyed by fiscal-period-end).
+
+        Verified May 25 2026: the endpoint is populated within hours of the
+        8-K earnings filing — usable at real-time-reconciliation time, not
+        only after the 10-Q lands weeks later.
+        """
+        return self._fetch_fmp_list_data(
+            endpoint=FMPEndpoint(
+                FMPAPI.STABLE,
+                "income-statement",
+                {"symbol": symbol, "period": "quarter", "limit": limit},
+            ),
+            model_type=QuarterlyIncomeStatementData,
+            log_entity_name=f"{symbol} quarterly income statements",
         )

--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -9,7 +9,7 @@ Stream layout per ticker (spec §3):
   yahoo_eps_<sym>_<conv> — raw Yahoo ingestion (written when Yahoo has the data)
   truf_eps_<sym>_<conv>  — consensus (written only when ≥2 sources agree)
 
-Settlement logic (spec §3–4):
+Settlement logic (spec §3-4):
   SETTLED  — FMP and Yahoo agree within $0.01 → write consensus; exact figure,
              no averaging (primary source = FMP)
   PENDING  — only one source has reported → skip consensus; re-run later
@@ -37,6 +37,7 @@ Each source identity owns a distinct TN wallet so the on-chain
 `data_provider` field reflects who produced the data. Pass the same
 block for all three when source identities share a wallet.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -46,8 +47,8 @@ from pandera.typing import DataFrame
 from prefect import flow, task
 
 from tsn_adapters.blocks.fmp import FMPBlock
-from tsn_adapters.blocks.yahoo import YahooBlock
 from tsn_adapters.blocks.tn_access import TNAccessBlock
+from tsn_adapters.blocks.yahoo import YahooBlock
 from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
 from tsn_adapters.common.trufnetwork.tasks.insert import task_split_and_insert_records
 from tsn_adapters.tasks.eps.config import (
@@ -56,7 +57,7 @@ from tsn_adapters.tasks.eps.config import (
     MAG7,
     YAHOO_EPS_STREAM_IDS,
 )
-from tsn_adapters.tasks.eps.reconciler import SourceReading, reconcile
+from tsn_adapters.tasks.eps.reconciler import SourceReading, canonical_key, reconcile
 from tsn_adapters.utils.logging import get_logger_safe
 from tsn_adapters.utils.time_utils import date_string_to_unix
 
@@ -98,10 +99,23 @@ def detect_and_prepare_eps(
     that owns it, so the underlying `read_records` query resolves to the
     correct on-chain `data_provider`.
 
-    Workset is the union of quarter dates from both sources so a quarter
-    reported by only one source is still processed. Per spec §3: readings
-    are passed to the reconciler in source-priority order (fmp first) so
-    the committed consensus value is FMP's exact figure.
+    Workset is the union of canonical event keys from both sources so a
+    quarter reported by only one source is still processed. The canonical
+    key (symbol, calendar_year, calendar_quarter) is derived from each
+    source's fiscal-period-end so FMP rows (keyed by announcement date)
+    and Yahoo rows (keyed by fiscal-period-end) reconcile on event identity
+    rather than on a release-date artifact. See trufnetwork/website#3936 for
+    the diagnosis.
+
+    Per spec §3: readings are passed to the reconciler in source-priority
+    order (fmp first) so the committed consensus value is FMP's exact
+    figure.
+
+    On-chain date semantics:
+      - fmp_eps_* primitive stream: written under FMP's announcement date
+      - yahoo_eps_* primitive stream: written under Yahoo's period-end date
+      - truf_eps_* consensus stream: written under FMP's announcement date
+        (preserves "consensus appears at announcement time" semantics)
     """
     logger = get_logger_safe(__name__)
     consensus_stream = EPS_STREAM_IDS[symbol]
@@ -110,65 +124,115 @@ def detect_and_prepare_eps(
 
     earnings_df = fmp_block.get_historical_earnings(symbol, limit=RECENT_QUARTERS)
     yahoo_df = yahoo_block.get_historical_earnings(symbol, limit=RECENT_QUARTERS)
+    # +2 keeps the lookup tolerant of fetch-window drift between earnings and
+    # income-statement (income-statement may lag earnings by one filing).
+    income_stmt_df = fmp_block.get_quarterly_income_statements(symbol, limit=RECENT_QUARTERS + 2)
 
-    # Build per-date lookup dicts for O(1) access inside the loop
-    fmp_by_date: dict[str, float] = {}
-    fmp_retrieved: dict[str, str] = {}
+    # Build filing_date → fiscal-period-end mapping from quarterly income
+    # statements. `filingDate` matches FMP earnings' `date` (announcement
+    # date) exactly for the same event; `date` is the fiscal-period-end.
+    filing_to_period_end: dict[str, str] = {}
+    for _, row in income_stmt_df.iterrows():
+        fd = row.get("filingDate")
+        pe = row.get("date")
+        if fd and pe and not pd.isna(fd) and not pd.isna(pe):
+            filing_to_period_end[str(fd)] = str(pe)
+
+    # Build per-source dicts keyed by canonical event identity:
+    # (symbol, calendar_year_of_period_end, calendar_quarter_of_period_end).
+    # Value stores (eps_actual, source_date_str, retrieved_at) so we can
+    # write each primitive stream under its own source-specific date.
+    fmp_by_key: dict[tuple[str, int, int], tuple[float, str, str]] = {}
     for _, row in earnings_df.iterrows():
-        if not pd.isna(row.get("epsActual")):
-            d = str(row["date"])
-            fmp_by_date[d] = float(row["epsActual"])
-            fmp_retrieved[d] = str(row.get("lastUpdated") or datetime.now(timezone.utc).isoformat())
+        if pd.isna(row.get("epsActual")):
+            continue
+        announcement_date = str(row["date"])
+        period_end = filing_to_period_end.get(announcement_date)
+        if period_end is None:
+            # Income-statement hasn't been published yet for this earnings
+            # (rare edge case at the moment of announcement). Re-run later.
+            logger.info(
+                f"{symbol} {announcement_date}: income-statement not yet "
+                f"published for this filing; skipping reconciliation cycle"
+            )
+            continue
+        key = canonical_key(symbol, period_end)
+        fmp_by_key[key] = (
+            float(row["epsActual"]),
+            announcement_date,
+            str(row.get("lastUpdated") or datetime.now(timezone.utc).isoformat()),
+        )
 
-    yahoo_by_date: dict[str, float] = {}
+    yahoo_by_key: dict[tuple[str, int, int], tuple[float, str]] = {}
     for _, row in yahoo_df.iterrows():
         raw = row.get("epsActual")
-        if raw is not None and not pd.isna(raw):
-            yahoo_by_date[str(row["date"])] = float(raw)
-
-    # Union of all quarter dates with at least one source reporting
-    all_dates = sorted(set(fmp_by_date) | set(yahoo_by_date))
+        if raw is None or pd.isna(raw):
+            continue
+        yahoo_date = str(row["date"])
+        # Yahoo's `date` IS the fiscal-period-end (typically rounded to
+        # calendar-month-end). Pass it directly to canonical_key.
+        key = canonical_key(symbol, yahoo_date)
+        yahoo_by_key[key] = (float(raw), yahoo_date)
 
     fmp_rows: list[dict] = []
     yahoo_rows: list[dict] = []
     truf_rows: list[dict] = []
 
-    for date_str in all_dates:
-        date_unix = date_string_to_unix(date_str)
+    # Iterate over the union of canonical event keys so single-source quarters
+    # are still processed (they end up as `pending` from the reconciler).
+    for key in sorted(set(fmp_by_key) | set(yahoo_by_key)):
+        fmp_data = fmp_by_key.get(key)
+        yahoo_data = yahoo_by_key.get(key)
+
+        # Consensus stream is keyed by FMP announcement date when available
+        # (preserves the "consensus appears at announcement time" semantic
+        # that downstream markets rely on). Fall back to Yahoo's date when
+        # only Yahoo has reported — that branch resolves as `pending` from
+        # the reconciler anyway.
+        consensus_date_str = fmp_data[1] if fmp_data else yahoo_data[1]
+        consensus_date_unix = date_string_to_unix(consensus_date_str)
 
         # Skip entirely if consensus is already committed
-        if _is_published(truf_tn_block, consensus_stream, date_unix):
+        if _is_published(truf_tn_block, consensus_stream, consensus_date_unix):
             continue
 
         # Build readings in priority order (spec §3: fmp first)
         readings: list[SourceReading] = []
+        fmp_eps: float | None = None
+        yahoo_eps: float | None = None
 
-        fmp_eps = fmp_by_date.get(date_str)
-        if fmp_eps is not None:
-            if not _is_published(fmp_tn_block, fmp_stream, date_unix):
-                fmp_rows.append({
-                    "stream_id": fmp_stream,
-                    "date": date_unix,
-                    "value": str(fmp_eps),
-                    "data_provider": None,
-                })
+        if fmp_data is not None:
+            fmp_eps, fmp_date_str, fmp_retrieved_at = fmp_data
+            fmp_date_unix = date_string_to_unix(fmp_date_str)
+            if not _is_published(fmp_tn_block, fmp_stream, fmp_date_unix):
+                fmp_rows.append(
+                    {
+                        "stream_id": fmp_stream,
+                        "date": fmp_date_unix,
+                        "value": str(fmp_eps),
+                        "data_provider": None,
+                    }
+                )
             readings.append(
                 SourceReading(
                     source="fmp",
                     eps_actual=fmp_eps,
-                    retrieved_at=fmp_retrieved[date_str],
+                    retrieved_at=fmp_retrieved_at,
                 )
             )
 
-        yahoo_eps = yahoo_by_date.get(date_str)
-        if yahoo_eps is not None:
-            if not _is_published(yahoo_tn_block, yahoo_stream, date_unix):
-                yahoo_rows.append({
-                    "stream_id": yahoo_stream,
-                    "date": date_unix,
-                    "value": str(yahoo_eps),
-                    "data_provider": None,
-                })
+        if yahoo_data is not None:
+            yahoo_eps, yahoo_date_str = yahoo_data
+            yahoo_date_unix = date_string_to_unix(yahoo_date_str)
+            if not _is_published(yahoo_tn_block, yahoo_stream, yahoo_date_unix):
+                yahoo_rows.append(
+                    {
+                        "stream_id": yahoo_stream,
+                        "date": yahoo_date_unix,
+                        "value": str(yahoo_eps),
+                        "data_provider": None,
+                    }
+                )
             readings.append(
                 SourceReading(
                     source="yahoo",
@@ -181,26 +245,23 @@ def detect_and_prepare_eps(
         result = reconcile(readings)
 
         if result.status == "settled":
-            truf_rows.append({
-                "stream_id": consensus_stream,
-                "date": date_unix,
-                "value": str(result.value),  # exact primary-source figure
-                "data_provider": None,
-            })
+            truf_rows.append(
+                {
+                    "stream_id": consensus_stream,
+                    "date": consensus_date_unix,
+                    "value": str(result.value),  # exact primary-source figure
+                    "data_provider": None,
+                }
+            )
             logger.info(
-                f"{symbol} {date_str}: settled at {result.value} "
-                f"(agreed: {result.sources_agree})"
+                f"{symbol} {key}: settled at {result.value} "
+                f"(agreed: {result.sources_agree}, "
+                f"consensus_date={consensus_date_str})"
             )
         elif result.status == "disputed":
-            logger.warning(
-                f"{symbol} {date_str}: DISPUTED — "
-                f"fmp={fmp_eps}, yahoo={yahoo_eps}; manual review required"
-            )
+            logger.warning(f"{symbol} {key}: DISPUTED — " f"fmp={fmp_eps}, yahoo={yahoo_eps}; manual review required")
         else:
-            logger.info(
-                f"{symbol} {date_str}: pending — "
-                f"{len(readings)} source(s) available, need ≥2 to settle"
-            )
+            logger.info(f"{symbol} {key}: pending — " f"{len(readings)} source(s) available, need ≥2 to settle")
 
     return fmp_rows, yahoo_rows, truf_rows
 
@@ -271,6 +332,7 @@ def eps_real_time_flow(
 
 if __name__ == "__main__":
     import asyncio
+
     from tsn_adapters.utils import deroutine
 
     async def main() -> None:

--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -116,6 +116,12 @@ def detect_and_prepare_eps(
       - yahoo_eps_* primitive stream: written under Yahoo's period-end date
       - truf_eps_* consensus stream: written under FMP's announcement date
         (preserves "consensus appears at announcement time" semantics)
+
+    Primitive emission is decoupled from reconciliation: each ingestion
+    loop emits its source's raw value as soon as fresh data is available,
+    even when reconciliation can't yet run (e.g. FMP's income-statement
+    hasn't been published for the current announcement). Only the
+    consensus write is gated on the reconciler verdict.
     """
     logger = get_logger_safe(__name__)
     consensus_stream = EPS_STREAM_IDS[symbol]
@@ -138,48 +144,76 @@ def detect_and_prepare_eps(
         if fd and pe and not pd.isna(fd) and not pd.isna(pe):
             filing_to_period_end[str(fd)] = str(pe)
 
-    # Build per-source dicts keyed by canonical event identity:
-    # (symbol, calendar_year_of_period_end, calendar_quarter_of_period_end).
-    # Value stores (eps_actual, source_date_str, retrieved_at) so we can
-    # write each primitive stream under its own source-specific date.
+    fmp_rows: list[dict] = []
+    yahoo_rows: list[dict] = []
+    truf_rows: list[dict] = []
+
+    # FMP ingestion. Always emit the raw primitive when fresh; populate the
+    # canonical-key dict only when income-statement provides the period-end.
+    # Decoupling lets the fmp_eps_* stream stay faithful to FMP's announcement
+    # even during the rare race window where the income-statement filing
+    # hasn't landed yet — reconciliation simply defers to the next cycle.
     fmp_by_key: dict[tuple[str, int, int], tuple[float, str, str]] = {}
     for _, row in earnings_df.iterrows():
         if pd.isna(row.get("epsActual")):
             continue
         announcement_date = str(row["date"])
+        eps = float(row["epsActual"])
+        retrieved_at = str(row.get("lastUpdated") or datetime.now(timezone.utc).isoformat())
+
+        # Emit primitive (always, when FMP has data and the date isn't published)
+        fmp_date_unix = date_string_to_unix(announcement_date)
+        if not _is_published(fmp_tn_block, fmp_stream, fmp_date_unix):
+            fmp_rows.append(
+                {
+                    "stream_id": fmp_stream,
+                    "date": fmp_date_unix,
+                    "value": str(eps),
+                    "data_provider": None,
+                }
+            )
+
+        # Populate canonical-key dict for reconciliation, only when income-
+        # statement lookup resolves. Missing income-statement is the rare
+        # race-at-announcement window; reconciliation retries next cycle.
         period_end = filing_to_period_end.get(announcement_date)
         if period_end is None:
-            # Income-statement hasn't been published yet for this earnings
-            # (rare edge case at the moment of announcement). Re-run later.
             logger.info(
                 f"{symbol} {announcement_date}: income-statement not yet "
-                f"published for this filing; skipping reconciliation cycle"
+                f"published for this filing; primitive emitted, "
+                f"reconciliation deferred to next cycle"
             )
             continue
-        key = canonical_key(symbol, period_end)
-        fmp_by_key[key] = (
-            float(row["epsActual"]),
-            announcement_date,
-            str(row.get("lastUpdated") or datetime.now(timezone.utc).isoformat()),
-        )
+        fmp_by_key[canonical_key(symbol, period_end)] = (eps, announcement_date, retrieved_at)
 
+    # Yahoo ingestion. Yahoo's `date` IS the fiscal-period-end (typically
+    # rounded to calendar-month-end), so no auxiliary lookup is needed —
+    # primitive emission and canonical-key population happen together.
     yahoo_by_key: dict[tuple[str, int, int], tuple[float, str]] = {}
     for _, row in yahoo_df.iterrows():
         raw = row.get("epsActual")
         if raw is None or pd.isna(raw):
             continue
         yahoo_date = str(row["date"])
-        # Yahoo's `date` IS the fiscal-period-end (typically rounded to
-        # calendar-month-end). Pass it directly to canonical_key.
-        key = canonical_key(symbol, yahoo_date)
-        yahoo_by_key[key] = (float(raw), yahoo_date)
+        eps = float(raw)
 
-    fmp_rows: list[dict] = []
-    yahoo_rows: list[dict] = []
-    truf_rows: list[dict] = []
+        # Emit primitive
+        yahoo_date_unix = date_string_to_unix(yahoo_date)
+        if not _is_published(yahoo_tn_block, yahoo_stream, yahoo_date_unix):
+            yahoo_rows.append(
+                {
+                    "stream_id": yahoo_stream,
+                    "date": yahoo_date_unix,
+                    "value": str(eps),
+                    "data_provider": None,
+                }
+            )
+        yahoo_by_key[canonical_key(symbol, yahoo_date)] = (eps, yahoo_date)
 
-    # Iterate over the union of canonical event keys so single-source quarters
-    # are still processed (they end up as `pending` from the reconciler).
+    # Reconciliation loop. Primitive writes were emitted above during
+    # ingestion; this loop only decides each event's consensus verdict.
+    # Iterate the union of canonical keys so single-source quarters are
+    # still surfaced (they resolve as `pending`).
     for key in sorted(set(fmp_by_key) | set(yahoo_by_key)):
         fmp_data = fmp_by_key.get(key)
         yahoo_data = yahoo_by_key.get(key)
@@ -192,7 +226,7 @@ def detect_and_prepare_eps(
         consensus_date_str = fmp_data[1] if fmp_data else yahoo_data[1]
         consensus_date_unix = date_string_to_unix(consensus_date_str)
 
-        # Skip entirely if consensus is already committed
+        # Skip if consensus is already committed
         if _is_published(truf_tn_block, consensus_stream, consensus_date_unix):
             continue
 
@@ -202,17 +236,7 @@ def detect_and_prepare_eps(
         yahoo_eps: float | None = None
 
         if fmp_data is not None:
-            fmp_eps, fmp_date_str, fmp_retrieved_at = fmp_data
-            fmp_date_unix = date_string_to_unix(fmp_date_str)
-            if not _is_published(fmp_tn_block, fmp_stream, fmp_date_unix):
-                fmp_rows.append(
-                    {
-                        "stream_id": fmp_stream,
-                        "date": fmp_date_unix,
-                        "value": str(fmp_eps),
-                        "data_provider": None,
-                    }
-                )
+            fmp_eps, _, fmp_retrieved_at = fmp_data
             readings.append(
                 SourceReading(
                     source="fmp",
@@ -222,17 +246,7 @@ def detect_and_prepare_eps(
             )
 
         if yahoo_data is not None:
-            yahoo_eps, yahoo_date_str = yahoo_data
-            yahoo_date_unix = date_string_to_unix(yahoo_date_str)
-            if not _is_published(yahoo_tn_block, yahoo_stream, yahoo_date_unix):
-                yahoo_rows.append(
-                    {
-                        "stream_id": yahoo_stream,
-                        "date": yahoo_date_unix,
-                        "value": str(yahoo_eps),
-                        "data_provider": None,
-                    }
-                )
+            yahoo_eps, _ = yahoo_data
             readings.append(
                 SourceReading(
                     source="yahoo",
@@ -241,7 +255,6 @@ def detect_and_prepare_eps(
                 )
             )
 
-        # --- Reconcile & write consensus ---
         result = reconcile(readings)
 
         if result.status == "settled":

--- a/src/tsn_adapters/tasks/eps/reconciler.py
+++ b/src/tsn_adapters/tasks/eps/reconciler.py
@@ -14,25 +14,53 @@ Caller ordering contract: pass readings sorted by source priority
 (primary source first, e.g. fmp → yahoo → edgar). The first reading in
 the largest agreeing group determines the committed value.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from typing import Literal, Optional
 
 TOLERANCE = 0.01  # sources must agree within $0.01 to settle
 
 
+def canonical_key(symbol: str, period_end_date_str: str) -> tuple[str, int, int]:
+    """Map a fiscal-period-end date to (symbol, calendar_year, calendar_quarter).
+
+    This is the canonical event identity for cross-source EPS reconciliation:
+    the key that two sources reporting on the same fiscal quarter will reduce
+    to even when their raw date strings differ.
+
+    Why this exists: FMP's /stable/earnings returns the announcement date as
+    its `date` field, while Yahoo's earnings_history returns the
+    fiscal-period-end. Joining on raw date strings treats the same event as
+    two separate entries. Both sources are describing the same fiscal
+    quarter — the canonical key reduces them to the same tuple.
+
+    Calendar-quarter keying avoids per-ticker fiscal-calendar lookups: it
+    works the same for NVDA's Jan-ending fiscal, AAPL's Sep-ending fiscal,
+    and the calendar-quarter reporters (META/GOOGL/AMZN/TSLA).
+
+    Correctness check across known Mag-7 earnings (the events #3936 cites):
+      NVDA Q1 FY27:  2026-04-26 → (NVDA, 2026, 2)  (Yahoo's 2026-04-30 → same)
+      AAPL Q2 FY26:  2026-03-28 → (AAPL, 2026, 1)  (Yahoo's 2026-03-31 → same)
+      META Q4 FY25:  2025-12-31 → (META, 2025, 4)  (Yahoo's 2025-12-31 → same)
+    """
+    d = date.fromisoformat(period_end_date_str)
+    return (symbol, d.year, (d.month - 1) // 3 + 1)
+
+
 @dataclass(frozen=True)
 class SourceReading:
-    source: str         # e.g. "fmp", "yahoo", "edgar"
+    source: str  # e.g. "fmp", "yahoo", "edgar"
     eps_actual: float
-    retrieved_at: str   # ISO datetime string
+    retrieved_at: str  # ISO datetime string
 
 
 @dataclass
 class ReconcileResult:
     status: Literal["settled", "disputed", "pending"]
-    value: Optional[float]       # exact figure; only set when settled
+    value: Optional[float]  # exact figure; only set when settled
     sources_agree: list[str]
     sources_disagree: list[str]
 

--- a/tests/eps/test_real_time_flow.py
+++ b/tests/eps/test_real_time_flow.py
@@ -1,0 +1,324 @@
+"""Tests for the EPS real-time reconciliation flow.
+
+Covers the canonical-key reconciliation introduced in
+trufnetwork/website#3936: FMP and Yahoo use different date semantics for
+the same earnings event (announcement date vs fiscal-period-end). The
+reconciler must derive a canonical event identity from each source so
+naïve dict-key joins on raw dates don't treat the same event as two
+separate single-source entries.
+"""
+
+import pandas as pd
+from pandera.typing import DataFrame
+from pydantic import PrivateAttr, SecretStr
+from tests.utils.constants import FAKE_PRIVATE_KEY
+from tests.utils.fake_tn_access import FakeTNAccessBlock
+
+from tsn_adapters.blocks.fmp import EarningsData, FMPBlock, QuarterlyIncomeStatementData
+from tsn_adapters.blocks.yahoo import YahooBlock
+from tsn_adapters.flows.eps.real_time_flow import detect_and_prepare_eps
+from tsn_adapters.utils.create_empty_df import create_empty_df
+from tsn_adapters.utils.time_utils import date_string_to_unix
+
+# --- DataFrame builders matching the schemas the blocks return ---
+
+
+def _earnings_df(rows: list[dict]) -> DataFrame[EarningsData]:
+    if not rows:
+        return create_empty_df(EarningsData)
+    return DataFrame[EarningsData](pd.DataFrame(rows))
+
+
+def _income_df(rows: list[dict]) -> DataFrame[QuarterlyIncomeStatementData]:
+    if not rows:
+        return create_empty_df(QuarterlyIncomeStatementData)
+    return DataFrame[QuarterlyIncomeStatementData](pd.DataFrame(rows))
+
+
+# --- Fake blocks (mirror the pattern in test_historical_flow.py) ---
+
+
+class RealTimeFakeFMPBlock(FMPBlock):
+    _earnings_data: dict = PrivateAttr(default_factory=dict)
+    _income_data: dict = PrivateAttr(default_factory=dict)
+
+    def get_historical_earnings(self, symbol: str, limit: int = 40) -> DataFrame[EarningsData]:
+        return _earnings_df(self._earnings_data.get(symbol, []))
+
+    def get_quarterly_income_statements(self, symbol: str, limit: int = 8) -> DataFrame[QuarterlyIncomeStatementData]:
+        return _income_df(self._income_data.get(symbol, []))
+
+
+class RealTimeFakeYahooBlock(YahooBlock):
+    _data: dict = PrivateAttr(default_factory=dict)
+
+    def get_historical_earnings(self, symbol: str, limit: int = 40) -> DataFrame[EarningsData]:
+        return _earnings_df(self._data.get(symbol, []))
+
+
+def _make_fmp(earnings: dict[str, list[dict]], income_statements: dict[str, list[dict]]) -> RealTimeFakeFMPBlock:
+    block = RealTimeFakeFMPBlock(api_key=SecretStr(FAKE_PRIVATE_KEY.get_secret_value()))
+    block._earnings_data = earnings
+    block._income_data = income_statements
+    return block
+
+
+def _make_yahoo(data: dict[str, list[dict]]) -> RealTimeFakeYahooBlock:
+    block = RealTimeFakeYahooBlock()
+    block._data = data
+    return block
+
+
+# --- Test fixtures — the events from issue #3936 ---
+
+# NVDA Q1 FY27 — Michael's primary example.
+# FMP date = announcement date (2026-05-20)
+# Yahoo date = fiscal-period-end (2026-04-30, calendar-month-end rounding)
+# Income-statement date = exact fiscal-period-end (2026-04-26)
+# Income-statement filingDate = matches FMP announcement date exactly
+NVDA_Q1_FY27_FMP_EARNINGS = {
+    "symbol": "NVDA",
+    "date": "2026-05-20",
+    "epsActual": 1.87,
+    "epsEstimated": 1.76,
+    "lastUpdated": None,
+}
+NVDA_Q1_FY27_YAHOO_EARNINGS = {
+    "symbol": "NVDA",
+    "date": "2026-04-30",
+    "epsActual": 1.87,
+    "epsEstimated": 1.76,
+    "lastUpdated": None,
+}
+NVDA_Q1_FY27_INCOME_STMT = {
+    "symbol": "NVDA",
+    "period": "Q1",
+    "fiscalYear": "2027",
+    "date": "2026-04-26",
+    "filingDate": "2026-05-20",
+    "acceptedDate": None,
+}
+
+
+# --- The bug from #3936: same event, mismatched source dates ---
+
+
+def test_reconciles_despite_source_date_mismatch():
+    """The exact bug condition from #3936.
+
+    FMP and Yahoo report the same NVDA Q1 FY27 event under different dates
+    (announcement vs period-end). Under the previous dict-key-union join,
+    these became two single-source entries and the consensus stream never
+    settled. Under canonical-key matching, both sources reduce to
+    (NVDA, 2026, 2) and reconcile correctly.
+    """
+    fmp = _make_fmp(
+        earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
+        income_statements={"NVDA": [NVDA_Q1_FY27_INCOME_STMT]},
+    )
+    yahoo = _make_yahoo({"NVDA": [NVDA_Q1_FY27_YAHOO_EARNINGS]})
+    fmp_tn = FakeTNAccessBlock()
+    yahoo_tn = FakeTNAccessBlock()
+    truf_tn = FakeTNAccessBlock()
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=fmp_tn,
+        yahoo_tn_block=yahoo_tn,
+        truf_tn_block=truf_tn,
+        symbol="NVDA",
+    )
+
+    # Each primitive stream gets its own row, keyed by its own source date
+    assert len(fmp_rows) == 1
+    assert fmp_rows[0]["value"] == "1.87"
+    assert fmp_rows[0]["date"] == date_string_to_unix("2026-05-20")
+
+    assert len(yahoo_rows) == 1
+    assert yahoo_rows[0]["value"] == "1.87"
+    assert yahoo_rows[0]["date"] == date_string_to_unix("2026-04-30")
+
+    # And — the fix — the consensus stream gets the settled row.
+    # Consensus uses FMP's announcement date (preserves the "consensus at
+    # announcement time" semantic that downstream markets rely on).
+    assert len(truf_rows) == 1
+    assert truf_rows[0]["value"] == "1.87"
+    assert truf_rows[0]["date"] == date_string_to_unix("2026-05-20")
+
+
+def test_aapl_fiscal_quarter_mismatch_resolves():
+    """AAPL Q2 FY26 (a non-calendar fiscal): FMP announces in April (calendar
+    Q2), Yahoo period-end is March 31 (calendar Q1). Income-statement period-
+    end is March 28 (calendar Q1). Both FMP and Yahoo reduce to (AAPL, 2026, 1)
+    via canonical-key — proves the fix handles non-calendar fiscals too.
+    """
+    aapl_fmp = {"symbol": "AAPL", "date": "2026-04-30", "epsActual": 2.01, "epsEstimated": 1.99, "lastUpdated": None}
+    aapl_yahoo = {"symbol": "AAPL", "date": "2026-03-31", "epsActual": 2.01, "epsEstimated": 1.99, "lastUpdated": None}
+    aapl_income = {
+        "symbol": "AAPL",
+        "period": "Q2",
+        "fiscalYear": "2026",
+        "date": "2026-03-28",
+        "filingDate": "2026-04-30",
+        "acceptedDate": None,
+    }
+
+    fmp = _make_fmp(earnings={"AAPL": [aapl_fmp]}, income_statements={"AAPL": [aapl_income]})
+    yahoo = _make_yahoo({"AAPL": [aapl_yahoo]})
+
+    _, _, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=FakeTNAccessBlock(),
+        yahoo_tn_block=FakeTNAccessBlock(),
+        truf_tn_block=FakeTNAccessBlock(),
+        symbol="AAPL",
+    )
+
+    assert len(truf_rows) == 1
+    assert truf_rows[0]["value"] == "2.01"
+
+
+# --- Disagreement / pending paths ---
+
+
+def test_disputed_when_same_event_different_values():
+    """FMP and Yahoo reduce to the same canonical key but disagree on the
+    EPS value (beyond $0.01 tolerance). Consensus is NOT written; primitive
+    streams still get their per-source rows."""
+    fmp_row = dict(NVDA_Q1_FY27_FMP_EARNINGS, epsActual=1.87)
+    yahoo_row = dict(NVDA_Q1_FY27_YAHOO_EARNINGS, epsActual=1.50)  # 0.37 mismatch
+
+    fmp = _make_fmp(
+        earnings={"NVDA": [fmp_row]},
+        income_statements={"NVDA": [NVDA_Q1_FY27_INCOME_STMT]},
+    )
+    yahoo = _make_yahoo({"NVDA": [yahoo_row]})
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=FakeTNAccessBlock(),
+        yahoo_tn_block=FakeTNAccessBlock(),
+        truf_tn_block=FakeTNAccessBlock(),
+        symbol="NVDA",
+    )
+
+    # Each primitive is written with its raw source value
+    assert len(fmp_rows) == 1
+    assert fmp_rows[0]["value"] == "1.87"
+    assert len(yahoo_rows) == 1
+    assert yahoo_rows[0]["value"] == "1.5"
+
+    # Consensus deliberately NOT written — disputed
+    assert len(truf_rows) == 0
+
+
+def test_pending_when_only_fmp_has_event():
+    """Only FMP has data for this event. Result: pending (no consensus)."""
+    fmp = _make_fmp(
+        earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
+        income_statements={"NVDA": [NVDA_Q1_FY27_INCOME_STMT]},
+    )
+    yahoo = _make_yahoo({"NVDA": []})
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=FakeTNAccessBlock(),
+        yahoo_tn_block=FakeTNAccessBlock(),
+        truf_tn_block=FakeTNAccessBlock(),
+        symbol="NVDA",
+    )
+
+    assert len(fmp_rows) == 1
+    assert len(yahoo_rows) == 0
+    assert len(truf_rows) == 0
+
+
+def test_pending_when_only_yahoo_has_event():
+    """Only Yahoo has data for this event. Result: pending (no consensus)."""
+    fmp = _make_fmp(earnings={"NVDA": []}, income_statements={"NVDA": []})
+    yahoo = _make_yahoo({"NVDA": [NVDA_Q1_FY27_YAHOO_EARNINGS]})
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=FakeTNAccessBlock(),
+        yahoo_tn_block=FakeTNAccessBlock(),
+        truf_tn_block=FakeTNAccessBlock(),
+        symbol="NVDA",
+    )
+
+    assert len(fmp_rows) == 0
+    assert len(yahoo_rows) == 1
+    assert len(truf_rows) == 0
+
+
+# --- Edge cases ---
+
+
+def test_skips_fmp_event_when_income_statement_not_yet_published():
+    """Rare race at the moment of an earnings announcement: FMP /stable/earnings
+    has the new actual but /stable/income-statement hasn't yet been populated
+    for that filing. The FMP entry is skipped (we can't derive canonical key
+    without a period-end). Yahoo still writes its primitive. Consensus
+    pending — will resolve on the next cycle once income-statement catches up.
+    """
+    fmp = _make_fmp(
+        earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
+        income_statements={"NVDA": []},  # income-statement hasn't published
+    )
+    yahoo = _make_yahoo({"NVDA": [NVDA_Q1_FY27_YAHOO_EARNINGS]})
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=FakeTNAccessBlock(),
+        yahoo_tn_block=FakeTNAccessBlock(),
+        truf_tn_block=FakeTNAccessBlock(),
+        symbol="NVDA",
+    )
+
+    # FMP earnings entry is silently skipped — no canonical key derivable
+    assert len(fmp_rows) == 0
+    # Yahoo still publishes its primitive
+    assert len(yahoo_rows) == 1
+    # No consensus possible with single source
+    assert len(truf_rows) == 0
+
+
+def test_idempotent_skips_already_published_consensus():
+    """If consensus is already on-chain for this canonical event, the whole
+    iteration is skipped — no primitive rows, no consensus row. Mirrors the
+    existing _is_published guard."""
+    fmp = _make_fmp(
+        earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
+        income_statements={"NVDA": [NVDA_Q1_FY27_INCOME_STMT]},
+    )
+    yahoo = _make_yahoo({"NVDA": [NVDA_Q1_FY27_YAHOO_EARNINGS]})
+
+    truf_tn = FakeTNAccessBlock()
+    # Seed the consensus stream with the date we're about to compute —
+    # FMP announcement date 2026-05-20 → unix
+    from tsn_adapters.tasks.eps.config import EPS_STREAM_IDS
+
+    truf_tn.seed_records(
+        EPS_STREAM_IDS["NVDA"],
+        [date_string_to_unix("2026-05-20")],
+    )
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=FakeTNAccessBlock(),
+        yahoo_tn_block=FakeTNAccessBlock(),
+        truf_tn_block=truf_tn,
+        symbol="NVDA",
+    )
+
+    # Existing _is_published guard short-circuits the whole iteration
+    assert len(fmp_rows) == 0
+    assert len(yahoo_rows) == 0
+    assert len(truf_rows) == 0

--- a/tests/eps/test_real_time_flow.py
+++ b/tests/eps/test_real_time_flow.py
@@ -262,9 +262,10 @@ def test_pending_when_only_yahoo_has_event():
 def test_skips_fmp_event_when_income_statement_not_yet_published():
     """Rare race at the moment of an earnings announcement: FMP /stable/earnings
     has the new actual but /stable/income-statement hasn't yet been populated
-    for that filing. The FMP entry is skipped (we can't derive canonical key
-    without a period-end). Yahoo still writes its primitive. Consensus
-    pending — will resolve on the next cycle once income-statement catches up.
+    for that filing. The raw FMP primitive still emits under the announcement
+    date — the income-statement is only needed to derive the canonical key
+    for reconciliation. Yahoo still writes its primitive. Consensus is
+    pending and resolves on the next cycle once income-statement catches up.
     """
     fmp = _make_fmp(
         earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
@@ -281,18 +282,25 @@ def test_skips_fmp_event_when_income_statement_not_yet_published():
         symbol="NVDA",
     )
 
-    # FMP earnings entry is silently skipped — no canonical key derivable
-    assert len(fmp_rows) == 0
+    # FMP primitive still emits under the announcement date — primitive
+    # emission is decoupled from reconciliation
+    assert len(fmp_rows) == 1
+    assert fmp_rows[0]["value"] == "1.87"
+    assert fmp_rows[0]["date"] == date_string_to_unix("2026-05-20")
     # Yahoo still publishes its primitive
     assert len(yahoo_rows) == 1
-    # No consensus possible with single source
+    # No consensus possible — FMP entry isn't in the canonical-key dict
+    # without a period-end lookup, so reconciliation defers to next cycle
     assert len(truf_rows) == 0
 
 
 def test_idempotent_skips_already_published_consensus():
-    """If consensus is already on-chain for this canonical event, the whole
-    iteration is skipped — no primitive rows, no consensus row. Mirrors the
-    existing _is_published guard."""
+    """Per-stream idempotency: when only consensus is already on-chain
+    but the primitive streams are not, the primitives still emit. The
+    _is_published guard is independent per stream — consensus state
+    doesn't gate primitive emission. This is the property required by
+    CodeRabbit's review on #229.
+    """
     fmp = _make_fmp(
         earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
         income_statements={"NVDA": [NVDA_Q1_FY27_INCOME_STMT]},
@@ -300,8 +308,7 @@ def test_idempotent_skips_already_published_consensus():
     yahoo = _make_yahoo({"NVDA": [NVDA_Q1_FY27_YAHOO_EARNINGS]})
 
     truf_tn = FakeTNAccessBlock()
-    # Seed the consensus stream with the date we're about to compute —
-    # FMP announcement date 2026-05-20 → unix
+    # Seed ONLY the consensus stream with the FMP announcement date
     from tsn_adapters.tasks.eps.config import EPS_STREAM_IDS
 
     truf_tn.seed_records(
@@ -318,7 +325,47 @@ def test_idempotent_skips_already_published_consensus():
         symbol="NVDA",
     )
 
-    # Existing _is_published guard short-circuits the whole iteration
+    # Primitive streams aren't seeded → they emit
+    assert len(fmp_rows) == 1
+    assert len(yahoo_rows) == 1
+    # Consensus stream is seeded → it's skipped
+    assert len(truf_rows) == 0
+
+
+def test_idempotent_when_all_streams_already_published():
+    """Full idempotency: when every stream's date is already on-chain,
+    a re-run produces no writes anywhere. Mirrors the steady-state
+    behaviour of the scheduled flow re-encountering the same recent
+    earnings rows on subsequent ticks.
+    """
+    from tsn_adapters.tasks.eps.config import (
+        EPS_STREAM_IDS,
+        FMP_EPS_STREAM_IDS,
+        YAHOO_EPS_STREAM_IDS,
+    )
+
+    fmp = _make_fmp(
+        earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
+        income_statements={"NVDA": [NVDA_Q1_FY27_INCOME_STMT]},
+    )
+    yahoo = _make_yahoo({"NVDA": [NVDA_Q1_FY27_YAHOO_EARNINGS]})
+
+    fmp_tn = FakeTNAccessBlock()
+    yahoo_tn = FakeTNAccessBlock()
+    truf_tn = FakeTNAccessBlock()
+    fmp_tn.seed_records(FMP_EPS_STREAM_IDS["NVDA"], [date_string_to_unix("2026-05-20")])
+    yahoo_tn.seed_records(YAHOO_EPS_STREAM_IDS["NVDA"], [date_string_to_unix("2026-04-30")])
+    truf_tn.seed_records(EPS_STREAM_IDS["NVDA"], [date_string_to_unix("2026-05-20")])
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=fmp_tn,
+        yahoo_tn_block=yahoo_tn,
+        truf_tn_block=truf_tn,
+        symbol="NVDA",
+    )
+
     assert len(fmp_rows) == 0
     assert len(yahoo_rows) == 0
     assert len(truf_rows) == 0

--- a/tests/eps/test_reconciler.py
+++ b/tests/eps/test_reconciler.py
@@ -1,8 +1,6 @@
 """Tests for the EPS multi-source reconciler."""
 
-import pytest
-
-from tsn_adapters.tasks.eps.reconciler import SourceReading, reconcile
+from tsn_adapters.tasks.eps.reconciler import SourceReading, canonical_key, reconcile
 
 NOW = "2025-01-01T00:00:00+00:00"
 
@@ -77,3 +75,61 @@ def test_chained_three_way_disputed():
     # All pairs diverge beyond tolerance — no group of ≥2 can settle.
     result = reconcile([reading("fmp", 1.00), reading("yahoo", 1.02), reading("edgar", 1.04)])
     assert result.status == "disputed"
+
+
+# --- canonical_key tests (added with the trufnetwork/website#3936 fix) ---
+
+
+def test_canonical_key_nvda_q1_fy27():
+    """NVDA's fiscal Q1 FY27 ends April 26, 2026 — falls in calendar Q2 2026."""
+    assert canonical_key("NVDA", "2026-04-26") == ("NVDA", 2026, 2)
+
+
+def test_canonical_key_aapl_q2_fy26():
+    """AAPL's fiscal Q2 FY26 ends March 28, 2026 — falls in calendar Q1 2026."""
+    assert canonical_key("AAPL", "2026-03-28") == ("AAPL", 2026, 1)
+
+
+def test_canonical_key_meta_q4_fy25():
+    """META's Q4 FY25 ends December 31, 2025 — calendar Q4 2025."""
+    assert canonical_key("META", "2025-12-31") == ("META", 2025, 4)
+
+
+def test_canonical_key_collapses_yahoo_rounding():
+    """FMP's exact fiscal-period-end and Yahoo's calendar-month-end rounded
+    version both fall in the same calendar quarter — so they reduce to the
+    same canonical key. This is the property that makes the reconciler join
+    actually work after the #3936 fix.
+    """
+    fmp_key = canonical_key("NVDA", "2026-04-26")  # FMP's actual period-end
+    yahoo_key = canonical_key("NVDA", "2026-04-30")  # Yahoo's month-end rounding
+    assert fmp_key == yahoo_key == ("NVDA", 2026, 2)
+
+
+def test_canonical_key_month_to_quarter_mapping():
+    """Verify the (month - 1) // 3 + 1 formula across every month."""
+    expectations = [
+        (1, 1),
+        (2, 1),
+        (3, 1),  # Q1
+        (4, 2),
+        (5, 2),
+        (6, 2),  # Q2
+        (7, 3),
+        (8, 3),
+        (9, 3),  # Q3
+        (10, 4),
+        (11, 4),
+        (12, 4),  # Q4
+    ]
+    for month, expected_q in expectations:
+        date_str = f"2026-{month:02d}-15"
+        sym, year, q = canonical_key("TEST", date_str)
+        assert sym == "TEST"
+        assert year == 2026
+        assert q == expected_q, f"month {month} should map to Q{expected_q}, got Q{q}"
+
+
+def test_canonical_key_distinguishes_symbols():
+    """Same period-end, different symbols — different canonical keys."""
+    assert canonical_key("NVDA", "2026-04-26") != canonical_key("AAPL", "2026-04-26")


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3936

## Summary

The EPS consensus reconciler never settled because FMP and Yahoo use different date semantics for the same earnings event:

- **FMP** `/stable/earnings` returns the **announcement date** (e.g. NVDA Q1 FY27 → `2026-05-20`)
- **Yahoo** `earnings_history` returns the **fiscal-period-end** (e.g. same event → `2026-04-30`)

The previous reconciler joined the two sources on raw date string. Same fiscal quarter, different keys, two distinct single-source entries, no 2-of-3 quorum, no consensus written. This is the bug filed in trufnetwork/website#3936.

This PR makes both sources reduce to a **canonical key** before joining: `(symbol, calendar_year_of_period_end, calendar_quarter_of_period_end)`. For FMP, the period-end is looked up via `/stable/income-statement?period=quarter` (whose `filingDate` matches the earnings `date` exactly). For Yahoo, the row already carries the period-end. Both sources collapse to the same tuple for the same fiscal quarter, and the consensus stream settles.

## Why canonical-key (vs proximity-matching)

I considered two solutions:

- **A — Proximity matching.** Join Yahoo and FMP rows if their dates fall within ±N days. Quick to write, but introduces a fuzzy window that needs hand-tuning per ticker (Mag-7 cadence ranges from ~70 days TSLA-tightest to ~90 days typical) and creates ambiguity when announcements cluster.
- **B — Canonical key (this PR).** Map both sources to `(symbol, calendar_year, calendar_quarter)` deterministically. No magic numbers, no ambiguity, generalises cleanly to a third source (EDGAR / Finnhub) by just calling `canonical_key()` on its row.

Going with B because it removes the date-arithmetic guesswork entirely and the implementation is shorter. Calendar-quarter keying also avoids per-ticker fiscal-calendar lookups — NVDA's Q1 FY27 ends in calendar Q2 2026 and that's fine; we key on the calendar quarter the period-end falls into, not the fiscal label.

## What changed

| File | Change |
|------|--------|
| `src/tsn_adapters/blocks/fmp.py` | New `QuarterlyIncomeStatementData` schema and `get_quarterly_income_statements()` method on `FMPBlock` — the filingDate → period-end lookup |
| `src/tsn_adapters/tasks/eps/reconciler.py` | New `canonical_key()` helper alongside the existing `reconcile()` function |
| `src/tsn_adapters/flows/eps/real_time_flow.py` | `detect_and_prepare_eps` builds per-source dicts keyed by `canonical_key` and iterates the union of their keys |
| `tests/eps/test_reconciler.py` | +6 unit tests for `canonical_key` including the Yahoo-rounding-collapse case |
| `tests/eps/test_real_time_flow.py` | New file — 7 flow-level tests including the exact #3936 bug scenario |

## On-chain semantics are unchanged

The canonical key is **internal join logic only**. On-chain stream dates stay the same:

- `fmp_eps_<sym>_<conv>` — written under FMP's announcement date (unchanged)
- `yahoo_eps_<sym>_<conv>` — written under Yahoo's period-end date (unchanged)
- `truf_eps_<sym>_<conv>` — written under FMP's announcement date, so "consensus appears at announcement time" still holds (unchanged)

## Test plan

This repo has no GitHub Actions, so test runs are manual. The full EPS suite (existing + new) on this branch:

```bash
uv sync
pytest tests/eps/ -v
```

Last local run:

```
============================= 39 passed, 1 warning in 9.80s =============================
```

The single warning is a pre-existing pandera `FutureWarning` unrelated to this PR.

### Bug-scenario coverage

The bug condition from #3936 is reproduced and fixed in `tests/eps/test_real_time_flow.py::test_reconciles_despite_source_date_mismatch`. The fixture:

- FMP earnings row: `date=2026-05-20`, `epsActual=1.87` (announcement)
- Yahoo earnings row: `date=2026-04-30`, `epsActual=1.87` (period-end)
- FMP income-statement row: `filingDate=2026-05-20`, `date=2026-04-26`

Both sources reduce to `("NVDA", 2026, 2)` and the consensus stream settles at `1.87` with both `fmp` and `yahoo` in the agreeing set.

### Edge cases verified

- `test_aapl_fiscal_quarter_mismatch_resolves` — non-calendar-fiscal ticker (AAPL's Sep-ending fiscal still keys correctly)
- `test_disputed_when_same_event_different_values` — values differ beyond ±$0.01 → DISPUTED (not falsely settled)
- `test_pending_when_only_fmp_has_event` / `test_pending_when_only_yahoo_has_event` — single-source quarters stay PENDING
- `test_skips_fmp_event_when_income_statement_not_yet_published` — race window where FMP earnings has fired but income-statement hasn't yet (skipped this cycle, retried next run)
- `test_idempotent_skips_already_published_consensus` — re-running the flow doesn't double-write

### canonical_key unit coverage

In `tests/eps/test_reconciler.py`:

- `test_canonical_key_nvda_q1_fy27` / `test_canonical_key_aapl_q2_fy26` / `test_canonical_key_meta_q4_fy25` — known Mag-7 events keyed correctly
- `test_canonical_key_collapses_yahoo_rounding` — FMP's exact period-end (`2026-04-26`) and Yahoo's rounded version (`2026-04-30`) reduce to the same key
- `test_canonical_key_month_to_quarter_mapping` — formula sweep across all 12 months
- `test_canonical_key_distinguishes_symbols` — same date, different symbols → different keys

## Out of scope

- Wiring a third settlement source (EDGAR or Finnhub). The architecture is source-agnostic (`reconcile()` already accepts any number of `SourceReading`s), but actually adding a third source is a separate PR.
- Pre-existing lint warnings in `reconciler.py` (`Optional[float]` could be `float | None`) and one long line in `fmp.py` — untouched to keep this PR minimally scoped to the bug.

## References

Refs: [trufnetwork/website#3936](https://github.com/truflation/website/issues/3936#issuecomment-4533343490)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added quarterly income statement data fetching from Financial Modeling Prep (FMP)

* **Improvements**
  * Updated EPS reconciliation to use fiscal period end dates for source matching between data providers
  * Enhanced handling of fiscal quarters that don't align with calendar quarters

* **Tests**
  * Added comprehensive test suite for EPS real-time reconciliation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->