### PR TITLE
chore: keep EPS ingestion within FMP's 5-quarter limit

### DIFF
--- a/src/tsn_adapters/flows/eps/historical_flow.py
+++ b/src/tsn_adapters/flows/eps/historical_flow.py
@@ -40,8 +40,11 @@ from tsn_adapters.tasks.eps.config import FMP_EPS_STREAM_IDS, MAG7, YAHOO_EPS_ST
 from tsn_adapters.utils.logging import get_logger_safe
 from tsn_adapters.utils.time_utils import date_string_to_unix
 
-# FMP earnings endpoint returns up to `limit` quarters. 50 covers ~12.5 years.
-EARNINGS_LIMIT = 50
+# FMP earnings endpoint returns up to `limit` quarters. The current FMP plan
+# rejects `limit` > 5 with HTTP 402, and ignores offset/page/date-range params,
+# so deeper history is unreachable without a plan upgrade. Yahoo (yfinance) is
+# also shallow (~4 quarters). Raise this once FMP access is restored.
+EARNINGS_LIMIT = 5
 
 
 @task(retries=3, retry_delay_seconds=30)

--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -132,7 +132,8 @@ def detect_and_prepare_eps(
     yahoo_df = yahoo_block.get_historical_earnings(symbol, limit=RECENT_QUARTERS)
     # +2 keeps the lookup tolerant of fetch-window drift between earnings and
     # income-statement (income-statement may lag earnings by one filing).
-    income_stmt_df = fmp_block.get_quarterly_income_statements(symbol, limit=RECENT_QUARTERS + 2)
+    # Capped at 5: the current FMP plan rejects `limit` > 5 with HTTP 402.
+    income_stmt_df = fmp_block.get_quarterly_income_statements(symbol, limit=min(RECENT_QUARTERS + 2, 5))
 
     # Build filing_date → fiscal-period-end mapping from quarterly income
     # statements. For most tickers, `filingDate` matches FMP earnings'


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3970

## Problem

The FMP "prod" plan was downgraded and now rejects `limit` > 5 with HTTP 402 on the time-series endpoints (`/stable/earnings`, `/stable/income-statement`), and ignores `offset`/`page`/`from`/`to` — so only the latest ~5 quarters are reachable. This breaks both EPS write flows (testnet and mainnet), which had been failing every 6h:

- `historical_flow` requests `EARNINGS_LIMIT = 50`
- `real_time_flow` requests income-statement `limit = RECENT_QUARTERS + 2` (6)

## Change

Cap the FMP request limits at 5 so the flows run within the current plan:

- `EARNINGS_LIMIT` 50 → 5
- income-statement `limit` → `min(RECENT_QUARTERS + 2, 5)`

Yahoo (yfinance) returns only ~4 quarters regardless of limit, so this matches what the sources can actually provide.

## Result

Both flows complete and write records again instead of 402-ing — verified against the live nodes (the FMP, Yahoo, and Truf consensus streams all populate). Deep history is not recoverable from either source on the current plan; once FMP access is restored, raise the limits back (the comment in `historical_flow.py` marks where) and re-run the historical backfill.
