### PR TITLE
chore: decouple aggregation from preprocess scheduling

### DIFF
--- a/src/tsn_adapters/tasks/argentina/flows/aggregate_products_flow.py
+++ b/src/tsn_adapters/tasks/argentina/flows/aggregate_products_flow.py
@@ -61,24 +61,19 @@ async def aggregate_argentina_products_flow(
             product_averages_provider=product_averages_provider,
             force_reprocess=force_reprocess,
         )
-        # Unpack the results from the task
-        dates_to_process, last_agg_date_used, last_prep_date_used = task_result
+        dates_to_process, last_agg_date_used = task_result
 
-        # Check if any dates remain after filtering by the task
         if not dates_to_process:
-            # Use the context dates returned by the task
             logger.info(
-                f"Task determine_aggregation_dates returned no new dates to process between {last_agg_date_used} ({ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE}) and {last_prep_date_used} ({ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE}). Flow finished early."
+                f"Task determine_aggregation_dates returned no new dates to process after {last_agg_date_used} ({ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE}). Flow finished early."
             )
-            # Create artifact even if no dates processed
             create_markdown_artifact(
                 key="argentina-product-aggregation-summary",
-                markdown=f"# Argentina Product Aggregation Summary\\n\\nNo new dates found to process between {last_agg_date_used} ({ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE}) and {last_prep_date_used} ({ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE}).",
+                markdown=f"# Argentina Product Aggregation Summary\\n\\nNo new dates found to process after {last_agg_date_used} ({ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE}).",
                 description="Summary of the Argentina SEPA product aggregation flow run.",
             )
             return
 
-        # Log the result from the task
         logger.info(
             f"Task determine_aggregation_dates determined {len(dates_to_process)} dates to process: {dates_to_process[0]} to {dates_to_process[-1]}"
         )

