### PR TITLE
chore: use fuzzy filing date match for income-statement lookup

### DIFF
--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -40,7 +40,7 @@ block for all three when source identities share a wallet.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pandas as pd
 from pandera.typing import DataFrame
@@ -135,14 +135,19 @@ def detect_and_prepare_eps(
     income_stmt_df = fmp_block.get_quarterly_income_statements(symbol, limit=RECENT_QUARTERS + 2)
 
     # Build filing_date → fiscal-period-end mapping from quarterly income
-    # statements. `filingDate` matches FMP earnings' `date` (announcement
-    # date) exactly for the same event; `date` is the fiscal-period-end.
+    # statements. For most tickers, `filingDate` matches FMP earnings'
+    # `date` exactly. Some tickers (AAPL, GOOGL, AMZN, META, TSLA) are
+    # off by ±1 day, so we index each filing under its date and both
+    # neighbors.
     filing_to_period_end: dict[str, str] = {}
     for _, row in income_stmt_df.iterrows():
         fd = row.get("filingDate")
         pe = row.get("date")
         if fd and pe and not pd.isna(fd) and not pd.isna(pe):
-            filing_to_period_end[str(fd)] = str(pe)
+            fd_date = date.fromisoformat(str(fd))
+            for offset in (-1, 0, 1):
+                key = (fd_date + timedelta(days=offset)).isoformat()
+                filing_to_period_end.setdefault(key, str(pe))
 
     fmp_rows: list[dict] = []
     yahoo_rows: list[dict] = []

--- a/tests/eps/test_real_time_flow.py
+++ b/tests/eps/test_real_time_flow.py
@@ -212,6 +212,7 @@ def test_aapl_filing_date_off_by_one():
     assert len(yahoo_rows) == 1
     assert len(truf_rows) == 1
     assert truf_rows[0]["value"] == "2.01"
+    assert truf_rows[0]["date"] == date_string_to_unix("2026-04-30")
 
 
 # --- Disagreement / pending paths ---

--- a/tests/eps/test_real_time_flow.py
+++ b/tests/eps/test_real_time_flow.py
@@ -180,6 +180,40 @@ def test_aapl_fiscal_quarter_mismatch_resolves():
     assert truf_rows[0]["value"] == "2.01"
 
 
+def test_aapl_filing_date_off_by_one():
+    """Real production data: AAPL's income-statement filingDate is one day
+    after FMP earnings date (2026-05-01 vs 2026-04-30). The ±1 day fuzzy
+    match on filing dates resolves this.
+    """
+    aapl_fmp = {"symbol": "AAPL", "date": "2026-04-30", "epsActual": 2.01, "epsEstimated": 1.99, "lastUpdated": None}
+    aapl_yahoo = {"symbol": "AAPL", "date": "2026-03-31", "epsActual": 2.01, "epsEstimated": 1.99, "lastUpdated": None}
+    aapl_income = {
+        "symbol": "AAPL",
+        "period": "Q2",
+        "fiscalYear": "2026",
+        "date": "2026-03-28",
+        "filingDate": "2026-05-01",  # +1 day vs earnings date
+        "acceptedDate": None,
+    }
+
+    fmp = _make_fmp(earnings={"AAPL": [aapl_fmp]}, income_statements={"AAPL": [aapl_income]})
+    yahoo = _make_yahoo({"AAPL": [aapl_yahoo]})
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=FakeTNAccessBlock(),
+        yahoo_tn_block=FakeTNAccessBlock(),
+        truf_tn_block=FakeTNAccessBlock(),
+        symbol="AAPL",
+    )
+
+    assert len(fmp_rows) == 1
+    assert len(yahoo_rows) == 1
+    assert len(truf_rows) == 1
+    assert truf_rows[0]["value"] == "2.01"
+
+
 # --- Disagreement / pending paths ---
 
 


### PR DESCRIPTION
follow up from: https://github.com/trufnetwork/adapters/pull/229
resolves: https://github.com/truflation/website/issues/3936

## Summary
- FMP's income-statement `filingDate` is off by ±1 day from the earnings `date` for some tickers (AAPL, GOOGL, AMZN, META, TSLA)
- The `filing_to_period_end` dict now indexes each filing under its date and both neighbors, so a ±1 day offset still resolves the canonical key for reconciliation
- Adds test with real production data (AAPL `filingDate=2026-05-01` vs earnings `date=2026-04-30`)

## Test plan
- [x] All 25 EPS tests pass (24 existing + 1 new fuzzy-match test)
- [ ] Hotpatch server and verify AAPL/GOOGL/AMZN/META/TSLA settle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced earnings data reconciliation to tolerate filing date variations of ±1 day across data sources, improving event matching accuracy and reducing missed reconciliations due to minor date discrepancies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/adapters/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->