### PR TITLE
chore: broadcast fresh EPS prints past gap-filled TN reads

### DIFF
--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -67,6 +67,13 @@ RECENT_QUARTERS = 4
 def _is_published(tn_block: TNAccessBlock, stream_id: str, date_unix: int) -> bool:
     """Return True if a record for this exact date already exists in TN.
 
+    TN's `get_records` gap-fills: a query for [date, date] also returns the
+    latest record at-or-before `date` (the LOCF anchor), so a non-empty
+    result only proves the stream has *some* earlier history — not that this
+    date is published. Only an exact event-time match counts; treating the
+    anchor as "published" made every date after a stream's first record read
+    as a duplicate and silently no-op'd all publishes (website#4362).
+
     Raises on TN errors (fail-closed) — callers are retried by Prefect so a
     transient failure never silently breaks the read-before-write guarantee.
     """
@@ -75,7 +82,9 @@ def _is_published(tn_block: TNAccessBlock, stream_id: str, date_unix: int) -> bo
         date_from=date_unix,
         date_to=date_unix,
     )
-    return not df.empty
+    if df.empty:
+        return False
+    return bool((df["date"].astype("int64") == int(date_unix)).any())
 
 
 @task(retries=3, retry_delay_seconds=30)

--- a/tests/eps/test_real_time_flow.py
+++ b/tests/eps/test_real_time_flow.py
@@ -367,6 +367,53 @@ def test_idempotent_skips_already_published_consensus():
     assert len(truf_rows) == 0
 
 
+def test_publishes_fresh_print_despite_older_stream_history():
+    """A fresh print must publish even when the stream already holds older
+    quarters. TN's gap-filled read answers a [date, date] query with the
+    PREVIOUS record (the LOCF anchor), so an is-it-published check that only
+    tests non-emptiness sees every new announcement as a duplicate once the
+    stream has any history at all. That silently no-op'd every scheduled run
+    (website#4362: TSLA's Q2-2026 print never reached TN while the streams
+    held Q1 and older). Only an exact date match may count as published.
+    """
+    from tsn_adapters.tasks.eps.config import (
+        EPS_STREAM_IDS,
+        FMP_EPS_STREAM_IDS,
+        YAHOO_EPS_STREAM_IDS,
+    )
+
+    fmp = _make_fmp(
+        earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
+        income_statements={"NVDA": [NVDA_Q1_FY27_INCOME_STMT]},
+    )
+    yahoo = _make_yahoo({"NVDA": [NVDA_Q1_FY27_YAHOO_EARNINGS]})
+
+    # Every stream already carries the PREVIOUS quarter — the production
+    # steady state. The gap-filled read returns these as anchors for the
+    # fresh dates.
+    fmp_tn = FakeTNAccessBlock()
+    yahoo_tn = FakeTNAccessBlock()
+    truf_tn = FakeTNAccessBlock()
+    fmp_tn.seed_records(FMP_EPS_STREAM_IDS["NVDA"], [date_string_to_unix("2026-02-25")])
+    yahoo_tn.seed_records(YAHOO_EPS_STREAM_IDS["NVDA"], [date_string_to_unix("2026-01-31")])
+    truf_tn.seed_records(EPS_STREAM_IDS["NVDA"], [date_string_to_unix("2026-02-25")])
+
+    fmp_rows, yahoo_rows, truf_rows = detect_and_prepare_eps.fn(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=fmp_tn,
+        yahoo_tn_block=yahoo_tn,
+        truf_tn_block=truf_tn,
+        symbol="NVDA",
+    )
+
+    # The fresh quarter publishes everywhere — the older history must not
+    # shadow it.
+    assert [r["date"] for r in fmp_rows] == [date_string_to_unix("2026-05-20")]
+    assert [r["date"] for r in yahoo_rows] == [date_string_to_unix("2026-04-30")]
+    assert [r["date"] for r in truf_rows] == [date_string_to_unix("2026-05-20")]
+
+
 def test_idempotent_when_all_streams_already_published():
     """Full idempotency: when every stream's date is already on-chain,
     a re-run produces no writes anywhere. Mirrors the steady-state

--- a/tests/utils/fake_tn_access.py
+++ b/tests/utils/fake_tn_access.py
@@ -282,8 +282,19 @@ class FakeTNAccessBlock(TNAccessBlock):
     ) -> PanderaDataFrame[TnRecordModel]:
         rows = self._seeded_records.get(stream_id, [])
         if date_from is not None:
-            rows = [r for r in rows if r["date"] >= date_from]
-        if date_to is not None:
+            # Mirror TN's get_records gap-fill: rows within [date_from, date_to]
+            # plus the LOCF anchor — the latest record strictly before
+            # date_from when no row sits exactly at it. A bare >= filter
+            # models a contract the real node does not honor, which let the
+            # EPS real-time dedup bug pass CI (website#4362).
+            in_range = [
+                r for r in rows if r["date"] >= date_from and (date_to is None or r["date"] <= date_to)
+            ]
+            earlier = [r for r in rows if r["date"] < date_from]
+            rows = sorted(in_range, key=lambda r: r["date"])
+            if earlier and all(r["date"] != date_from for r in in_range):
+                rows = [max(earlier, key=lambda r: r["date"]), *rows]
+        elif date_to is not None:
             rows = [r for r in rows if r["date"] <= date_to]
         if not rows:
             return PanderaDataFrame[TnRecordModel](pd.DataFrame({"date": pd.Series([], dtype=int), "value": pd.Series([], dtype=str)}))


### PR DESCRIPTION
Mag-7 EPS stopped broadcasting: every scheduled real-time run ended green with "No new EPS records to publish", and TSLA's Q2-2026 print (announced 2026-07-22) never reached TN.

Root cause: TN's `get_records` gap-fills a `[date, date]` query with the latest record at-or-before the date (the LOCF anchor). `_is_published` treated any non-empty result as "already published", so once a stream had any history, every new announcement read as a duplicate — FMP primitives, Yahoo primitives, and consensus writes were all skipped.

Verified on the ingestor box through the flow's own read path: querying the TSLA FMP stream at the announcement date returns the previous quarter's record (2026-04-22) — and so does a control date with no announcement at all.

Changes:

- `_is_published` counts only an exact event-time match as published
- `FakeTNAccessBlock.read_records` mirrors TN's gap-fill, so tests exercise the read contract the real node honors (the `>=` filter modeled one it doesn't)
- regression test reproducing the production shape — older quarters on-chain, fresh print arrives; it fails against the previous dedup

- towards: https://github.com/truflation/website/issues/4362


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EPS publishing so new event dates are not skipped when older stream history is present.
  * Improved detection of previously published events by requiring an exact event-time match.
  * Corrected handling of historical gap-fill records during date-range reads.

* **Tests**
  * Added regression coverage confirming fresh EPS prints are published despite older records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->