--- a/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
+++ b/src/tsn_adapters/tasks/argentina/tasks/aggregate_products_tasks.py
@@ -47,24 +47,21 @@ def _is_client_error_not_found(e: ClientError) -> bool:
 def determine_aggregation_dates(
     product_averages_provider: ProductAveragesProvider,
     force_reprocess: bool = False,
-) -> tuple[list[DateStr], str, str]:
+) -> tuple[list[DateStr], str]:
     """
     Determines the range of dates to aggregate based on available data and gating variables.
 
-    Uses the provider to list available dates and filters them based on:
-    - LAST_PREPROCESS_SUCCESS_DATE (Process only dates <= this variable)
-    - LAST_AGGREGATION_SUCCESS_DATE (Process only dates > this variable)
-    - force_reprocess flag (If True, ignore LAST_AGGREGATION_SUCCESS_DATE but still respect LAST_PREPROCESS_SUCCESS_DATE)
+    Processes all available dates in S3 that are after LAST_AGGREGATION_SUCCESS_DATE.
+    No preprocess gate — S3 data may be uploaded by external parties.
 
     Args:
         product_averages_provider: Provider instance to access product average data keys.
-        force_reprocess: If True, ignore the last aggregation date but still respect the last preprocess date.
+        force_reprocess: If True, ignore the last aggregation date and reprocess all available data.
 
     Returns:
         Tuple containing:
             - Sorted list of date strings (YYYY-MM-DD) to process.
             - The last aggregation success date used for filtering.
-            - The last preprocess success date used for filtering.
 
     Raises:
         Exception: Propagated from provider's list_available_keys or variable access.
@@ -72,22 +69,13 @@ def determine_aggregation_dates(
     logger = get_logger_safe(__name__)
     logger.info(f"Determining date range to process... Force reprocess: {force_reprocess}")
 
-    # 2. Fetch Gating Variables (Fetch PREPROCESS always, AGGREGATION conditionally)
     try:
-        last_preprocess_success_date = variables.Variable.get(
-            ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE, default=ArgentinaFlowVariableNames.DEFAULT_DATE
-        )
-        assert isinstance(last_preprocess_success_date, str)
-        logger.info(f"Using {ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE}: {last_preprocess_success_date}")
-
         if force_reprocess:
-            # If forcing, ignore the actual last aggregation date, start from default
             last_aggregation_success_date = ArgentinaFlowVariableNames.DEFAULT_DATE
             logger.warning(
                 f"force_reprocess=True. Using default start date {last_aggregation_success_date} instead of actual last aggregation date."
             )
         else:
-            # If not forcing, use the actual last aggregation date
             last_aggregation_success_date = variables.Variable.get(
                 ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE,
                 default=ArgentinaFlowVariableNames.DEFAULT_DATE,
@@ -98,53 +86,31 @@ def determine_aggregation_dates(
             )
     except Exception as e:
         logger.error(f"Failed to retrieve gating Prefect variables: {e}", exc_info=True)
-        raise  # Cannot proceed without gating info
+        raise
 
-    # 1. Fetch available dates
     try:
         available_dates_str = product_averages_provider.list_available_keys()
         logger.debug(f"Found {len(available_dates_str)} available dates in S3 provider.")
         if not available_dates_str:
             logger.info("No available dates found in provider.")
-            # Need to fetch variables anyway to return context
-            return [], str(last_aggregation_success_date), str(last_preprocess_success_date)
-        available_dates_str.sort()  # Ensure chronological order
+            return [], str(last_aggregation_success_date)
+        available_dates_str.sort()
     except Exception as e:
         logger.error(f"Error listing available keys from provider: {e}", exc_info=True)
         raise
 
-    # 3. Filter Dates based on Gating Variables and Preprocess Limit
     dates_to_process = [
         date_str
         for date_str in available_dates_str
-        # Always respect the preprocess limit
-        if date_str <= last_preprocess_success_date
-        # Use the determined aggregation start date (actual or default)
-        and date_str > last_aggregation_success_date
+        if date_str > last_aggregation_success_date
     ]
 
-    # 4. Log Skipped Dates Information (using the *actual* variables fetched or used)
-    skipped_preprocess = sum(1 for d in available_dates_str if d > last_preprocess_success_date)
-    skipped_aggregation = sum(
-        1
-        for d in available_dates_str
-        # Count dates before or equal to the aggregation date *used* for filtering
-        if d <= last_aggregation_success_date
-        # And also ensure they are within the preprocess limit we considered
-        and d <= last_preprocess_success_date
-    )
-
-    if skipped_preprocess > 0:
-        logger.info(
-            f"Skipped {skipped_preprocess} dates later than {last_preprocess_success_date} ({ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE})."
-        )
-    # Use the value of last_aggregation_success_date determined in step 2 for logging
+    skipped_aggregation = sum(1 for d in available_dates_str if d <= last_aggregation_success_date)
     if skipped_aggregation > 0:
         logger.info(
             f"Skipped {skipped_aggregation} dates up to and including {last_aggregation_success_date} (based on {ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE} or default if forced)."
         )
 
-    # 5. Log Final Result and Return with Context
     if dates_to_process:
         logger.info(
             f"Determined {len(dates_to_process)} dates to process after gating: "
@@ -153,8 +119,7 @@ def determine_aggregation_dates(
     else:
         logger.info("No new dates to process after applying gating logic.")
 
-    # Return the list and the context dates used
-    return dates_to_process, last_aggregation_success_date, last_preprocess_success_date
+    return dates_to_process, last_aggregation_success_date
 
 
 # --- Single Date Processing Helpers ---

--- a/tests/argentina/flows/test_aggregate_products_flow.py
+++ b/tests/argentina/flows/test_aggregate_products_flow.py
@@ -3,7 +3,6 @@ Integration tests for the Argentina SEPA Product Aggregation Flow.
 """
 
 import io
