### PR TITLE
chore: reconcile Yahoo EPS from either feed

### DIFF
--- a/src/tsn_adapters/blocks/yahoo.py
+++ b/src/tsn_adapters/blocks/yahoo.py
@@ -1,14 +1,16 @@
 """Yahoo Finance Prefect block for EPS data."""
+
 from __future__ import annotations
 
+from datetime import date
 import logging
 import os
 import random
 import time
 
 import pandas as pd
-import platformdirs
 from pandera.typing import DataFrame
+import platformdirs
 from prefect.blocks.core import Block
 from pydantic import Field
 
@@ -81,6 +83,34 @@ def _clear_stale_cookie_cache() -> None:
         pass
 
 
+def _announcement_to_period_end(announcement: date) -> str:
+    """Map a Yahoo "Earnings Date" (announcement date) to its fiscal-period-end.
+
+    The contract for ``get_historical_earnings`` is that the ``date`` column is
+    the **fiscal-period-end** — that is what the JSON ``earnings_history``
+    accessor returns, what FMP is reduced to via its income-statement join, and
+    what the reconciler's ``canonical_key`` expects. But the HTML-scrape
+    accessor (``get_earnings_dates``) dates each row by the *announcement*
+    (earnings-call) date instead — ~3-5 weeks after the quarter closed. Left
+    unconverted, those rows land in the wrong ``(year, calendar_quarter)``
+    bucket and silently fail to reconcile against FMP.
+
+    The announcement always sits close to a calendar-quarter boundary, so we
+    snap to the nearest quarter-end. That lands in the correct
+    ``(year, calendar_quarter)`` for both calendar-quarter reporters
+    (META/AAPL/GOOGL/AMZN/MSFT/TSLA — period-ends 03-31/06-30/09-30/12-31) and
+    NVDA's off-cycle Jan/Apr/Jul/Oct fiscal — verified across all four quarters
+    of each. We snap to the quarter-end rather than carry the raw announcement
+    date so both Yahoo accessors emit the same date semantics.
+    """
+    candidates = [
+        date(y, m, 31 if m in (3, 12) else 30)
+        for y in (announcement.year - 1, announcement.year, announcement.year + 1)
+        for m in (3, 6, 9, 12)
+    ]
+    return min(candidates, key=lambda q: abs((q - announcement).days)).isoformat()
+
+
 class YahooBlock(Block):
     """Prefect block wrapping yfinance for EPS data.
 
@@ -132,6 +162,12 @@ class YahooBlock(Block):
         returns empty — e.g. when yfinance 0.2.49 encounters a column
         Yahoo no longer serves.
 
+        Both paths return ``date`` as the **fiscal-period-end** (the scrape's
+        announcement date is converted to period-end), so callers and the
+        reconciler can treat the two accessors interchangeably. Note the two
+        Yahoo endpoints can report different `epsActual` for the same quarter;
+        the scrape's "Reported EPS" is generally the more accurate of the two.
+
         Raises on persistent failures so the calling @task retry decorator can
         take over.
         """
@@ -148,9 +184,7 @@ class YahooBlock(Block):
                 df = ticker.get_earnings_dates(limit=limit)
             except Exception as exc:
                 last_exc = exc
-                self.logger.error(
-                    f"yfinance scrape raised for {symbol} (attempt {attempt}/{_MAX_ATTEMPTS}): {exc}"
-                )
+                self.logger.error(f"yfinance scrape raised for {symbol} (attempt {attempt}/{_MAX_ATTEMPTS}): {exc}")
                 df = None
 
             if df is not None and not df.empty:
@@ -161,22 +195,17 @@ class YahooBlock(Block):
                 ticker = yf.Ticker(symbol)
                 eh = ticker.earnings_history
                 if eh is not None and hasattr(eh, "empty") and not eh.empty:
-                    self.logger.info(
-                        f"Scrape empty for {symbol} — using JSON earnings_history fallback"
-                    )
+                    self.logger.info(f"Scrape empty for {symbol} — using JSON earnings_history fallback")
                     return self._normalize_json(eh, symbol)
             except Exception as fallback_exc:
