### PR TITLE
chore: collapse duplicate EPS rows on insert

### DIFF
--- a/src/tsn_adapters/flows/eps/historical_flow.py
+++ b/src/tsn_adapters/flows/eps/historical_flow.py
@@ -25,6 +25,7 @@ Usage (single-shot, idempotent — already-published dates are skipped):
 `fmp_tn_block` and `yahoo_tn_block` may point at the same TN wallet
 when source identities are not split.
 """
+
 from __future__ import annotations
 
 import pandas as pd
@@ -32,10 +33,10 @@ from pandera.typing import DataFrame
 from prefect import flow, task
 
 from tsn_adapters.blocks.fmp import EarningsData, FMPBlock
-from tsn_adapters.blocks.yahoo import YahooBlock
 from tsn_adapters.blocks.tn_access import TNAccessBlock
+from tsn_adapters.blocks.yahoo import YahooBlock
 from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
-from tsn_adapters.common.trufnetwork.tasks.insert import task_split_and_insert_records
+from tsn_adapters.flows.eps.publish import publish_eps_records
 from tsn_adapters.tasks.eps.config import FMP_EPS_STREAM_IDS, MAG7, YAHOO_EPS_STREAM_IDS
 from tsn_adapters.utils.logging import get_logger_safe
 from tsn_adapters.utils.time_utils import date_string_to_unix
@@ -76,9 +77,7 @@ def build_new_records(
     published_dates: set[int],
 ) -> DataFrame[TnDataRowModel]:
     """Filter to unpublished quarters and convert to TN row format."""
-    _empty = DataFrame[TnDataRowModel](
-        pd.DataFrame(columns=["stream_id", "date", "value", "data_provider"])
-    )
+    _empty = DataFrame[TnDataRowModel](pd.DataFrame(columns=["stream_id", "date", "value", "data_provider"]))
     if earnings_df.empty:
         return _empty
 
@@ -89,12 +88,14 @@ def build_new_records(
         date_unix = date_string_to_unix(str(row["date"]))
         if date_unix in published_dates:
             continue
-        rows.append({
-            "stream_id": stream_id,
-            "date": date_unix,
-            "value": str(float(row["epsActual"])),
-            "data_provider": None,
-        })
+        rows.append(
+            {
+                "stream_id": stream_id,
+                "date": date_unix,
+                "value": str(float(row["epsActual"])),
+                "data_provider": None,
+            }
+        )
 
     if not rows:
         return _empty
@@ -156,22 +157,15 @@ def eps_historical_flow(
         return
 
     if not fmp_records.empty:
-        task_split_and_insert_records(
-            block=fmp_tn_block,
-            records=DataFrame[TnDataRowModel](fmp_records),
-        )
-        logger.info(f"Inserted {len(fmp_records)} EPS records into FMP streams")
+        publish_eps_records(fmp_tn_block, fmp_records, "FMP")
 
     if not yahoo_records.empty:
-        task_split_and_insert_records(
-            block=yahoo_tn_block,
-            records=DataFrame[TnDataRowModel](yahoo_records),
-        )
-        logger.info(f"Inserted {len(yahoo_records)} EPS records into Yahoo streams")
+        publish_eps_records(yahoo_tn_block, yahoo_records, "Yahoo")
 
 
 if __name__ == "__main__":
     import asyncio
+
     from tsn_adapters.utils import deroutine
 
     async def main() -> None:

--- a/src/tsn_adapters/flows/eps/publish.py
+++ b/src/tsn_adapters/flows/eps/publish.py
@@ -1,0 +1,49 @@
+"""Shared EPS publish path — dedup + fail-loud TN insert.
+
+Both EPS flows funnel their outgoing rows through here so that
+
+1. duplicate (stream_id, date) rows are collapsed before the write. FMP
+   occasionally repeats a fresh announcement row in its response (observed
+   for GOOGL on 2026-07-22), and two records with the same primitive key
+   inside one insert_records tx violate the stream's primary key and roll
+   back the WHOLE batch — including every non-duplicate record riding in it.
+2. insert failures fail the flow run. The SplitInsertResults returned by
+   task_split_and_insert_records was previously discarded, so a rolled-back
+   batch still logged "Published" and the loss was invisible (website#4362).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from pandera.typing import DataFrame
+
+from tsn_adapters.blocks.tn_access import TNAccessBlock
+from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
+from tsn_adapters.common.trufnetwork.tasks.insert import task_split_and_insert_records
+from tsn_adapters.utils.logging import get_logger_safe
+
+
+def publish_eps_records(block: TNAccessBlock, records: pd.DataFrame, label: str) -> int:
+    """Insert EPS rows for one wallet, deduped and fail-loud.
+
+    Returns the number of records submitted after deduplication. Raises
+    RuntimeError when any record fails to insert, so the flow run reports
+    the loss instead of logging success over a rollback.
+    """
+    logger = get_logger_safe(__name__)
+
+    frame = records.drop_duplicates(subset=["stream_id", "date"], keep="first")
+    dropped = len(records) - len(frame)
+    if dropped:
+        logger.warning(f"{label}: dropped {dropped} duplicate (stream_id, date) row(s) before insert")
+
+    results = task_split_and_insert_records(
+        block=block,
+        records=DataFrame[TnDataRowModel](frame),
+    )
+    failed = results["failed_records"]
+    if not failed.empty:
+        raise RuntimeError(f"{label}: {len(failed)} record(s) failed to insert: {results['failed_reasons']}")
+
+    logger.info(f"Published {len(frame)} record(s) to {label} streams")
+    return len(frame)

--- a/src/tsn_adapters/flows/eps/real_time_flow.py
+++ b/src/tsn_adapters/flows/eps/real_time_flow.py
@@ -43,20 +43,13 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta, timezone
 
 import pandas as pd
-from pandera.typing import DataFrame
 from prefect import flow, task
 
 from tsn_adapters.blocks.fmp import FMPBlock
 from tsn_adapters.blocks.tn_access import TNAccessBlock
 from tsn_adapters.blocks.yahoo import YahooBlock
-from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
-from tsn_adapters.common.trufnetwork.tasks.insert import task_split_and_insert_records
-from tsn_adapters.tasks.eps.config import (
-    EPS_STREAM_IDS,
-    FMP_EPS_STREAM_IDS,
-    MAG7,
-    YAHOO_EPS_STREAM_IDS,
-)
+from tsn_adapters.flows.eps.publish import publish_eps_records
+from tsn_adapters.tasks.eps.config import EPS_STREAM_IDS, FMP_EPS_STREAM_IDS, MAG7, YAHOO_EPS_STREAM_IDS
 from tsn_adapters.tasks.eps.reconciler import SourceReading, canonical_key, reconcile
 from tsn_adapters.utils.logging import get_logger_safe
 from tsn_adapters.utils.time_utils import date_string_to_unix
@@ -338,25 +331,13 @@ def eps_real_time_flow(
         return
 
     if fmp_rows:
-        task_split_and_insert_records(
-            block=fmp_tn_block,
-            records=DataFrame[TnDataRowModel](pd.DataFrame(fmp_rows)),
-        )
-        logger.info(f"Published {len(fmp_rows)} record(s) to FMP streams")
+        publish_eps_records(fmp_tn_block, pd.DataFrame(fmp_rows), "FMP")
 
     if yahoo_rows:
-        task_split_and_insert_records(
-            block=yahoo_tn_block,
-            records=DataFrame[TnDataRowModel](pd.DataFrame(yahoo_rows)),
-        )
-        logger.info(f"Published {len(yahoo_rows)} record(s) to Yahoo streams")
+        publish_eps_records(yahoo_tn_block, pd.DataFrame(yahoo_rows), "Yahoo")
 
     if truf_rows:
-        task_split_and_insert_records(
-            block=truf_tn_block,
-            records=DataFrame[TnDataRowModel](pd.DataFrame(truf_rows)),
-        )
-        logger.info(f"Published {len(truf_rows)} record(s) to Truf consensus streams")
+        publish_eps_records(truf_tn_block, pd.DataFrame(truf_rows), "Truf consensus")
 
 
 if __name__ == "__main__":

--- a/tests/eps/test_historical_flow.py
+++ b/tests/eps/test_historical_flow.py
@@ -3,12 +3,12 @@
 from typing import Any
 
 import pandas as pd
-import pytest
 from pandera.typing import DataFrame
 from pydantic import PrivateAttr, SecretStr
-
+import pytest
 from tests.utils.constants import FAKE_PRIVATE_KEY
 from tests.utils.fake_tn_access import FakeTNAccessBlock
+
 from tsn_adapters.blocks.fmp import EarningsData, FMPBlock
 from tsn_adapters.blocks.yahoo import YahooBlock
 from tsn_adapters.flows.eps.historical_flow import build_new_records, eps_historical_flow
@@ -84,6 +84,7 @@ def test_build_new_records_empty_input():
 
 # --- flow-level tests ---
 
+
 @pytest.fixture(scope="module", autouse=True)
 def prefect_harness(prefect_test_fixture: Any):
     yield prefect_test_fixture
@@ -91,6 +92,30 @@ def prefect_harness(prefect_test_fixture: Any):
 
 AAPL_FMP_ROW = AAPL_ROW
 AAPL_YAHOO_ROW = {"symbol": "AAPL", "date": "2024-03-31", "epsActual": 1.53, "epsEstimated": None, "lastUpdated": None}
+
+
+@pytest.mark.timeout(30, func_only=True)
+def test_backfill_collapses_duplicate_source_rows():
+    """FMP can repeat an announcement row in its response (website#4362);
+    both copies pass the published-dates filter and would ride one insert
+    tx, which the primitive PK rejects wholesale. The publish path must
+    collapse them so the backfill still lands."""
+    fmp_block = make_fmp_block({"AAPL": [AAPL_FMP_ROW, AAPL_FMP_ROW]})
+    yahoo_block = make_yahoo_block({})
+    fmp_tn_block = FakeTNAccessBlock(existing_streams={FMP_EPS_STREAM_IDS["AAPL"]})
+    yahoo_tn_block = FakeTNAccessBlock()
+
+    eps_historical_flow(
+        fmp_block=fmp_block,
+        yahoo_block=yahoo_block,
+        fmp_tn_block=fmp_tn_block,
+        yahoo_tn_block=yahoo_tn_block,
+        symbols=["AAPL"],
+    )
+
+    inserted = pd.concat(fmp_tn_block.inserted_records, ignore_index=True)
+    assert len(inserted) == 1
+    assert inserted.iloc[0]["date"] == date_string_to_unix("2024-03-31")
 
 
 @pytest.mark.timeout(30, func_only=True)

--- a/tests/eps/test_publish.py
+++ b/tests/eps/test_publish.py
@@ -1,0 +1,55 @@
+"""Tests for the shared EPS publish path — dedup + fail-loud insert.
+
+Covers website#4362: FMP repeated GOOGL's Q2-2026 announcement row in its
+response, both copies rode one insert_records tx, and the primitive PK
+rejected the whole batch — while the flow logged "Published" because the
+insert result was discarded.
+"""
+
+from typing import Any
+
+import pandas as pd
+from pandera.typing import DataFrame
+from prefect import flow
+import pytest
+from tests.utils.fake_tn_access import FakeTNAccessBlock
+
+from tsn_adapters.common.trufnetwork.models.tn_models import TnDataRowModel
+from tsn_adapters.flows.eps import publish as publish_module
+from tsn_adapters.flows.eps.publish import publish_eps_records
+from tsn_adapters.tasks.eps.config import FMP_EPS_STREAM_IDS
+
+STREAM = FMP_EPS_STREAM_IDS["GOOGL"]
+
+
+def _frame(dates: list[int]) -> pd.DataFrame:
+    return pd.DataFrame([{"stream_id": STREAM, "date": d, "value": "9.11", "data_provider": None} for d in dates])
+
+
+@pytest.fixture(scope="module")
+def prefect_harness(prefect_test_fixture: Any):
+    yield prefect_test_fixture
+
+
+def test_collapses_duplicate_stream_date_rows(prefect_harness: Any):
+    block = FakeTNAccessBlock(existing_streams={STREAM})
+
+    @flow
+    def run_publish() -> int:
+        return publish_eps_records(block, _frame([100, 100, 200]), "FMP")
+
+    submitted = run_publish()
+    assert submitted == 2
+    inserted = pd.concat(block.inserted_records, ignore_index=True)
+    assert sorted(inserted["date"].tolist()) == [100, 200]
+
+
+def test_raises_when_records_fail_to_insert(monkeypatch: pytest.MonkeyPatch):
+    failed = DataFrame[TnDataRowModel](_frame([100]).assign(data_provider="0x" + "0" * 40))
+
+    def fake_insert(block, records):
+        return {"success_tx_hashes": [], "failed_records": failed, "failed_reasons": ["duplicate key"]}
+
+    monkeypatch.setattr(publish_module, "task_split_and_insert_records", fake_insert)
+    with pytest.raises(RuntimeError, match="duplicate key"):
+        publish_eps_records(FakeTNAccessBlock(existing_streams={STREAM}), _frame([100]), "FMP")

--- a/tests/eps/test_real_time_flow.py
+++ b/tests/eps/test_real_time_flow.py
@@ -8,15 +8,18 @@ naïve dict-key joins on raw dates don't treat the same event as two
 separate single-source entries.
 """
 
+from typing import Any
+
 import pandas as pd
 from pandera.typing import DataFrame
 from pydantic import PrivateAttr, SecretStr
+import pytest
 from tests.utils.constants import FAKE_PRIVATE_KEY
 from tests.utils.fake_tn_access import FakeTNAccessBlock
 
 from tsn_adapters.blocks.fmp import EarningsData, FMPBlock, QuarterlyIncomeStatementData
 from tsn_adapters.blocks.yahoo import YahooBlock
-from tsn_adapters.flows.eps.real_time_flow import detect_and_prepare_eps
+from tsn_adapters.flows.eps.real_time_flow import detect_and_prepare_eps, eps_real_time_flow
 from tsn_adapters.utils.create_empty_df import create_empty_df
 from tsn_adapters.utils.time_utils import date_string_to_unix
 
@@ -376,11 +379,7 @@ def test_publishes_fresh_print_despite_older_stream_history():
     (website#4362: TSLA's Q2-2026 print never reached TN while the streams
     held Q1 and older). Only an exact date match may count as published.
     """
-    from tsn_adapters.tasks.eps.config import (
-        EPS_STREAM_IDS,
-        FMP_EPS_STREAM_IDS,
-        YAHOO_EPS_STREAM_IDS,
-    )
+    from tsn_adapters.tasks.eps.config import EPS_STREAM_IDS, FMP_EPS_STREAM_IDS, YAHOO_EPS_STREAM_IDS
 
     fmp = _make_fmp(
         earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
@@ -420,11 +419,7 @@ def test_idempotent_when_all_streams_already_published():
     behaviour of the scheduled flow re-encountering the same recent
     earnings rows on subsequent ticks.
     """
-    from tsn_adapters.tasks.eps.config import (
-        EPS_STREAM_IDS,
-        FMP_EPS_STREAM_IDS,
-        YAHOO_EPS_STREAM_IDS,
-    )
+    from tsn_adapters.tasks.eps.config import EPS_STREAM_IDS, FMP_EPS_STREAM_IDS, YAHOO_EPS_STREAM_IDS
 
     fmp = _make_fmp(
         earnings={"NVDA": [NVDA_Q1_FY27_FMP_EARNINGS]},
@@ -451,3 +446,74 @@ def test_idempotent_when_all_streams_already_published():
     assert len(fmp_rows) == 0
     assert len(yahoo_rows) == 0
     assert len(truf_rows) == 0
+
+
+# --- Flow-level: the 2026-07-22 duplicate-row incident (website#4362) ---
+
+GOOGL_Q2_2026_FMP_EARNINGS = {
+    "symbol": "GOOGL",
+    "date": "2026-07-22",
+    "epsActual": 9.11,
+    "epsEstimated": None,
+    "lastUpdated": None,
+}
+GOOGL_Q2_2026_YAHOO_EARNINGS = {
+    "symbol": "GOOGL",
+    "date": "2026-06-30",
+    "epsActual": 9.11,
+    "epsEstimated": None,
+    "lastUpdated": None,
+}
+GOOGL_Q2_2026_INCOME_STMT = {
+    "symbol": "GOOGL",
+    "period": "Q2",
+    "fiscalYear": "2026",
+    "date": "2026-06-30",
+    "filingDate": "2026-07-22",
+    "acceptedDate": None,
+}
+
+
+@pytest.fixture(scope="module")
+def prefect_harness(prefect_test_fixture: Any):
+    yield prefect_test_fixture
+
+
+@pytest.mark.timeout(120, func_only=True)
+def test_duplicate_fmp_announcement_rows_publish_once(prefect_harness: Any):
+    """The 2026-07-22 incident shape (website#4362): FMP returned GOOGL's
+    fresh Q2 print twice; both copies passed the not-yet-published check
+    and rode one insert_records tx, whose primitive PK rejected the whole
+    batch on-chain — TSLA's print rolled back with it. Duplicates must
+    collapse before the write so one repeated upstream row can't sink
+    every record in the batch."""
+    from tsn_adapters.tasks.eps.config import EPS_STREAM_IDS, FMP_EPS_STREAM_IDS, YAHOO_EPS_STREAM_IDS
+
+    fmp = _make_fmp(
+        earnings={"GOOGL": [GOOGL_Q2_2026_FMP_EARNINGS, GOOGL_Q2_2026_FMP_EARNINGS]},
+        income_statements={"GOOGL": [GOOGL_Q2_2026_INCOME_STMT]},
+    )
+    yahoo = _make_yahoo({"GOOGL": [GOOGL_Q2_2026_YAHOO_EARNINGS]})
+    fmp_tn = FakeTNAccessBlock(existing_streams={FMP_EPS_STREAM_IDS["GOOGL"]})
+    yahoo_tn = FakeTNAccessBlock(existing_streams={YAHOO_EPS_STREAM_IDS["GOOGL"]})
+    truf_tn = FakeTNAccessBlock(existing_streams={EPS_STREAM_IDS["GOOGL"]})
+
+    eps_real_time_flow(
+        fmp_block=fmp,
+        yahoo_block=yahoo,
+        fmp_tn_block=fmp_tn,
+        yahoo_tn_block=yahoo_tn,
+        truf_tn_block=truf_tn,
+        symbols=["GOOGL"],
+    )
+
+    fmp_inserted = pd.concat(fmp_tn.inserted_records, ignore_index=True)
+    assert len(fmp_inserted) == 1
+    assert fmp_inserted.iloc[0]["date"] == date_string_to_unix("2026-07-22")
+
+    yahoo_inserted = pd.concat(yahoo_tn.inserted_records, ignore_index=True)
+    assert len(yahoo_inserted) == 1
+
+    truf_inserted = pd.concat(truf_tn.inserted_records, ignore_index=True)
+    assert len(truf_inserted) == 1
+    assert truf_inserted.iloc[0]["value"] == "9.11"


### PR DESCRIPTION
Changes:

- new `flows/eps/publish.py`: shared publish path for both EPS flows — collapses duplicate `(stream_id, date)` rows before the write and raises when any record fails to insert, so a rolled-back batch fails the flow run instead of logging success
- real-time and historical flows route their FMP/Yahoo/consensus writes through it (the weekly backfill had the same exposure)
- tests: flow-level reproduction of the GOOGL incident (duplicate announcement rows publish once, batch still lands), same coverage for the backfill, and unit tests for the dedup + fail-loud contract

- towards: https://github.com/truflation/website/issues/4362

## Summary by CodeRabbit

* **Enchancemenet**
  * Prevented duplicate EPS records from being published for the same stream and date.
  * Improved error handling so failed record insertions are reported instead of appearing successful.
  * Applied duplicate-record protection to both historical backfills and real-time EPS updates.

* **Tests**
  * Added coverage for duplicate source rows and failed publication scenarios.
  * Verified correct publishing across supported EPS destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->