-from typing import Any
 from unittest.mock import (
     AsyncMock,
     MagicMock,
@@ -194,7 +193,7 @@ async def test_aggregate_flow_with_state_and_artifacts_simplified_mock(
     with (
         patch(
             "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.determine_aggregation_dates",
-            return_value=(dates_to_process, "1970-01-01", "1970-01-01"),
+            return_value=(dates_to_process, "1970-01-01"),
         ) as mock_date_range_task,
         patch(
             "tsn_adapters.tasks.argentina.flows.aggregate_products_flow.ProductAveragesProvider",
@@ -293,7 +292,7 @@ async def test_aggregate_flow_no_dates_to_process_with_artifact(
         ) as mock_create_artifact,
     ):
         # mock_load_state.return_value = (empty_aggregated_df, default_metadata)
-        mock_determine_range.return_value = ([], "1970-01-01", "1970-01-01")  # Return empty list in 3-tuple format
+        mock_determine_range.return_value = ([], "1970-01-01")
 
         # --- Flow Execution ---
         await aggregate_argentina_products_flow(
@@ -344,17 +343,7 @@ async def test_aggregate_flow_end_to_end_cold_start(
 
     # Mock Prefect Variables needed by determine_aggregation_dates
     with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_variable_get:
-        
-        def get_variable_side_effect(name: str, default: Any = None) -> str:
-            if name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                # Set a date that allows our test dates (2024-03-10 to 12) to be processed
-                return "2024-03-12" 
-            elif name == ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE:
-                # For cold start, use the default (no previous aggregation)
-                return ArgentinaFlowVariableNames.DEFAULT_DATE
-            return default # Should not happen for these vars, but good practice
-            
-        mock_variable_get.side_effect = get_variable_side_effect
+        mock_variable_get.return_value = ArgentinaFlowVariableNames.DEFAULT_DATE
 
         # Act: Run the flow (first time)
         await aggregate_argentina_products_flow(
@@ -429,15 +418,7 @@ async def test_aggregate_flow_end_to_end_resume(
 
     # Mock Prefect Variables for gating (assuming resume after 2024-03-10)
     with patch("prefect.variables.Variable.get") as mock_variable_get:
-        # Configure side effect for different variable names
-        def get_side_effect(name: str, default: Any = None) -> Any:
-            if name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2024-03-12"  # Allow processing up to 12th
-            if name == ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE:
-                return "2024-03-10"  # Resume after 10th
-            return default
-
-        mock_variable_get.side_effect = get_side_effect
+        mock_variable_get.return_value = "2024-03-10"
 
         # Act: Run the flow (should resume from 2024-03-11)
         await aggregate_argentina_products_flow(
@@ -501,22 +482,12 @@ async def test_aggregate_flow_end_to_end_force_reprocess(
     upload_sample_data(s3_bucket_block, DateStr("2024-03-11"), daily_data_2024_03_11)
     upload_sample_data(s3_bucket_block, DateStr("2024-03-12"), daily_data_2024_03_12)
 
-    # Mock Prefect Variables for gating (force_reprocess=True means LAST_AGGREGATION not fetched)
-    with patch("prefect.variables.Variable.get") as mock_variable_get:
-        # Only need to mock PREPROCESS date
-        def get_side_effect(name: str, default: Any = None) -> str | None:
-            if name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2024-03-12"  # Allow processing up to 12th
-            return default
-
-        mock_variable_get.side_effect = get_side_effect
-
-        # Act: Run the flow with force_reprocess=True
-        await aggregate_argentina_products_flow(
-            s3_block=s3_bucket_block,
-            descriptor_block=mock_descriptor_block,
-            force_reprocess=True,
-        )
+    # force_reprocess=True means LAST_AGGREGATION not fetched — no variable mock needed
+    await aggregate_argentina_products_flow(
+        s3_block=s3_bucket_block,
+        descriptor_block=mock_descriptor_block,
+        force_reprocess=True,
+    )
 
     # --- Verify Final State (Verify MOCK upsert calls) ---
     # Expected state is the same as cold start, should process 10, 11, 12

--- a/tests/argentina/tasks/test_aggregate_products_tasks.py
+++ b/tests/argentina/tasks/test_aggregate_products_tasks.py
@@ -218,34 +218,19 @@ def test_determine_dates_no_prior_state(mock_provider: MagicMock):
     available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11"), DateStr("2024-03-12")]
     mock_provider.list_available_keys.return_value = available_dates
     force_reprocess = False
-    
-    # Mock Prefect variables to simulate:
-    # - Preprocess date: far future (to include all dates)
-    # - Aggregation date: default 1970-01-01 (to process all dates after it)
+
     with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_var_get:
-        def _mock_get(var_name: str, default: Any) -> str:
-            if var_name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2099-12-31"
-            elif var_name == ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE:
-                return "1970-01-01"
-            return default
-        mock_var_get.side_effect = _mock_get
-        
+        mock_var_get.return_value = "1970-01-01"
+
         # Act
-        result, _, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
-    
+        result, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
+
         # Assert
         assert result == available_dates
-        # Use assert_called_once for synchronous mock
         mock_provider.list_available_keys.assert_called_once()
-        
-        # Verify variable calls
-        mock_var_get.assert_any_call(
-            ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE, 
-            default=ArgentinaFlowVariableNames.DEFAULT_DATE
-        )
-        mock_var_get.assert_any_call(
-            ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE, 
+
+        mock_var_get.assert_called_once_with(
+            ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE,
             default=ArgentinaFlowVariableNames.DEFAULT_DATE
         )
 
@@ -256,21 +241,13 @@ def test_determine_dates_force_reprocess(mock_provider: MagicMock):
     available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11"), DateStr("2024-03-12")]
     mock_provider.list_available_keys.return_value = available_dates
     force_reprocess = True
-    
-    # Mock Prefect variables
-    with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_var_get:
-        def _mock_get(var_name: str, default: Any) -> str:
-            if var_name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2024-03-15"
-            return default
-        mock_var_get.side_effect = _mock_get
-        
-        # Act
-        result, _, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
-    
-        # Assert
-        assert result == available_dates
-        mock_provider.list_available_keys.assert_called_once()
+
+    # Act — force_reprocess bypasses Variable.get entirely
+    result, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
+
+    # Assert
+    assert result == available_dates
+    mock_provider.list_available_keys.assert_called_once()
 
 
 def test_determine_dates_prior_state_exists(mock_provider: MagicMock):
@@ -280,20 +257,13 @@ def test_determine_dates_prior_state_exists(mock_provider: MagicMock):
     mock_provider.list_available_keys.return_value = available_dates
     force_reprocess = False
     expected_dates = [DateStr("2024-03-12"), DateStr("2024-03-13")]
-    
-    # Mock Prefect variables
+
     with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_var_get:
-        def _mock_get(var_name: str, default: Any) -> str:
-            if var_name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2024-03-15"
-            elif var_name == ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE:
-                return "2024-03-11"
-            return default
-        mock_var_get.side_effect = _mock_get
-        
+        mock_var_get.return_value = "2024-03-11"
+
         # Act
-        result, _, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
-    
+        result, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
+
         # Assert
         assert result == expected_dates
 
@@ -304,20 +274,13 @@ def test_determine_dates_no_new_dates(mock_provider: MagicMock):
     available_dates = [DateStr("2024-03-10"), DateStr("2024-03-11")]
     mock_provider.list_available_keys.return_value = available_dates
     force_reprocess = False
-    
-    # Mock Prefect variables - all available dates already processed
+
     with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_var_get:
-        def _mock_get(var_name: str, default: Any) -> str:
-            if var_name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2024-03-15"
-            elif var_name == ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE:
-                return "2024-03-11"
-            return default
-        mock_var_get.side_effect = _mock_get
-        
+        mock_var_get.return_value = "2024-03-11"
+
         # Act
-        result, _, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
-    
+        result, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
+
         # Assert
         assert result == []
         mock_provider.list_available_keys.assert_called_once()
@@ -330,20 +293,13 @@ def test_determine_dates_gaps_in_available_dates(mock_provider: MagicMock):
     mock_provider.list_available_keys.return_value = available_dates
     force_reprocess = False
     expected_dates = [DateStr("2024-03-12"), DateStr("2024-03-13")]
-    
-    # Mock Prefect variables
+
     with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_var_get:
-        def _mock_get(var_name: str, default: Any) -> str:
-            if var_name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2024-03-15"
-            elif var_name == ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE:
-                return "2024-03-10"
-            return default
-        mock_var_get.side_effect = _mock_get
-        
+        mock_var_get.return_value = "2024-03-10"
+
         # Act
-        result, _, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
-    
+        result, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
+
         # Assert
         assert result == expected_dates
         mock_provider.list_available_keys.assert_called_once()
@@ -354,14 +310,13 @@ def test_determine_dates_no_available_dates(mock_provider: MagicMock):
     # Arrange
     mock_provider.list_available_keys.return_value = []
     force_reprocess = False
-    
-    # Mock Prefect variables
+
     with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_var_get:
-        mock_var_get.return_value = "2024-03-15"  # Any date
-        
+        mock_var_get.return_value = "2024-03-15"
+
         # Act
-        result, _, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
-    
+        result, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
+
         # Assert
         assert result == []
         mock_provider.list_available_keys.assert_called_once()
@@ -374,21 +329,14 @@ def test_determine_dates_invalid_metadata_date(mock_provider: MagicMock, caplog:
     mock_provider.list_available_keys.return_value = available_dates
     force_reprocess = False
     expected_dates = available_dates
-    
-    # Mock Prefect variables
+
     with patch("tsn_adapters.tasks.argentina.tasks.aggregate_products_tasks.variables.Variable.get") as mock_var_get:
-        def _mock_get(var_name: str, default: Any) -> str:
-            if var_name == ArgentinaFlowVariableNames.LAST_PREPROCESS_SUCCESS_DATE:
-                return "2024-03-15"
-            elif var_name == ArgentinaFlowVariableNames.LAST_AGGREGATION_SUCCESS_DATE:
-                return "1970-01-01"
-            return default
-        mock_var_get.side_effect = _mock_get
-        
+        mock_var_get.return_value = "1970-01-01"
+
         # Act
-        with caplog.at_level(logging.WARNING):  # Use logging.WARNING
-            result, _, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
-    
+        with caplog.at_level(logging.WARNING):
+            result, _ = determine_aggregation_dates.fn(mock_provider, force_reprocess)
+
         # Assert
         assert result == expected_dates
 


### PR DESCRIPTION
## Summary
- The aggregate flow now processes all available `product_averages.zip` dates in S3 after `LAST_AGGREGATION_SUCCESS_DATE`, independent of the preprocess deployment schedule
- S3 data may be uploaded by external parties (George's team handles raw→preprocess externally); the aggregate/deploy/insert trio should consume whatever is available
- Removes `LAST_PREPROCESS_SUCCESS_DATE` gating from `determine_aggregation_dates` and simplifies the return type from 3-tuple to 2-tuple

## Test plan
- [x] All 14 unit tests in `test_aggregate_products_tasks.py` pass
- [x] All 5 integration tests in `test_aggregate_products_flow.py` pass
- [ ] Verify next scheduled aggregate run (1:00 AM UTC) picks up available dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined date-range determination in the product aggregation workflow by consolidating multiple date-tracking dependencies into a single reference point, reducing complexity in date calculations and logging.

* **Tests**
  * Updated unit and integration tests to align with the simplified date-determination logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->