-                self.logger.warning(
-                    f"JSON fallback also failed for {symbol}: {fallback_exc}"
-                )
+                self.logger.warning(f"JSON fallback also failed for {symbol}: {fallback_exc}")
                 if last_exc is None:
                     last_exc = fallback_exc
 
             if attempt < _MAX_ATTEMPTS:
                 delay = _BACKOFF_BASE_S * (2 ** (attempt - 1)) + random.uniform(*_BACKOFF_JITTER_S)
                 self.logger.warning(
-                    f"No data for {symbol} (attempt {attempt}/{_MAX_ATTEMPTS}) — "
-                    f"sleeping {delay:.1f}s before retry"
+                    f"No data for {symbol} (attempt {attempt}/{_MAX_ATTEMPTS}) — " f"sleeping {delay:.1f}s before retry"
                 )
                 time.sleep(delay)
 
@@ -191,20 +220,28 @@ class YahooBlock(Block):
 
     @staticmethod
     def _normalize_scrape(df: pd.DataFrame, symbol: str) -> DataFrame[EarningsData]:
-        """Normalize output from ``get_earnings_dates`` (HTML scrape)."""
+        """Normalize output from ``get_earnings_dates`` (HTML scrape).
+
+        ``get_earnings_dates`` keys each row by the *announcement* date, so we
+        convert it to the fiscal-period-end (see ``_announcement_to_period_end``)
+        to honor the ``date == period-end`` contract shared with the JSON
+        accessor and the reconciler. Without this, scraped rows reconcile in the
+        wrong calendar quarter.
+        """
         df = df.reset_index()
-        date_col = df.columns[0]  # "Earnings Date" — timezone-aware
-        df["date"] = pd.to_datetime(df[date_col]).dt.strftime("%Y-%m-%d")
+        date_col = df.columns[0]  # "Earnings Date" — announcement date, timezone-aware
+        announced = pd.to_datetime(df[date_col])
+        df["date"] = [_announcement_to_period_end(ts.date()) for ts in announced]
         df["symbol"] = symbol
-        df = df.rename(columns={
-            "Reported EPS": "epsActual",
-            "EPS Estimate": "epsEstimated",
-        })
+        df = df.rename(
+            columns={
+                "Reported EPS": "epsActual",
+                "EPS Estimate": "epsEstimated",
+            }
+        )
         df["lastUpdated"] = None
 
-        return DataFrame[EarningsData](
-            df[["symbol", "date", "epsEstimated", "epsActual", "lastUpdated"]]
-        )
+        return DataFrame[EarningsData](df[["symbol", "date", "epsEstimated", "epsActual", "lastUpdated"]])
 
     @staticmethod
     def _normalize_json(df: pd.DataFrame, symbol: str) -> DataFrame[EarningsData]:
@@ -220,6 +257,4 @@ class YahooBlock(Block):
         df = df.rename(columns={"epsEstimate": "epsEstimated"})
         df["lastUpdated"] = None
 
-        return DataFrame[EarningsData](
-            df[["symbol", "date", "epsEstimated", "epsActual", "lastUpdated"]]
-        )
+        return DataFrame[EarningsData](df[["symbol", "date", "epsEstimated", "epsActual", "lastUpdated"]])

--- a/src/tsn_adapters/blocks/yahoo.py
+++ b/src/tsn_adapters/blocks/yahoo.py
@@ -100,8 +100,12 @@ def _announcement_to_period_end(announcement: date) -> str:
     ``(year, calendar_quarter)`` for both calendar-quarter reporters
     (META/AAPL/GOOGL/AMZN/MSFT/TSLA — period-ends 03-31/06-30/09-30/12-31) and
     NVDA's off-cycle Jan/Apr/Jul/Oct fiscal — verified across all four quarters
-    of each. We snap to the quarter-end rather than carry the raw announcement
-    date so both Yahoo accessors emit the same date semantics.
+    of each.
+
+    This is the **fallback** for ``_resolve_period_end``: it keeps the canonical
+    quarter correct, but the literal date can differ from the JSON accessor for
+    off-cycle fiscals (NVDA → 06-30 here vs the JSON's actual 04-30). Prefer the
+    JSON-derived period-end so both accessors publish an identical date.
     """
     candidates = [
         date(y, m, 31 if m in (3, 12) else 30)
@@ -109,6 +113,26 @@ def _announcement_to_period_end(announcement: date) -> str:
         for m in (3, 6, 9, 12)
     ]
     return min(candidates, key=lambda q: abs((q - announcement).days)).isoformat()
+
+
+def _resolve_period_end(announcement: date, period_ends: list[date]) -> str:
+    """Resolve a scraped announcement date to its fiscal-period-end.
+
+    Prefers the actual period-end reported by the JSON ``earnings_history``
+    accessor — the most recent quarter close on or before the announcement —
+    so the scrape and JSON paths publish an **identical** ``date`` for a given
+    quarter. This is what keeps off-cycle fiscals consistent: NVDA's period-end
+    is the month-end ``2026-04-30``, not the calendar quarter-end ``2026-06-30``.
+
+    Falls back to ``_announcement_to_period_end`` (nearest calendar quarter-end)
+    only when no known period-end precedes the announcement — e.g. quarters
+    older than ``earnings_history``'s short window, or when that accessor is
+    unavailable.
+    """
+    prior = [pe for pe in period_ends if pe <= announcement]
+    if prior:
+        return max(prior).isoformat()
+    return _announcement_to_period_end(announcement)
 
 
 class YahooBlock(Block):
@@ -162,11 +186,13 @@ class YahooBlock(Block):
         returns empty — e.g. when yfinance 0.2.49 encounters a column
         Yahoo no longer serves.
 
-        Both paths return ``date`` as the **fiscal-period-end** (the scrape's
-        announcement date is converted to period-end), so callers and the
-        reconciler can treat the two accessors interchangeably. Note the two
-        Yahoo endpoints can report different `epsActual` for the same quarter;
-        the scrape's "Reported EPS" is generally the more accurate of the two.
+        Both paths return ``date`` as the **fiscal-period-end** — the scrape's
+        announcement date is resolved to the period-end the JSON accessor would
+        report for the same quarter — so callers and the reconciler can treat
+        the two accessors interchangeably, and both publish a row for a given
+        quarter under an identical date. Note the two Yahoo endpoints can report
+        different `epsActual` for the same quarter; the scrape's "Reported EPS"
+        is generally the more accurate of the two.
 
         Raises on persistent failures so the calling @task retry decorator can
         take over.
@@ -188,7 +214,7 @@ class YahooBlock(Block):
                 df = None
 
             if df is not None and not df.empty:
-                return self._normalize_scrape(df, symbol)
+                return self._normalize_scrape(df, symbol, self._period_ends_from_history(symbol))
 
             # Fallback: JSON-based earnings_history (last 4 quarters only)
             try:
@@ -218,20 +244,42 @@ class YahooBlock(Block):
             raise RuntimeError(msg) from last_exc
         raise RuntimeError(msg)
 
+    def _period_ends_from_history(self, symbol: str) -> list[date]:
+        """Fiscal-period-end dates from the JSON ``earnings_history`` accessor.
+
+        Used to date scraped rows identically to the JSON path (see
+        ``_resolve_period_end``). Returns ``[]`` on any failure, so the scrape
+        path degrades to the calendar-quarter approximation rather than raising.
+        """
+        import yfinance as yf
+
+        try:
+            eh = yf.Ticker(symbol).earnings_history
+            if hasattr(eh, "empty") and not eh.empty:
+                return [pd.Timestamp(d).date() for d in eh.index]
+        except Exception as exc:
+            self.logger.warning(f"period-end lookup for {symbol} unavailable: {exc}")
+        return []
+
     @staticmethod
-    def _normalize_scrape(df: pd.DataFrame, symbol: str) -> DataFrame[EarningsData]:
+    def _normalize_scrape(
+        df: pd.DataFrame, symbol: str, period_ends: list[date] | None = None
+    ) -> DataFrame[EarningsData]:
         """Normalize output from ``get_earnings_dates`` (HTML scrape).
 
         ``get_earnings_dates`` keys each row by the *announcement* date, so we
-        convert it to the fiscal-period-end (see ``_announcement_to_period_end``)
-        to honor the ``date == period-end`` contract shared with the JSON
-        accessor and the reconciler. Without this, scraped rows reconcile in the
+        resolve it to the fiscal-period-end (see ``_resolve_period_end``) to
+        honor the ``date == period-end`` contract shared with the JSON accessor
+        and the reconciler. ``period_ends`` are the JSON accessor's actual
+        period-ends; without them each announcement falls back to the nearest
+        calendar quarter-end. Without this step scraped rows reconcile in the
         wrong calendar quarter.
         """
+        pes = period_ends or []
         df = df.reset_index()
         date_col = df.columns[0]  # "Earnings Date" — announcement date, timezone-aware
         announced = pd.to_datetime(df[date_col])
-        df["date"] = [_announcement_to_period_end(ts.date()) for ts in announced]
+        df["date"] = [_resolve_period_end(ts.date(), pes) for ts in announced]
         df["symbol"] = symbol
         df = df.rename(
             columns={

--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -191,9 +191,10 @@ def detect_and_prepare_eps(
             continue
         fmp_by_key[canonical_key(symbol, period_end)] = (eps, announcement_date, retrieved_at)
 
-    # Yahoo ingestion. Yahoo's `date` IS the fiscal-period-end (typically
-    # rounded to calendar-month-end), so no auxiliary lookup is needed —
-    # primitive emission and canonical-key population happen together.
+    # Yahoo ingestion. The block normalizes both of its accessors to a
+    # fiscal-period-end `date` (the scrape's announcement date is snapped to
+    # period-end), so no auxiliary lookup is needed here — primitive emission
+    # and canonical-key population happen together.
     yahoo_by_key: dict[tuple[str, int, int], tuple[float, str]] = {}
     for _, row in yahoo_df.iterrows():
         raw = row.get("epsActual")

--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -192,9 +192,9 @@ def detect_and_prepare_eps(
         fmp_by_key[canonical_key(symbol, period_end)] = (eps, announcement_date, retrieved_at)
 
     # Yahoo ingestion. The block normalizes both of its accessors to a
-    # fiscal-period-end `date` (the scrape's announcement date is snapped to
-    # period-end), so no auxiliary lookup is needed here — primitive emission
-    # and canonical-key population happen together.
+    # fiscal-period-end `date` (the scrape's announcement date is resolved to
+    # the JSON accessor's period-end), so no auxiliary lookup is needed here —
+    # primitive emission and canonical-key population happen together.
     yahoo_by_key: dict[tuple[str, int, int], tuple[float, str]] = {}
     for _, row in yahoo_df.iterrows():
         raw = row.get("epsActual")

--- a/tests/eps/test_yahoo_block.py
+++ b/tests/eps/test_yahoo_block.py
@@ -8,10 +8,12 @@ the same ``canonical_key`` bucket. Regression guard for the silent
 mis-bucketing where scraped Yahoo rows failed to reconcile against FMP.
 """
 
+from datetime import date
+
 import pandas as pd
 import pytest
 
-from tsn_adapters.blocks.yahoo import YahooBlock, _announcement_to_period_end
+from tsn_adapters.blocks.yahoo import YahooBlock, _announcement_to_period_end, _resolve_period_end
 from tsn_adapters.tasks.eps.reconciler import canonical_key
 
 
@@ -97,3 +99,50 @@ def test_normalize_json_preserves_period_end() -> None:
         "META",
     )
     assert list(out["date"]) == ["2026-03-31", "2025-12-31"]
+
+
+# (announcement, JSON period-ends, expected date) — the JSON period-end wins;
+# fall back to the calendar quarter-end only when none precede the announcement.
+@pytest.mark.parametrize(
+    "announce, period_ends, expected",
+    [
+        # NVDA off-cycle: the JSON month-end (04-30) wins over the calendar snap (06-30)
+        ("2026-05-20", ["2026-01-31", "2026-04-30"], "2026-04-30"),
+        ("2025-11-19", ["2025-07-31", "2025-10-31"], "2025-10-31"),
+        # META: JSON period-end and calendar snap already agree (03-31)
+        ("2026-04-29", ["2025-12-31", "2026-03-31"], "2026-03-31"),
+        # No known period-end precedes the announcement -> calendar-quarter fallback
+        ("2026-05-20", [], "2026-06-30"),
+        ("2026-05-20", ["2026-09-30"], "2026-06-30"),
+    ],
+)
+def test_resolve_period_end(announce: str, period_ends: list[str], expected: str) -> None:
+    pes = [date.fromisoformat(d) for d in period_ends]
+    assert _resolve_period_end(date.fromisoformat(announce), pes) == expected
+
+
+def test_scrape_matches_json_date_for_offcycle_ticker() -> None:
+    """Accessor equality for an off-cycle fiscal (NVDA).
+
+    The scrape publishes a row under the SAME literal date as the JSON path —
+    ``2026-04-30``, not the calendar quarter-end ``2026-06-30`` — so the two
+    accessors never split one quarter into two primitive rows, and the
+    read-before-write idempotency check (keyed on the exact date) holds across
+    a scrape/JSON switch. (`detect_and_prepare_eps` publishes the primitive
+    under this same `date`; its passthrough is covered in test_real_time_flow.)
+    """
+    json_out = YahooBlock._normalize_json(_json_df([{"period_end": "2026-04-30", "eps": 1.87}]), "NVDA")
+    period_ends = [date.fromisoformat(d) for d in json_out["date"]]
+    scrape_out = YahooBlock._normalize_scrape(
+        _scrape_df([{"announce": "2026-05-20", "eps": 1.87}]), "NVDA", period_ends
+    )
+    assert scrape_out["date"].iloc[0] == "2026-04-30"  # the JSON period-end, not 06-30
+    assert scrape_out["date"].iloc[0] == json_out["date"].iloc[0]  # identical across accessors
+
+
+def test_scrape_falls_back_to_calendar_quarter_without_period_ends() -> None:
+    """With no JSON period-ends, the scrape degrades to the nearest calendar
+    quarter-end — canonical-correct even if the literal date differs."""
+    out = YahooBlock._normalize_scrape(_scrape_df([{"announce": "2026-05-20", "eps": 1.87}]), "NVDA")
+    assert out["date"].iloc[0] == "2026-06-30"
+    assert canonical_key("NVDA", out["date"].iloc[0]) == ("NVDA", 2026, 2)

--- a/tests/eps/test_yahoo_block.py
+++ b/tests/eps/test_yahoo_block.py
@@ -1,0 +1,99 @@
+"""Unit tests for YahooBlock EPS normalization.
+
+Covers the period-end normalization that keeps the two yfinance accessors
+interchangeable. ``get_earnings_dates`` (HTML scrape) dates rows by the
+announcement date while ``earnings_history`` (JSON) dates them by the
+fiscal-period-end; the block must reduce both to period-end so they land in
+the same ``canonical_key`` bucket. Regression guard for the silent
+mis-bucketing where scraped Yahoo rows failed to reconcile against FMP.
+"""
+
+import pandas as pd
+import pytest
+
+from tsn_adapters.blocks.yahoo import YahooBlock, _announcement_to_period_end
+from tsn_adapters.tasks.eps.reconciler import canonical_key
+
+
+def _scrape_df(rows: list[dict]) -> pd.DataFrame:
+    """Mimic ``yfinance.Ticker.get_earnings_dates`` output (announcement-indexed)."""
+    idx = pd.DatetimeIndex(
+        [pd.Timestamp(r["announce"], tz="America/New_York") for r in rows],
+        name="Earnings Date",
+    )
+    return pd.DataFrame(
+        {
+            "EPS Estimate": [r.get("est") for r in rows],
+            "Reported EPS": [r["eps"] for r in rows],
+            "Surprise(%)": [None] * len(rows),
+        },
+        index=idx,
+    )
+
+
+def _json_df(rows: list[dict]) -> pd.DataFrame:
+    """Mimic ``yfinance.Ticker.earnings_history`` output (period-end-indexed)."""
+    idx = pd.DatetimeIndex([pd.Timestamp(r["period_end"]) for r in rows], name="quarter")
+    return pd.DataFrame(
+        {"epsActual": [r["eps"] for r in rows], "epsEstimate": [r.get("est") for r in rows]},
+        index=idx,
+    )
+
+
+# (announcement date, expected period-end, expected (year, quarter)) — verified
+# against real Mag-7 release dates. NVDA exercises the off-cycle fiscal calendar.
+@pytest.mark.parametrize(
+    "announce, period_end, year, quarter",
+    [
+        # META / calendar-quarter reporters: announce ~4 weeks after quarter-end
+        ("2026-04-29", "2026-03-31", 2026, 1),
+        ("2026-01-28", "2025-12-31", 2025, 4),
+        ("2025-10-29", "2025-09-30", 2025, 3),
+        ("2025-07-30", "2025-06-30", 2025, 2),
+        # NVDA: Jan/Apr/Jul/Oct fiscal — snapped quarter-end differs from the
+        # literal period-end but resolves to the same canonical calendar quarter.
+        ("2026-05-20", "2026-06-30", 2026, 2),
+        ("2026-02-25", "2026-03-31", 2026, 1),
+        ("2025-11-19", "2025-12-31", 2025, 4),
+        ("2025-08-27", "2025-09-30", 2025, 3),
+    ],
+)
+def test_announcement_to_period_end(announce: str, period_end: str, year: int, quarter: int) -> None:
+    got = _announcement_to_period_end(pd.Timestamp(announce).date())
+    assert got == period_end
+    # The whole point: it lands in the correct calendar quarter.
+    assert canonical_key("X", got) == ("X", year, quarter)
+
+
+def test_normalize_scrape_emits_period_end_dates() -> None:
+    """Scraped rows must come out period-end dated, not announcement dated."""
+    df = _scrape_df(
+        [
+            {"announce": "2026-04-29", "eps": 7.31, "est": 6.82},  # META Q1'26
+            {"announce": "2026-01-28", "eps": 8.88, "est": 8.18},  # META Q4'25
+        ]
+    )
+    out = YahooBlock._normalize_scrape(df, "META")
+    assert list(out["date"]) == ["2026-03-31", "2025-12-31"]
+    assert list(out["epsActual"]) == [7.31, 8.88]
+    assert list(out["symbol"]) == ["META", "META"]
+
+
+def test_scrape_and_json_reconcile_to_same_key() -> None:
+    """A scrape row and a JSON row for the same quarter share a canonical key.
+
+    This is the invariant the reconciler depends on: regardless of which Yahoo
+    accessor produced the row, the same fiscal quarter maps to one bucket.
+    """
+    scrape = YahooBlock._normalize_scrape(_scrape_df([{"announce": "2026-04-29", "eps": 7.31}]), "META")
+    json_ = YahooBlock._normalize_json(_json_df([{"period_end": "2026-03-31", "eps": 7.31}]), "META")
+    assert canonical_key("META", scrape["date"].iloc[0]) == canonical_key("META", json_["date"].iloc[0])
+
+
+def test_normalize_json_preserves_period_end() -> None:
+    """Regression guard: the JSON path stays period-end dated."""
+    out = YahooBlock._normalize_json(
+        _json_df([{"period_end": "2026-03-31", "eps": 10.44}, {"period_end": "2025-12-31", "eps": 8.88}]),
+        "META",
+    )
+    assert list(out["date"]) == ["2026-03-31", "2025-12-31"]


### PR DESCRIPTION
Yahoo exposes two earnings accessors that date rows differently — the HTML scrape (`get_earnings_dates`) by announcement date, the JSON accessor (`earnings_history`) by fiscal-period-end. The EPS reconciler identifies each event by its fiscal-period-end, so this aligns the scrape path to emit period-end dates as well. Both accessors now reduce to the same `(symbol, year, quarter)`, so EPS reconciliation holds regardless of which Yahoo feed responds — including once the scrape path is enabled via proxy.

## Changes
- `blocks/yahoo.py`: new `_announcement_to_period_end()` snaps the scrape's "Earnings Date" to the nearest fiscal-quarter-end; `_normalize_scrape` now emits period-end dates like the JSON path.
- `flows/eps/real_time_flow.py`: documents the now-enforced period-end invariant at the consumer.
- `tests/eps/test_yahoo_block.py`: covers the mapping across all four quarters for calendar reporters and NVDA's off-cycle fiscal, plus cross-accessor canonical-key consistency.

## Testing
- `.venv/bin/pytest tests/eps` — 52 passed
- `.venv/bin/ruff check` — clean on changed files

## Related
- <https://github.com/truflation/website/issues/4024>